### PR TITLE
QOL: Running Balance

### DIFF
--- a/source/common/res/features/running-balance/main.js
+++ b/source/common/res/features/running-balance/main.js
@@ -129,7 +129,7 @@
         invoke: function () {
           currentlyRunning = true;
 
-          Ember.run.next(function () {
+          Ember.run.later(function () {
             var applicationController = ynabToolKit.shared.containerLookup('controller:application');
 
             if (applicationController.get('currentPath').indexOf('accounts') > -1 && applicationController.get('selectedAccountId')) {
@@ -137,7 +137,7 @@
             }
 
             currentlyRunning = false;
-          });
+          }, 50);
         },
 
         observe: function invoke(changedNodes) {

--- a/source/common/res/features/running-balance/main.js
+++ b/source/common/res/features/running-balance/main.js
@@ -85,7 +85,7 @@
 
         var emberView = ynabToolKit.shared.getEmberView($currentRow.attr('id'));
         var transaction = emberView.get('content');
-        var runningBalance = transaction.get('__ynabToolKitRunningBalance');
+        var runningBalance = transaction.__ynabToolKitRunningBalance;
         var currencySpan = $('.user-data', currentRowRunningBalance);
 
         if (runningBalance < 0) {


### PR DESCRIPTION
Running Balance added a custom property to the transaction obejcts. Typescript was sad about this and threw a warning. This gets rid of that warning.

There was also a problem where Running Balance wouldn't always load on the first refresh, using `Ember.run.later` aims to fix that.