### PR TITLE
Issue #336 -- Multiple .on() listeners on ynab-grid

### DIFF
--- a/source/common/res/features/right-click-to-edit/main.js
+++ b/source/common/res/features/right-click-to-edit/main.js
@@ -63,13 +63,7 @@
           });
 
           $('body').on('contextmenu', '.modal-account-edit-transaction-list', hideContextMenu);
-        },
-
-        observe: function (changedNodes) {
-          if (changedNodes.has('ynab-grid-body')) {
-            ynabToolKit.rightClickToEdit.invoke();
-          }
-        },
+        }
       };
     })(); // Keep feature functions contained within this object
 


### PR DESCRIPTION
Fix for #336 

We shouldn't need to use observe here unless I don't understand the use of it.

`.on()` works on dynamic elements in the way that we've used it for this feature so we shouldn't have to re-invoke the right-click-to-edit feature every time there's a new row.