### PR TITLE
Slim Style Fixes

### DIFF
--- a/source/common/res/features/budget-rows-height/slim-fonts.css
+++ b/source/common/res/features/budget-rows-height/slim-fonts.css
@@ -1,7 +1,3 @@
-.budget-content ul.budget-table-header {
-    height: 1.2em !important;
-}
-
 .budget-table {
     top: 1em !important;
 }

--- a/source/common/res/features/budget-rows-height/slim-fonts.css
+++ b/source/common/res/features/budget-rows-height/slim-fonts.css
@@ -10,43 +10,47 @@
     height: 1.6em !important;
 }
 
-    .budget-table-row.is-master-category .budget-table-cell-name .budget-table-cell-name-row-label-item {
-        padding-top: 0.1em !important;
-    }
+.budget-table-row.is-master-category {
+    margin-top: 0px;
+}
 
-    .budget-table-row.is-master-category .budget-table-cell-add-category .flaticon {
-        top: 0.2em;
-    }
+.budget-table-row.is-master-category .budget-table-cell-name .budget-table-cell-name-row-label-item {
+    padding-top: 0.1em !important;
+}
+
+.budget-table-row.is-master-category .budget-table-cell-add-category .flaticon {
+    top: 0.2em;
+}
 
 .budget-table-row.is-sub-category {
     height: 1.6em !important;
     font-size: 0.78em;
 }
 
-    .budget-table-row.is-master-category .budget-table-cell-name {
-        padding-top: 0;
-        font-size: 1.05em;
-    }
+.budget-table-row.is-master-category .budget-table-cell-name {
+    padding-top: 0;
+    font-size: 1.05em;
+}
 
-    .budget-table-row.is-sub-category > .budget-table-cell-available .positive, .budget-table-row.is-sub-category > .budget-table-cell-available .negative, .budget-table-row.is-sub-category > .budget-table-cell-available .cautious, .budget-table-row.is-sub-category > .budget-table-cell-available .zero {
-        top: 0 !important;
-        padding: 0em 0.4em;
-        font-size: 1em !important;
-    }
+.budget-table-row.is-sub-category > .budget-table-cell-available .positive, .budget-table-row.is-sub-category > .budget-table-cell-available .negative, .budget-table-row.is-sub-category > .budget-table-cell-available .cautious, .budget-table-row.is-sub-category > .budget-table-cell-available .zero {
+    top: 0 !important;
+    padding: 0em 0.4em;
+    font-size: 1em !important;
+}
 
-    .budget-table-row.is-sub-category .budget-table-cell-activity {
-        top: 0 !important;
-    }
+.budget-table-row.is-sub-category .budget-table-cell-activity {
+    top: 0 !important;
+}
 
-    .budget-table-cell-budgeted .currency-input span {
-        height: 1.45em;
-        padding: 0.05em;
-        border-width: 1px !important;
-    }
+.budget-table-cell-budgeted .currency-input span {
+    height: 1.45em;
+    padding: 0.05em;
+    border-width: 1px !important;
+}
 
-    .budget-table-cell-budgeted .currency-input input {
-        height: 1.45em !important;
-    }
+.budget-table-cell-budgeted .currency-input input {
+    height: 1.45em !important;
+}
 
 .toolkit-goalindicator {
 	line-height: 1.8em !important;

--- a/source/common/res/features/budget-rows-height/slim.css
+++ b/source/common/res/features/budget-rows-height/slim.css
@@ -10,44 +10,48 @@
     height: 1.6em !important;
 }
 
-    .budget-table-row.is-master-category .budget-table-cell-name .budget-table-cell-name-row-label-item {
-        padding-top: 0.1em !important;
-    }
-
-    .budget-table-row.is-master-category .budget-table-cell-add-category .flaticon {
-        top: 0.2em;
-    }
-
-.budget-table-row.is-sub-category {
-    height: 1.4em !important;
+.budget-table-row.is-master-category {
+    margin-top: 0px;
 }
 
-    .budget-table-row.is-master-category .budget-table-cell-name {
-        padding-top: 0;
-        font-size: 1.05em;
-    }
+.budget-table-row.is-master-category .budget-table-cell-name .budget-table-cell-name-row-label-item {
+    padding-top: 0.1em !important;
+}
 
-    .budget-table-row.is-sub-category > .budget-table-cell-available .positive, .budget-table-row.is-sub-category > .budget-table-cell-available .negative, .budget-table-row.is-sub-category > .budget-table-cell-available .cautious, .budget-table-row.is-sub-category > .budget-table-cell-available .zero {
-        top: 0 !important;
-        padding: 0em 0.4em !important;
-        font-size: 1em !important;
-    }
+.budget-table-row.is-master-category .budget-table-cell-add-category .flaticon {
+    top: 0.2em;
+}
 
-    .budget-table-row.is-sub-category .budget-table-cell-activity {
-        top: 0 !important;
-    }
+.budget-table-row.is-sub-category {
+    height: 1.42em !important;
+}
 
-    .budget-table-cell-budgeted .currency-input span {
-        height: 1.45em;
-        padding: 0.05em;
-        border-width: 1px !important;
-    }
+.budget-table-row.is-master-category .budget-table-cell-name {
+    padding-top: 0;
+    font-size: 1.05em;
+}
 
-    .budget-table-cell-budgeted .currency-input input {
-        height: 1.45em !important;
-    }
-    
+.budget-table-row.is-sub-category > .budget-table-cell-available .positive, .budget-table-row.is-sub-category > .budget-table-cell-available .negative, .budget-table-row.is-sub-category > .budget-table-cell-available .cautious, .budget-table-row.is-sub-category > .budget-table-cell-available .zero {
+    top: 0 !important;
+    padding: 0em 0.4em !important;
+    font-size: 1em !important;
+}
+
+.budget-table-row.is-sub-category .budget-table-cell-activity {
+    top: 0 !important;
+}
+
+.budget-table-cell-budgeted .currency-input span {
+    height: 1.45em;
+    padding: 0.05em;
+    border-width: 1px !important;
+}
+
+.budget-table-cell-budgeted .currency-input input {
+    height: 1.45em !important;
+}
+
 .toolkit-goalindicator {
-	line-height: 1.3em !important;
+    line-height: 1.3em !important;
 }
 

--- a/source/common/res/features/budget-rows-height/slim.css
+++ b/source/common/res/features/budget-rows-height/slim.css
@@ -1,7 +1,3 @@
-.budget-content ul.budget-table-header {
-    height: 1.2em !important;
-}
-
 .budget-table {
     top: 1em !important;
 }


### PR DESCRIPTION
I made a few changes to the numbers for the slim styles. 

I noticed some pretty annoying css issues with the slim styles so this fixes them:

- Header Row too small (cut off top pixels)
- Last sub-category 'available' bubble touched following master category row
- Text box border was cut off my neighboring sub-categories when hovering.

All in all this increased the page by about .04em so it shouldn't be incredibly noticeable height wise but should hopefully make it feel more like a native style.

I suggest adding ?w=1 to the diff URL to see changes since I also tabbed the styles over.