### PR TITLE
Fix Paid in Full Credit Card Assist

### DIFF
--- a/source/common/res/features/check-credit-balances/main.js
+++ b/source/common/res/features/check-credit-balances/main.js
@@ -162,10 +162,11 @@
               oldValue = oldValue ? oldValue : 0;
 
               // YNAB stores values *1000 for decimal places, so just
-              // divide by 1000 to get the actual amount.
-              var newValue = (ynab.unformat(oldValue) + difference / 1000);
+              // multiple by 1000 to get the actual amount.
+              var newValue = (ynab.unformat(oldValue) * 1000 + difference);
 
-              input.val(newValue);
+              // format the calculated value back to selected number format
+              input.val(ynab.formatCurrency(newValue));
 
               if (ynabToolKit.options.warnOnQuickBudget == 0) {
                 // only seems to work if the confirmation doesn't pop up?


### PR DESCRIPTION
Fixes Paid in Full Credit Card Assist when using non-default number formats.
Eg. when using number format "123 456,78" the current implementation tries to set the field value to 1234.56 which then gets changed to 123 456,00.
Tested this with a couple different formats and it works with all of them, even with weird formats with slashes as decimal separators.