### PR TITLE
BUGFIX: Right Click To Edit

### DIFF
--- a/source/common/res/features/right-click-to-edit/main.js
+++ b/source/common/res/features/right-click-to-edit/main.js
@@ -2,19 +2,22 @@
   // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
   if (typeof ynabToolKit !== 'undefined' && ynabToolKit.pageReady === true) {
     ynabToolKit.rightClickToEdit = (function () {
+      var isCurrentlyRunning = false;
+
       // Supporting functions,
       // or variables, etc
-      function displayContextMenu(element, e) {
+      function displayContextMenu(event) {
+        var $element = $(this);
         // check for a right click on a split transaction
-        if ($(element).hasClass('ynab-grid-body-sub')) {
+        if ($element.hasClass('ynab-grid-body-sub')) {
           // select parent transaction
-          element = $(element).prevAll('.ynab-grid-body-parent:first');
+          $element = $element.prevAll('.ynab-grid-body-parent:first');
         }
 
-        if (!$(element).hasClass('is-checked')) {
+        if (!$element.hasClass('is-checked')) {
           // clear existing, then check current
           $('.ynab-checkbox-button.is-checked').click();
-          $(element).find('.ynab-checkbox-button').click();
+          $element.find('.ynab-checkbox-button').click();
         }
 
         // make context menu appear
@@ -29,23 +32,25 @@
         // determine if modal needs to be positioned above or below clicked element
         var below = true;
         var height = $('.modal-account-edit-transaction-list .modal').outerHeight();
-        if (e.pageY + height > $(window).height()) below = false;
+        if (event.pageY + height > $(window).height()) below = false;
 
         // move context menu
-        var offset = $(element).offset();
+        var offset = $element.offset();
         if (below) {
           // position below
           $('.modal-account-edit-transaction-list .modal')
             .addClass('modal-below')
-            .css('left', e.pageX - 115)
+            .css('left', event.pageX - 115)
             .css('top', offset.top + 41);
         } else {
           // position above
           $('.modal-account-edit-transaction-list .modal')
             .addClass('modal-above')
-            .css('left', e.pageX - 115)
+            .css('left', event.pageX - 115)
             .css('top', offset.top - height - 8);
         }
+
+        return false;
       }
 
       function hideContextMenu() {
@@ -55,19 +60,28 @@
 
       return {
         invoke() {
-          $('.ynab-grid').on('contextmenu', '.ynab-grid-body-row', function (e) {
-            displayContextMenu(this, e);
-            return false;
-          });
+          isCurrentlyRunning = true;
 
-          $('body').on('contextmenu', '.modal-account-edit-transaction-list', hideContextMenu);
+          Ember.run.next(function () {
+            $('.ynab-grid').off('contextmenu', '.ynab-grid-body-row', displayContextMenu);
+            $('.ynab-grid').on('contextmenu', '.ynab-grid-body-row', displayContextMenu);
+
+            $('body').off('contextmenu', '.modal-account-edit-transaction-list', hideContextMenu);
+            $('body').on('contextmenu', '.modal-account-edit-transaction-list', hideContextMenu);
+
+            isCurrentlyRunning = false;
+          });
+        },
+
+        observe(changedNodes) {
+          if (changedNodes.has('ynab-grid-body') && !isCurrentlyRunning) {
+            ynabToolKit.rightClickToEdit.invoke();
+          }
         }
       };
     }()); // Keep feature functions contained within this object
 
-    if (/accounts/.test(window.location.href)) {
-      ynabToolKit.rightClickToEdit.invoke();
-    }
+    ynabToolKit.rightClickToEdit.invoke();
   } else {
     setTimeout(poll, 250);
   }


### PR DESCRIPTION
The right click to edit feature disappeared after navigating to the budget page because the `.ynab-grid` was removed from the page.

I brought back the observer and just used `$.off` and `$.on` to avoid the duplicate listener issue.