### PR TITLE
BIGFIX: Zero out budgeted disappeared again...

### DIFF
--- a/source/common/res/features/budget-balance-to-zero/main.js
+++ b/source/common/res/features/budget-balance-to-zero/main.js
@@ -1,12 +1,8 @@
-/* jshint multistr: true */
-/* jscs:disable disallowMultipleLineStrings */
-
 (function poll() {
   if (typeof ynabToolKit !== 'undefined' && ynabToolKit.pageReady === true) {
     ynabToolKit.budgetBalanceToZero = (function () {
       return {
-        budgetView: ynab.YNABSharedLib
-          .getBudgetViewModel_AllBudgetMonthsViewModel()._result, // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
+        budgetView: ynab.YNABSharedLib.getBudgetViewModel_AllBudgetMonthsViewModel()._result,
 
         invoke() {
           var categories = ynabToolKit.budgetBalanceToZero.getCategories();
@@ -77,7 +73,7 @@
             .append($('<strong>', { class: 'user-data', title: fAmount })
             .append(ynabToolKit.shared.appendFormattedCurrencyHtml($('<span>', { class: 'user-data currency zero' }), amount)));
 
-          $('.ember-view .inspector-quick-budget').append(button);
+          $('.inspector-quick-budget').append(button);
         },
 
         updateBudgetedBalance(name, difference) {


### PR DESCRIPTION
Just going to use the .inspector-quick-budget class. I guess the ember-view class can decide when it should and shouldn't be first.