### PR TITLE
Issue 361 change enter behavior

### DIFF
--- a/source/common/res/features/change-enter-behavior/main.js
+++ b/source/common/res/features/change-enter-behavior/main.js
@@ -2,22 +2,32 @@
   if (typeof ynabToolKit !== 'undefined'  && ynabToolKit.pageReady === true) {
 
     ynabToolKit.changeEnterBehavior = function ()  {
+      function changeEnterBehaviorInit() {
+        var addTransactionRow = getAddTransactionRow();
+
+        if (addTransactionRow) {
+          changeEnterBehaviorApply();
+        } else {
+          setTimeout(changeEnterBehaviorInit, 250);
+        }
+      }
 
       function changeEnterBehaviorApply() {
-        var addTransaction = document.getElementsByClassName('ynab-grid-add-rows')[0];
-        var memoField = addTransaction.getElementsByClassName('ynab-grid-cell-memo')[0].getElementsByClassName('ember-text-field')[0];
+        var addTransactionRow = getAddTransactionRow();
+
+        var memoField = addTransactionRow.getElementsByClassName('ynab-grid-cell-memo')[0].getElementsByClassName('ember-text-field')[0];
         memoField.onkeydown = function (event) {
           var e = event || window.event;
           changeEnterBehaviorClick(e);
         };
 
-        var outflowField = addTransaction.getElementsByClassName('ynab-grid-cell-outflow')[0].getElementsByClassName('ember-text-field')[0];
+        var outflowField = addTransactionRow.getElementsByClassName('ynab-grid-cell-outflow')[0].getElementsByClassName('ember-text-field')[0];
         outflowField.onkeydown = function (event) {
           var e = event || window.event;
           changeEnterBehaviorClick(e);
         };
 
-        var inflowField = addTransaction.getElementsByClassName('ynab-grid-cell-inflow')[0].getElementsByClassName('ember-text-field')[0];
+        var inflowField = addTransactionRow.getElementsByClassName('ynab-grid-cell-inflow')[0].getElementsByClassName('ember-text-field')[0];
         inflowField.onkeydown = function (event) {
           var e = event || window.event;
           changeEnterBehaviorClick(e);
@@ -32,7 +42,7 @@
           e.stopPropagation();
           var saveButtons = document.getElementsByClassName('ynab-grid-add-rows')[0].getElementsByClassName('button-primary');
           for (var i = 0; i < saveButtons.length; i++) {
-            button = saveButtons[i];
+            var button = saveButtons[i];
             if ((' ' + button.className + ' ').indexOf(' button-another ') == -1) {
               button.click();
               return;
@@ -41,20 +51,9 @@
         }
       }
 
-      function changeEnterBehaviorInit() {
-        var addTransaction = document.getElementsByClassName('ynab-grid-add-rows');
-        n = addTransaction.length;
-        if (n > 0) {
-          changeEnterBehaviorApply();
-        } else {
-          setTimeout(changeEnterBehaviorInit, 250);
-        }
-      }
-
       function changeEnterBehaviorRemoved() {
-        var addTransaction = document.getElementsByClassName('ynab-grid-add-rows');
-        n = addTransaction.length;
-        if (n === 0) {
+        var addTransactionRow = getAddTransactionRow();
+        if (addTransactionRow === null) {
           setTimeout(changeEnterBehaviorInit, 250);
         } else {
           setTimeout(changeEnterBehaviorRemoved, 250);
@@ -62,8 +61,22 @@
       }
 
       setTimeout(changeEnterBehaviorInit, 250);
-
     };
+
+    function getAddTransactionRow() {
+      var addRow = document.getElementsByClassName('ynab-grid-add-rows');
+
+      if (addRow.length) {
+        var addTransaction = addRow[0].getElementsByClassName('ynab-grid-body-row');
+        if (addTransaction.length) {
+          return addTransaction[0];
+        } else {
+          return null;
+        }
+      } else {
+        return null;
+      }
+    }
 
     ynabToolKit.changeEnterBehavior(); // Activate itself
 

--- a/source/common/res/features/right-click-to-edit/main.js
+++ b/source/common/res/features/right-click-to-edit/main.js
@@ -63,7 +63,7 @@
           });
 
           $('body').on('contextmenu', '.modal-account-edit-transaction-list', hideContextMenu);
-        }
+        },
       };
     })(); // Keep feature functions contained within this object
 


### PR DESCRIPTION
Problem (#361);

YNAB always loads the `ynab-grid-add-rows` div to the page now. We were originally checking for it to be on the page, and if it was, we were applying the feature. Since the feature is applied to a nested div, we were failing when that nested div wasn't actually there.

Fixes:

- Reordered the functions in the file to follow their logical order, I believe the build is putting 'use strict' at the top of all of our files so we must use `var` to specify the `button` variable.

- Added a function to get the add transaction row that way we can just simply change that function if YNAB changes behavior again.