### PR TITLE
BUGFIX: Remove running balance when going to All Accounts

### DIFF
--- a/source/common/res/features/running-balance/main.js
+++ b/source/common/res/features/running-balance/main.js
@@ -132,8 +132,12 @@
           Ember.run.later(function () {
             var applicationController = ynabToolKit.shared.containerLookup('controller:application');
 
-            if (applicationController.get('currentPath').indexOf('accounts') > -1 && applicationController.get('selectedAccountId')) {
-              onYnabGridyBodyChanged();
+            if (applicationController.get('currentPath').indexOf('accounts') > -1) {
+              if (applicationController.get('selectedAccountId')) {
+                onYnabGridyBodyChanged();
+              } else {
+                $('.ynab-toolkit-grid-cell-running-balance').remove();
+              }
             }
 
             currentlyRunning = false;


### PR DESCRIPTION
My logic wasn't removing the column from all accounts if coming from another account.

This fixes it.