### PR TITLE
Re-fix #257 by remerging lost code from d4b5ce2

### DIFF
--- a/source/common/res/features/right-click-to-edit/main.js
+++ b/source/common/res/features/right-click-to-edit/main.js
@@ -7,15 +7,15 @@
       // Supporting functions,
       // or variables, etc
       function displayContextMenu(element, e) {
-        // clear all toggled checkboxes
-        $('.ynab-checkbox-button.is-checked').click();
-
-        // toggle checkbox
+        // check for a right click on a split transaction
         if ($(element).hasClass('ynab-grid-body-sub')) {
-          // select parent transaction to toggle
-          $(element).prevAll('.ynab-grid-body-parent:first').find('.ynab-checkbox-button').click();
-        } else {
-          // select current transaction to toggle
+          // select parent transaction
+          element = $(element).prevAll('.ynab-grid-body-parent:first');
+        }
+
+        if (!$(element).hasClass('is-checked')) {
+          // clear existing, then check current
+          $('.ynab-checkbox-button.is-checked').click();
           $(element).find('.ynab-checkbox-button').click();
         }
 
@@ -63,11 +63,13 @@
           });
 
           $('body').on('contextmenu', '.modal-account-edit-transaction-list', hideContextMenu);
-        }
+        },
       };
     })(); // Keep feature functions contained within this object
 
-    ynabToolKit.rightClickToEdit.invoke(); // Run once and activate setTimeOut()
+    if (/accounts/.test(window.location.href)) {
+      ynabToolKit.rightClickToEdit.invoke();
+    }
 
   } else {
     setTimeout(poll, 250);


### PR DESCRIPTION
This code from @falkencreative must have got lost from the rename of /src/ to /source/ and this feature stopped working as it should have.

He changed it as per Issue #257 request to allow multiple transactions to be right-clicked, instead of only opening the context menu for the right-clicked item.

[Original commit in falken's fork](https://github.com/falkencreative/toolkit-for-ynab/commit/d4b5ce2b194d9487e3e664a5f405946a2c24b6b0)