### PR TITLE
Fix visibility of Emphasize Outflows when checked

### DIFF
--- a/source/common/res/features/accounts-emphasized-outflows/main.css
+++ b/source/common/res/features/accounts-emphasized-outflows/main.css
@@ -9,3 +9,8 @@
 .ynab-grid-cell-outflow .currency {
 	color: #c00;
 }
+
+.ynab-grid-body-row.is-checked .ynab-grid-cell-outflow .currency {
+	color: #ff4b2b;
+	font-weight: bold;
+}


### PR DESCRIPTION
Selected transactions have a blue background which makes the red very hard to read.  
By making it bold and more of an orange, this is eliminated. The contrast between colours also makes it appear similar to the red, non-highlighted transactions.

Before and after:  
![ynab-highlight-emphasize-readability](https://cloud.githubusercontent.com/assets/14185045/16369816/165baf52-3c6d-11e6-92fe-cbba7ab5506d.png)
