### PR TITLE
Preventing error when account has no transactions

### DIFF
--- a/source/common/res/features/shared/main.js
+++ b/source/common/res/features/shared/main.js
@@ -47,9 +47,9 @@ ynabToolKit.shared = (function () {
     getVisibleTransactions: function (accountId)  {
       var transactions, endDate, endDateUTC, sortBySortableIndex, accountStartMonth, accountStartYear, subTransactionsAdded, scheduledTransactions, addSubTransactionToVisibleTransactions, transactionPosition, accountShowReconciled, accountSettings, subTransaction, singleOccurranceTransactions, accountShowScheduled, startDateUTC, sortedSubTransactions, subTransactions, accountEndMonth, accountEndYear, visibleTransactions, accountShowWithNotifications, b, f;
       if (accountId === 'null') {
-        transactions = ynab.YNABSharedLib.getBudgetViewModel_AllAccountTransactionsViewModel()._result.visibleTransactionDisplayItems;
+        transactions = ynab.YNABSharedLib.getBudgetViewModel_AllAccountTransactionsViewModel()._result.visibleTransactionDisplayItems || [];
       } else {
-        transactions = ynab.YNABSharedLib.getBudgetViewModel_AllAccountTransactionsViewModel()._result.transactionDisplayItemsCollection.findItemsByAccountId(accountId);
+        transactions = ynab.YNABSharedLib.getBudgetViewModel_AllAccountTransactionsViewModel()._result.transactionDisplayItemsCollection.findItemsByAccountId(accountId) || [];
       }
 
       accountSettings = jQuery.parseJSON(localStorage.getItem('.' + accountId + '_account_filter'));


### PR DESCRIPTION
`ynabToolKit.shared.getVisibleTransactions(accountId)` now has the
`transactions` variable default to an empty array instead of null.

This is supposed to fix #329 .