### PR TITLE
Fix split transactions

### DIFF
--- a/source/common/res/features/.eslintrc.js
+++ b/source/common/res/features/.eslintrc.js
@@ -93,7 +93,7 @@ module.exports = {
         "no-empty-function": "off",
         "no-eq-null": "off",
         "no-eval": "error",
-        "no-extend-native": "error",
+        "no-extend-native": "off",
         "no-extra-bind": "error",
         "no-extra-label": "error",
         "no-extra-parens": "off",

--- a/source/common/res/features/act-on-change/main.js
+++ b/source/common/res/features/act-on-change/main.js
@@ -15,6 +15,13 @@
 
       MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
 
+      Set.prototype.regex = function(regex) {
+        for(const item of this) {
+          if (regex.test(item)) return true;
+        }
+        return false;
+      };
+
       var observer = new MutationObserver(function (mutations) {
 
         if (ynabToolKit.debugNodes) {

--- a/source/common/res/features/split-keyboard-shortcut/main.js
+++ b/source/common/res/features/split-keyboard-shortcut/main.js
@@ -5,28 +5,53 @@
     ynabToolKit.splitKeyboardShortcut = (function () {
 
       return {
-        invoke: function () {
-        },
-
         observe: function (changedNodes) {
+          if (/accounts/.test(window.location.href)) {
+            if (changedNodes.regex(/^(?=.*\smodal-account-categories\s)(?=.*?\sactive)((?!closing).)*$/gm)) {
+              var splitButton = $(".button.button-primary.modal-account-categories-split-transaction");
 
-          // limit to accounts view
-          if (/accounts/.test(window.location.href))
-          {
-            if (changedNodes.has('modal-list'))
-            {
-              if ($('.ynab-grid-cell-subCategoryName input.accounts-text-field').val() == 'split')
-            {
-                $('button.modal-account-categories-split-transaction').mousedown();
-              }
+              // return if we are already inside a split subtransaction
+              if (splitButton.length < 1) return false;
+
+              var splitIcon = splitButton.html();
+              var categoryList = $(".modal-account-categories .modal-list");
+              var liElement = categoryList.find("li.user-data").last().clone();
+
+              liElement.find(".modal-account-categories-category").attr("title", "Split Transaction");
+              liElement.find(".modal-account-categories-category-name").html(splitIcon);
+              liElement.find(".user-data.currency").remove();
+
+              categoryList.append("<li class='user-data'><strong class='modal-account-categories-section-item'>Actions:</strong></li>");
+              categoryList.append(liElement);
+
+              $(".ynab-grid-cell-subCategoryName input").on("keydown", function(e) {
+                if (e.which == 13 || e.which == 9) {
+                  // Enter or Tab
+                  if (liElement.find(".button-list").hasClass("is-highlighted")) {
+                    e.preventDefault();
+                    splitButton.mousedown();
+                  }
+                }
+              }).on("keyup", function() {
+                const categoryInputString = new RegExp("^" + $(this).val());
+                if (categoryInputString.test("split") && categoryList.find(".no-button").length == 1) {
+                  // highlight new split button if input contains part of
+                  // 'split' and there are no other categories available
+                  liElement.find(".button-list").addClass("is-highlighted");
+                } else {
+                  liElement.find(".button-list").removeClass("is-highlighted");
+                }
+              });
+
+              liElement.on("mousedown", function() {
+                splitButton.mousedown();
+              });
             }
           }
         },
       };
 
     })(); // Keep feature functions contained within this object
-
-    ynabToolKit.splitKeyboardShortcut.invoke(); // Run once and activate setTimeOut()
 
   } else {
     setTimeout(poll, 250);


### PR DESCRIPTION
I’ve implemented an extension (custom prototype?) to the `Set` object to be used in place of `changedNodes.has()` and requires ESLint: `no-extend-native` to be disabled

It's also gets re-written by Babel I think (Although it is in the Standard definition of ECMAScript 2015 (6th Edition, ECMA-262))

Basically, `changedNodes.has('foo')` is not similar to jQuery's `.hasClass('foo')` as it must be an exact match. `changedNodes.has('foo')` on `foo bar` will return false.

I've implemented `Set.prototype.regex` so you can do `changedNodes.regex(/foo/)` which will match `foo`, `foo bar` etc.

It also allows you to do things like this
```javascript
// Must contain BOTH 'foo-account' and 'active' and must NOT contain 'closing'
changedNodes.regex(/^(?=.*\sfoo-account\s)(?=.*?\sactive)((?!closing).)*$/gm)
foo-account active					//true
bar active foo-account button		//true
foo-account							//false
foo-account active closing			//false
foo-account-settings active			//false
foo-account not-active				//false
```

This is all necessary because the changedNode I am looking for would require  
`changedNodes.has("pure-u modal-popup modal-account-dropdown modal-account-categories ember-view modal-overlay active")`  
If YNAB ever adds/changes classes to the node, that will fail.

Also, avoiding running your code when there's a changedNode with `closing` class removes unnecessary overhead.

Also, there's a weird bug with this in Safari, if you type split and press tab(Enter and click works perfectly), YNAB brings up the popup to select date and you can't type the letter T.

What are the thoughts on this?