### PR TITLE
Add instructions to disable signatures req for FF

### DIFF
--- a/source/common/res/features/HOW_TO_BUILD_FEATURES.md
+++ b/source/common/res/features/HOW_TO_BUILD_FEATURES.md
@@ -308,9 +308,10 @@ Firefox
 -------
 
 1. Run `./build` (Linux / Mac) or `build.bat` (Windows)
-2. Go to the URL about:addons
-3. Click the gear button, then select `Install Add-on From File`
-4. Select the file (relative to the root of the repository) `output/toolkitforynab_[version].xpi`
+2. Ensure `xpinstall.signatures.required` is set to __false__ in `about:config`
+3. Go to the URL about:addons
+4. Click the gear button, then select `Install Add-on From File`
+5. Select the file (relative to the root of the repository) `output/toolkitforynab_[version].xpi`
 
 You'll see the toolkit loaded in to Firefox and it'll work as normal. Whenever you make a change to the files in `source` you'll need to run `./build` or `build.bat` again, then remove and reinstall the extension from file.
 


### PR DESCRIPTION
Added line 311.

I didn't have Firefox installed, when I installed the (built from source) toolkit and wanted to contribute, it failed to edit allow our installation because of a security setting.

I found it after reading through some firefox docs, probably best to outline it here.