### PR TITLE
Hotfix accessing ember views

### DIFF
--- a/source/common/res/features/import-notification/main.js
+++ b/source/common/res/features/import-notification/main.js
@@ -4,7 +4,7 @@
     ynabToolKit.importNotification = function ()  {
         $('.import-notification').remove();
         $('.nav-account-row').each(function (index, row) {
-          var account = Ember.View.views[$(row).attr('id')].get('data');
+          var account = ynabToolKit.shared.getEmberView($(row).attr('id')).get('data');
           var transactions = ynab.utilities.TransactionImportUtilities.getImportTransactionsForAccount(account);
           if (transactions.length >= 1) {
             $(row).find('.nav-account-notification').append('<a class="notification import-notification">' + transactions.length + '</a>');

--- a/source/common/res/features/l10n/main.js
+++ b/source/common/res/features/l10n/main.js
@@ -208,7 +208,7 @@
     // Rerender sidebar and content views on page load.
     var rerenderClasses = ['.content', '.nav'];
     for (var i = 0; i < rerenderClasses.length; i++) {
-      Ember.View.views[$(rerenderClasses[i])[0].id].rerender();
+      ynabToolKit.shared.getEmberView($(rerenderClasses[i])[0].id).rerender();
     }
 
     // When rerendering sidebar accounts lists are closing, open them.

--- a/source/common/res/features/shared/main.js
+++ b/source/common/res/features/shared/main.js
@@ -192,7 +192,7 @@ ynabToolKit.shared = (function () {
     parseSelectedMonth: function () {
       // TODO: There's probably a better way to reference this view, but this works better than DOM scraping which seems to fail in Firefox
       if ($('.ember-view .budget-header').length) {
-        var headerView = Ember.View.views[$('.ember-view .budget-header').attr('id')];
+        var headerView = this.getEmberView($('.ember-view .budget-header').attr('id'));
         var selectedMonthUTC = headerView.get('currentMonth').toNativeDate();
         return new Date(selectedMonthUTC.getUTCFullYear(), selectedMonthUTC.getUTCMonth(), 1);
       } else {
@@ -257,7 +257,7 @@ ynabToolKit.shared = (function () {
       var containerName = name;
       var viewIndex = (typeof index !== 'undefined') ? index : 0;
 
-      return Ember.View.views[Ember.keys(Ember.View.views)[viewIndex]].container.lookup(containerName);
+      return this.getEmberView(Ember.keys(this.getEmberViewRegistry())[viewIndex]).container.lookup(containerName);
     },
 
     // Add formatting method to dates to get YYYY-MM.
@@ -265,6 +265,15 @@ ynabToolKit.shared = (function () {
       var yyyy = date.getFullYear().toString();
       var mm = (date.getMonth() + 1).toString(); // getMonth() is zero-based
       return yyyy + '-' + (mm[1] ? mm : '0' + mm[0]); // padding
+    },
+
+    getEmberView: function (viewId) {
+      var registry = this.getEmberViewRegistry();
+      return registry[viewId];
+    },
+
+    getEmberViewRegistry: function () {
+      return Ember.Component.create().get('_viewRegistry');
     },
 
     monthsShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',


### PR DESCRIPTION
Opted to use Ember.Component since Ember has deprecated Ember.View.

Used suggestions from @shama in #349 to resolve.

As he mentioned, this fix still uses internal APIs so they are subject to changes from updates but having the lookup happen in one function should make this easier to manage if it does change.