### PR TITLE
BUGFIX: Toggle Splits

### DIFF
--- a/source/common/res/features/accounts-transaction-search/main.js
+++ b/source/common/res/features/accounts-transaction-search/main.js
@@ -126,7 +126,6 @@
             Ember.run.later(onAccountChange, 250);
 
             accountsController.addObserver('hiddenTxnsCount', function () {
-              console.log('hiddenTxnsCount');
               Ember.run.next(function () {
                 originalTransactions = accountsController.get('contentResults').slice();
                 var $searchBox = $('.toolkit-transaction-search', '.accounts-toolbar-right');
@@ -136,7 +135,6 @@
             });
 
             accountsController.addObserver('editingId', function () {
-              console.log('editingId happening');
               filterOnRedraw = true;
             });
           }

--- a/source/common/res/features/toggle-splits/main.js
+++ b/source/common/res/features/toggle-splits/main.js
@@ -1,101 +1,117 @@
 (function poll() {
-  // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
   if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true) {
     ynabToolKit.toggleSplits = (function () {
-      // Supporting functions,
-      // or variables, etc
+      var calculatingDisplayEnd = false;
+
       function setDisplayEnd() {
+        if (ynabToolKit.toggleSplits.setting === 'show') return;
+
+        calculatingDisplayEnd = true;
         var rowView = ynabToolKit.shared.getEmberViewByContainerKey('view:ynab-grid/rows');
         var accountsController = ynabToolKit.shared.containerLookup('controller:accounts');
+        var contentResults = accountsController.get('contentResults');
         var containerView = rowView.get('containerView');
-        var content = accountsController.get('contentResults');
+        var gridView = rowView.get('gridView');
         var displayStart = containerView.get('displayStart');
-        var displayEnd = containerView.get('displayEnd');
-        var wantToDisplay = displayEnd - displayStart;
+        var recordsPerBody = containerView.get('recordsPerBody');
+
+        // this calculation was taken from YNAB's current codebase
+        var wouldBeDisplayEnd = Math.round(Math.min(displayStart + 4 * recordsPerBody, gridView.get('total')));
+
+        var fitOnPage = wouldBeDisplayEnd - displayStart;
         var displayedCount = 0;
+        var displayEnd = displayStart;
 
-        for (var i = this.get('displayStart'); i < content.length; i++) {
-          if (displayedCount === wantToDisplay) break;
+        for (var i = displayStart; i < contentResults.length; i++) {
+          if (displayedCount === fitOnPage) break;
 
-          if (content[i].parentEntityId) {
-            displayedCount++;
+          if (contentResults[i].get('parentEntityId')) {
+            if (ynabToolKit.toggleSplits.setting === 'hide') {
+              displayEnd++;
+              continue;
+            } else {
+              displayedCount++;
+            }
           } else {
-            continue;
+            displayedCount++;
+            displayEnd++;
           }
         }
 
         Ember.run.next(function () {
-          containerView.set('displayEnd', displayStart + wantToDisplay + displayedCount);
+          containerView.set('displayEnd', displayEnd);
+          calculatingDisplayEnd = false;
         });
       }
 
       function addScrollListener() {
         var rowView = ynabToolKit.shared.getEmberViewByContainerKey('view:ynab-grid/rows');
-        removeScrollListener();
         rowView.get('containerView').addObserver('scrollTop', setDisplayEnd);
+
+        if (rowView.get('containerView').get('scrollTop') === 0) {
+          setDisplayEnd();
+        }
       }
 
-      function removeScrollListener() {
-        var rowView = ynabToolKit.shared.getEmberViewByContainerKey('view:ynab-grid/rows');
-        rowView.get('containerView').removeObserver('scrollTop', setDisplayEnd);
+      function hideSubTransactions() {
+        ynabToolKit.toggleSplits.setting = 'hide';
+        $('.ynab-grid-body .ynab-grid-body-sub').hide();
+        $(".ynab-grid-cell-subCategoryName[title^='Split']").css('font-weight', 700);
+        setDisplayEnd();
+      }
+
+      function showSubTransactions() {
+        ynabToolKit.toggleSplits.setting = 'show';
+        $('.ynab-grid-body .ynab-grid-body-sub').show();
+        $(".ynab-grid-cell-subCategoryName[title^='Split']").css('font-weight', '');
       }
 
       return {
         setting: 'init',
-        invoke() {
-          if (!$('#toggleSplits').length) {
-            var buttonText = (ynabToolKit.l10nData && ynabToolKit.l10nData['toolkit.toggleSplits']) || 'Toggle Splits';
+        invoke: function invoke() {
+          // default the right arrow to hidden
+          if (ynabToolKit.toggleSplits.setting === 'init' || ynabToolKit.toggleSplits.setting === 'hide') {
+            $('#toggle-splits > .down').hide();
+            hideSubTransactions();
+          } else {
+            showSubTransactions();
+          }
 
-            $('<button>', { id: 'toggleSplits', class: 'ember-view button' }).append(
-              $('<i>', { class: 'ember-view flaticon stroke right' })
-            )
-            .append(
-              $('<i>', { class: 'ember-view flaticon stroke down' })
-            )
-            .append(
-              ' ' + buttonText
-            )
-            .insertAfter('.accounts-toolbar .undo-redo-container');
+          if (!$('#toggle-splits').length) {
+            var buttonText = ynabToolKit.l10nData && ynabToolKit.l10nData['toolkit.toggleSplits'] || 'Toggle Splits';
 
-            $('.accounts-toolbar-left').find('#toggleSplits').click(function () {
+            $('<button>', { id: 'toggle-splits', class: 'ember-view button' })
+              .append($('<i>', { class: 'ember-view flaticon stroke right' }))
+              .append($('<i>', { class: 'ember-view flaticon stroke down' }))
+              .append(' ' + buttonText)
+              .insertAfter('.accounts-toolbar .undo-redo-container');
+
+            $('.accounts-toolbar-left').find('#toggle-splits').click(function () {
               if (ynabToolKit.toggleSplits.setting === 'hide') {
-                ynabToolKit.toggleSplits.setting = 'show'; // invert setting
-                $('.ynab-grid-body-sub').show();
+                showSubTransactions();
               } else {
-                ynabToolKit.toggleSplits.setting = 'hide';
-                $('.ynab-grid-body-sub').hide();
+                hideSubTransactions();
               }
 
-              $('#toggleSplits > i').toggle();
+              $('#toggle-splits > i').toggle();
             });
 
             addScrollListener();
           }
-
-          // default the right arrow to hidden
-          if (ynabToolKit.toggleSplits.setting === 'init' || ynabToolKit.toggleSplits.setting === 'hide') {
-            $('#toggleSplits > .down').hide();
-            $('.ynab-grid-body-sub').hide();
-            ynabToolKit.toggleSplits.setting = 'hide';
-          } else {
-            $('.ynab-grid-body-sub').show();
-          }
-
-          $(".ynab-grid-cell-subCategoryName[title^='Split']").each(function () {
-            $(this).html(
-              $(this).html().replace(/Split/g, '<span class="split-transaction">Split</span>')
-            );
-          });
         },
 
-        observe(changedNodes) {
+        observe: function observe(changedNodes) {
           if (changedNodes.has('ynab-grid-body')) {
-            // We found Account transactions rows
             ynabToolKit.toggleSplits.invoke();
+            if (!calculatingDisplayEnd) {
+              setDisplayEnd();
+            }
           }
         }
       };
-    }()); // Keep feature functions contained within this object
+    }());
+
+    ynabToolKit.toggleSplits.invoke();
   } else {
     setTimeout(poll, 250);
   }

--- a/source/common/res/features/toggle-splits/main.js
+++ b/source/common/res/features/toggle-splits/main.js
@@ -4,6 +4,41 @@
     ynabToolKit.toggleSplits = (function () {
       // Supporting functions,
       // or variables, etc
+      function setDisplayEnd() {
+        var rowView = ynabToolKit.shared.getEmberViewByContainerKey('view:ynab-grid/rows');
+        var accountsController = ynabToolKit.shared.containerLookup('controller:accounts');
+        var containerView = rowView.get('containerView');
+        var content = accountsController.get('contentResults');
+        var displayStart = containerView.get('displayStart');
+        var displayEnd = containerView.get('displayEnd');
+        var wantToDisplay = displayEnd - displayStart;
+        var displayedCount = 0;
+
+        for (var i = this.get('displayStart'); i < content.length; i++) {
+          if (displayedCount === wantToDisplay) break;
+
+          if (content[i].parentEntityId) {
+            displayedCount++;
+          } else {
+            continue;
+          }
+        }
+
+        Ember.run.next(function () {
+          containerView.set('displayEnd', displayStart + wantToDisplay + displayedCount);
+        });
+      }
+
+      function addScrollListener() {
+        var rowView = ynabToolKit.shared.getEmberViewByContainerKey('view:ynab-grid/rows');
+        removeScrollListener();
+        rowView.get('containerView').addObserver('scrollTop', setDisplayEnd);
+      }
+
+      function removeScrollListener() {
+        var rowView = ynabToolKit.shared.getEmberViewByContainerKey('view:ynab-grid/rows');
+        rowView.get('containerView').removeObserver('scrollTop', setDisplayEnd);
+      }
 
       return {
         setting: 'init',
@@ -33,6 +68,8 @@
 
               $('#toggleSplits > i').toggle();
             });
+
+            addScrollListener();
           }
 
           // default the right arrow to hidden

--- a/source/common/res/features/toggle-splits/settings.json
+++ b/source/common/res/features/toggle-splits/settings.json
@@ -1,7 +1,6 @@
 {
          "name": "toggleSplits",
          "type": "checkbox",
-       "hidden": true,
       "default": false,
       "section": "accounts",
         "title": "Add a Toggle Splits Button",


### PR DESCRIPTION
Added a listener to the `scrollTop` variable on the `containerView`, when it changes, just recalculate what the `displayEnd` should be and set it, after doing that, Ember updates the grid.

Good stuff.

@blargity Don't merge this in yet, there's a few weird bugs that I need to look into first:

- [x] Toggle not appearing on first load if on accounts page
- [x] Adding a split transaction while toggled off doesn't show split rows
- [x] When adding a split, need to update the displayEnd value