### PR TITLE
BUGFIX: Cannot Call 'invoke' of undefined

### DIFF
--- a/source/common/res/features/budget-category-info/main.js
+++ b/source/common/res/features/budget-category-info/main.js
@@ -138,7 +138,7 @@
 
           // call external features if appropriate
           if (ynabToolKit.options.goalIndicator) {
-            ynabToolKit.goalIndicator.invoke();
+            ynabToolKit.shared.invokeExternalFeature('goalIndicator');
           }
         },
 

--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -158,7 +158,7 @@
               }
 
               if (['pacing', 'both'].indexOf(ynabToolKit.options.budgetProgressBars) !== -1) {
-                ynabToolKit.budgetProgressBars.invoke();
+                ynabToolKit.shared.invokeExternalFeature('budgetProgressBars');
               }
 
               e.stopPropagation();

--- a/source/common/res/features/shared/main.js
+++ b/source/common/res/features/shared/main.js
@@ -285,6 +285,17 @@ ynabToolKit.shared = (function () {
       return Ember.Component.create().get('_viewRegistry');
     },
 
+    invokeExternalFeature(featureName) {
+      var self = this;
+      if (ynabToolKit[featureName] && typeof ynabToolKit[featureName].invoke === 'function') {
+        ynabToolKit[featureName].invoke();
+      } else {
+        setTimeout(function () {
+          self.invokeExternalFeature(featureName);
+        }, 250);
+      }
+    },
+
     monthsShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
        ],


### PR DESCRIPTION
There was a race condition with pacing and goal indicators where they'd try to call an external feature's `invoke` before it was loaded. Added a shared function that we can use to invoke external features.