### PR TITLE
Bug fixes for Credit Card Assist

### DIFF
--- a/src/common/res/features/check-credit-balances/main.js
+++ b/src/common/res/features/check-credit-balances/main.js
@@ -1,4 +1,3 @@
-
 (function poll() {
   if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true) {
 
@@ -8,21 +7,25 @@
           .getBudgetViewModel_AllBudgetMonthsViewModel()._result,
 
         invoke: function() {
-          // Get debt accounts to process
-          var debtAccounts = ynabToolKit.checkCreditBalances.getDebtAccounts();
-
-          // Process the found debt accounts
-          ynabToolKit.checkCreditBalances.processDebtAccounts(debtAccounts);
+          if (ynabToolKit.checkCreditBalances.inCurrentMonth())
+          {
+          	var debtAccounts = ynabToolKit.checkCreditBalances.getDebtAccounts();
+          	ynabToolKit.checkCreditBalances.processDebtAccounts(debtAccounts);
+          }
         },
 
         observe: function(changedNodes) {
-
           if (changedNodes.has('budget-inspector')) {
-            // The user has changed their budget row selection
             ynabToolKit.checkCreditBalances.invoke();
           }
         },
 
+		inCurrentMonth: function() {
+		  var today = new Date();
+		  var selectedMonth = ynabToolKit.shared.parseSelectedMonth();
+		  return selectedMonth.getMonth() == today.getMonth() && selectedMonth.getYear() == today.getYear();
+		},
+		
         getDebtAccounts: function() {
           var categoryEntityId = ynabToolKit.checkCreditBalances.budgetView
             .categoriesViewModel.debtPaymentMasterCategory.entityId;
@@ -67,18 +70,19 @@
             }
           });
         },
-
+        
         updateRow: function(name) {
-
           var rows = $('.is-sub-category.is-debt-payment-category');
-
           rows.each(function(i) {
             var accountName = $(this).find('.budget-table-cell-name div.button-truncate').prop('title');
 
             if (name === accountName) {
 
               var categoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency');
-              categoryBalance.removeClass('positive negative zero').addClass('cautious');
+              categoryBalance.removeClass('positive zero');
+              if (! categoryBalance.hasClass('negative')) {              
+              	$(this).find('.budget-table-cell-available-div .user-data.currency').addClass('cautious'); 
+              }
             }
           });
         },
@@ -87,7 +91,10 @@
           var inspectorName = $('.inspector-category-name.user-data').text().trim();
           if (name === inspectorName) {
             var inspectorBalance = $('.inspector-overview-available .user-data .user-data.currency');
-            inspectorBalance.removeClass('positive negative zero').addClass('cautious');
+            inspectorBalance.removeClass('positive zero');
+            if (! inspectorBalance.hasClass('negative')) { 
+              $('.inspector-overview-available .user-data .user-data.currency').addClass('cautious'); 
+            }
           }
         },
 


### PR DESCRIPTION
Updates to ensure that the credit card assist only warns about the
current month, not past or future months, fixing #259. Also updated
styling so the category is negative, this feature doesn’t override the
default red warning label, since that warning should likely have
priority.