### PR TITLE
Add Seamless Budget Header feature

### DIFF
--- a/source/common/res/features/days-of-buffering/main.css
+++ b/source/common/res/features/days-of-buffering/main.css
@@ -1,8 +1,8 @@
 .budget-header-days.days-of-buffering {
-	display: block !important;
-	border-left: 1px solid #0e414c !important;
+	display: block;
+	border-left: 1px solid #0e414c;
 }
 
 .days-of-buffering .budget-header-days-age {
-    color: #23b2ce !important;
+    color: #23b2ce;
 }

--- a/source/common/res/features/seamless-budget-header/main.css
+++ b/source/common/res/features/seamless-budget-header/main.css
@@ -1,0 +1,3 @@
+.budget-header .budget-header-item {
+	border-left: 0px;
+}

--- a/source/common/res/features/seamless-budget-header/settings.json
+++ b/source/common/res/features/seamless-budget-header/settings.json
@@ -1,0 +1,13 @@
+{
+         "name": "seamlessBudgetHeader",
+         "type": "checkbox",
+      "default": false,
+      "section": "budget",
+        "title": "Seamless Budget Header",
+  "description": "Remove the borders between selected month, funds and Age of Money in the budget header.",
+      "actions": {
+                    "true": [
+                      "injectCSS", "main.css"
+                    ]
+                 }
+}


### PR DESCRIPTION
Removes the borders between current month, funds, Age of Money, and Days of Buffering(if enabled).

I find when Seamless is used in combination with Current Month Indicator, it makes the border to the right of the current month much sharper.

Had to remove important declarations from Days Of Buffering (that shouldn't have been there anyway)
In my testing, this commit doesn't affect DoB when turned off.