### PR TITLE
fixing ex-truthy evaluators

### DIFF
--- a/source/common/res/features/budget-balance-to-zero/main.js
+++ b/source/common/res/features/budget-balance-to-zero/main.js
@@ -82,7 +82,7 @@
 
         updateBudgetedBalance(name, difference) {
           // eslint-disable-next-line no-alert
-          if ((ynabToolKit.options.warnOnQuickBudget !== 0) && (!confirm('Are you sure you want to do this?'))) {
+          if (ynabToolKit.options.warnOnQuickBudget && !confirm('Are you sure you want to do this?')) {
             return;
           }
 
@@ -104,7 +104,7 @@
 
               $(input).val(newValue);
 
-              if (ynabToolKit.options.warnOnQuickBudget === 0) {
+              if (!ynabToolKit.options.warnOnQuickBudget) {
                 // only seems to work if the confirmation doesn't pop up?
                 // haven't figured out a way to properly blur otherwise
                 input.blur();

--- a/source/common/res/features/budget-category-info/main.js
+++ b/source/common/res/features/budget-category-info/main.js
@@ -137,7 +137,7 @@
           });
 
           // call external features if appropriate
-          if (ynabToolKit.options.goalIndicator !== 0) {
+          if (ynabToolKit.options.goalIndicator) {
             ynabToolKit.goalIndicator.invoke();
           }
         },


### PR DESCRIPTION
After updating eslint rules we require `===` and `!==` which broke these old truthy expressions. 

I changed them back to truthy without breaking rules.