### PR TITLE
pure-u is now ynab-u, also some qol changes to activity transactin link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,10 @@ Github Issue (if applicable): #XXX
 
 Trello Link (if applicable):
 
+Forum Link (if applicable):
+
 #### Explanation of Bugfix/Feature/Enhancement:
 
 
 
 #### Recommended Release Notes:
-
-
-

--- a/source/common/res/features/activity-transaction-link/main.css
+++ b/source/common/res/features/activity-transaction-link/main.css
@@ -1,0 +1,7 @@
+.toolkit-activity-row {
+	cursor: pointer;
+}
+
+.toolkit-activity-row:hover {
+	background: #DFE4E9
+}

--- a/source/common/res/features/activity-transaction-link/main.js
+++ b/source/common/res/features/activity-transaction-link/main.js
@@ -5,7 +5,9 @@
       var waitingForAccountsPage = false;
 
       function initialize() {
-        $('.activity-rows').children().each(function (index, row) {
+        $('.budget-activity').each(function (index, row) {
+          $(this).addClass('toolkit-activity-row');
+
           $(row).on('click', function () {
             var selectedTransEmberId = $(this).attr('id');
             var emberView = ynabToolKit.shared.getEmberView(selectedTransEmberId);
@@ -65,7 +67,7 @@
 
       return {
         observe: function observe(changedNodes) {
-          if (changedNodes.has('pure-u modal-popup modal-budget-activity ember-view modal-overlay active')) {
+          if (changedNodes.has('ynab-u modal-popup modal-budget-activity ember-view modal-overlay active')) {
             initialize();
           }
 

--- a/source/common/res/features/activity-transaction-link/settings.json
+++ b/source/common/res/features/activity-transaction-link/settings.json
@@ -7,7 +7,8 @@
   "description": "Turn the list of transactions in the activity modal into links that take you to the transaction on their respected accounts page.",
       "actions": {
                   "true": [
-                    "injectScript", "main.js"
+                    "injectScript", "main.js",
+                    "injectCSS", "main.css"
                   ]
                 }
 }

--- a/source/common/res/features/budget-category-info/main.js
+++ b/source/common/res/features/budget-category-info/main.js
@@ -149,9 +149,9 @@
             changedNodes.has('budget-inspector-goals')) {
             ynabToolKit.budgetCategoryInfo.invoke();
           } else if (
-            changedNodes.has('modal-overlay pure-u modal-popup modal-budget-edit-category active') ||
-            changedNodes.has('modal-overlay pure-u modal-popup modal-add-master-category active') ||
-            changedNodes.has('modal-overlay pure-u modal-popup modal-add-sub-category active')) {
+            changedNodes.has('modal-overlay ynab-u modal-popup modal-budget-edit-category active') ||
+            changedNodes.has('modal-overlay ynab-u modal-popup modal-add-master-category active') ||
+            changedNodes.has('modal-overlay ynab-u modal-popup modal-add-sub-category active')) {
             /**
              * Seems there should be a more 'Embery' way to know when the categories have been
              * updated, added, or deleted but this'll have to do for now. Note that the flag is

--- a/source/common/res/features/budget-progress-bars/main.js
+++ b/source/common/res/features/budget-progress-bars/main.js
@@ -222,9 +222,9 @@
           // Set {"budget-table-row is-sub-category goal-progress", "nav-main", "budget-header-item budget-header-calendar toolkit-highlight-current-month", "budget-header-flexbox"}
           if (changedNodes.has('budget-table-row') || changedNodes.has('navlink-budget active') || changedNodes.has('budget-inspector')) {
             ynabToolKit.budgetProgressBars.invoke();
-          } else if (changedNodes.has('modal-overlay pure-u modal-popup modal-budget-edit-category active') ||
-                      changedNodes.has('modal-overlay pure-u modal-popup modal-add-master-category active') ||
-                      changedNodes.has('modal-overlay pure-u modal-popup modal-add-sub-category active')) {
+          } else if (changedNodes.has('modal-overlay ynab-u modal-popup modal-budget-edit-category active') ||
+                      changedNodes.has('modal-overlay ynab-u modal-popup modal-add-master-category active') ||
+                      changedNodes.has('modal-overlay ynab-u modal-popup modal-add-sub-category active')) {
             /**
              * Seems there should be a more 'Embery' way to know when the categories have been
              * updated, added, or deleted but this'll have to do for now. Note that the flag is

--- a/source/common/res/features/l10n/main.js
+++ b/source/common/res/features/l10n/main.js
@@ -114,19 +114,19 @@
           }
 
           // Hidden categories modal
-          if (changedNodes.has('modal-overlay pure-u modal-budget-hidden-categories active')) {
+          if (changedNodes.has('modal-overlay ynab-u modal-budget-hidden-categories active')) {
             contentSetter.selectorPrefix = '.modal-budget-hidden-categories-master-unhidden:contains("Credit Card Payments")';
             contentSetter.set(l10n['toolkit.creditCardPayments'], 1);
           }
 
           // User prefs modal
-          if (changedNodes.has('modal-overlay pure-u modal-popup modal-user-prefs active')) {
+          if (changedNodes.has('modal-overlay ynab-u modal-popup modal-user-prefs active')) {
             contentSetter.selectorPrefix = '.modal-user-prefs button';
             contentSetter.set(l10n['toolkit.myAccount'], 1);
           }
 
           // New transaction fields modals
-          if (changedNodes.has('modal-overlay pure-u modal-popup modal-account-flags active')) {
+          if (changedNodes.has('modal-overlay ynab-u modal-popup modal-account-flags active')) {
             contentSetter.selectorPrefix = '.modal-account-flags';
             var colors = ['red', 'orange', 'yellow', 'green', 'blue', 'purple'].map(function (color) {
               return l10n['toolkit.' + color];
@@ -136,14 +136,14 @@
             contentSetter.setArray(colors, ' .label-bg');
           }
 
-          if (changedNodes.has('modal-overlay pure-u modal-popup modal-account-dropdown modal-account-categories active')) {
+          if (changedNodes.has('modal-overlay ynab-u modal-popup modal-account-dropdown modal-account-categories active')) {
             contentSetter.selectorPrefix = '.modal-account-categories ';
             contentSetter.setSeveral(
               [l10n['toolkit.inflow'], 0, '.modal-account-categories-section-item'], [l10n['budget.leftToBudget'], 1, '.modal-account-categories-category-name']
             );
           }
 
-          if (changedNodes.has('modal-overlay pure-u modal-popup modal-account-dropdown modal-account-payees active')) {
+          if (changedNodes.has('modal-overlay ynab-u modal-popup modal-account-dropdown modal-account-payees active')) {
             contentSetter.selectorPrefix = '.modal-account-payees .is-section-item';
             contentSetter.setArray(
               [
@@ -154,7 +154,7 @@
             );
           }
 
-          if (changedNodes.has('modal-overlay pure-u modal-account-calendar active') ||
+          if (changedNodes.has('modal-overlay ynab-u modal-account-calendar active') ||
             changedNodes.has('accounts-calendar')) {
             contentSetter.selectorPrefix = '.modal-account-calendar';
             var days = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'].map(function (day) {
@@ -170,7 +170,7 @@
           }
 
           // Accounts filters months options
-          if (changedNodes.has('modal-overlay pure-u modal-generic modal-account-filters active')) {
+          if (changedNodes.has('modal-overlay ynab-u modal-generic modal-account-filters active')) {
             contentSetter.selectorPrefix = '.modal-account-filters ';
             contentSetter.setArray(
               ynabToolKit.shared.monthsFull,
@@ -949,7 +949,7 @@
 //         }
 //
 //         // Calendar modal
-//         if ( changedNodes.has('modal-overlay pure-u modal-calendar active') ||
+//         if ( changedNodes.has('modal-overlay ynab-u modal-calendar active') ||
 //              changedNodes.has('ynab-calendar-months') ) { // Changing month
 //           ynabToolKit.l10n.calendarModal();
 //         }
@@ -971,57 +971,57 @@
 //         }
 //
 //         // Add master category modal
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-add-master-category active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-add-master-category active')) {
 //           ynabToolKit.l10n.addCategoryGroupModal();
 //         }
 //
 //         // Add sub category modal
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-add-sub-category active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-add-sub-category active')) {
 //           ynabToolKit.l10n.addCategoryModal();
 //         }
 //
 //         // Hidden categories modal
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-budget-hidden-categories active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-budget-hidden-categories active')) {
 //           ynabToolKit.l10n.hiddenCategoriesModal();
 //         }
 //
 //         // Edit category modal
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-budget-edit-category active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-budget-edit-category active')) {
 //           ynabToolKit.l10n.editCategoryModal();
 //         }
 //
 //         // Cover overspending modal
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-budget-overspending active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-budget-overspending active')) {
 //           ynabToolKit.l10n.coverOverspendingModal();
 //         }
 //
 //         // Move money modal
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-budget-move-money active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-budget-move-money active')) {
 //           ynabToolKit.l10n.moveMoneyModal();
 //         }
 //
 //         // Budget name dropdown
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-select-budget active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-select-budget active')) {
 //           ynabToolKit.l10n.selectBudgetModal();
 //         }
 //
 //         // User settings dropdown
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-user-prefs active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-user-prefs active')) {
 //           ynabToolKit.l10n.userPrefsModal();
 //         }
 //
 //         // Fresh start modal
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-budget-fresh-start active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-budget-fresh-start active')) {
 //           ynabToolKit.l10n.freshStartModal();
 //         }
 //
 //         // New budget and current budget settings modal
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-budget-settings active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-budget-settings active')) {
 //           ynabToolKit.l10n.budgetSettingsModal();
 //         }
 //
 //         // Reconcile account modal
-//         if (changedNodes.has('modal-overlay pure-u modal-popup modal-account-reconcile active')) {
+//         if (changedNodes.has('modal-overlay ynab-u modal-popup modal-account-reconcile active')) {
 //           ynabToolKit.l10n.reconcileAccountModal();
 //         }
 //

--- a/source/common/res/features/printing-improvements/main.css
+++ b/source/common/res/features/printing-improvements/main.css
@@ -45,7 +45,7 @@
 	* {
 		flex: none !important;
 	}
-	body .pure-u {
+	body .ynab-u {
 		display: block;
 	}
 	body .resize-inspector {

--- a/source/common/res/features/toggle-transaction-filters/main.js
+++ b/source/common/res/features/toggle-transaction-filters/main.js
@@ -86,7 +86,7 @@
           // activate button styles if filters potentially change
           // activate if switch to individual account, or all accounts views
           if (
-            changedNodes.has('modal-overlay pure-u modal-generic modal-account-filters active closing') ||
+            changedNodes.has('modal-overlay ynab-u modal-generic modal-account-filters active closing') ||
             changedNodes.has('ynab-grid-body')) {
             initToggleButtons();
           }


### PR DESCRIPTION
Github Issue (if applicable): n/a

Trello Link (if applicable): n/a

#### Explanation of Bugfix/Feature/Enhancement:
We had a lot of features that depended on `pure-u` in the `changedNodes` this was changed to `ynab-u`. I discovered it while making QOL changes to activity-transaction link which is why those changes are in this branch too.


#### Recommended Release Notes:
- It is now more obvious that you can click budget activity to go to a transaction when that feature is enabled.
- General bugfixes related to YNAB's latest release.