### PR TITLE
fixing activity transaction link issues regarding filtered data and t…

### DIFF
--- a/source/common/res/features/activity-transaction-link/main.js
+++ b/source/common/res/features/activity-transaction-link/main.js
@@ -21,19 +21,25 @@
       // find the parent entity if the selectedTransaction has one.
       function findTransactionIndex(contentResults) {
         var entityId = selectedTransaction.get('parentEntityId') || selectedTransaction.get('entityId');
-        for (var i = 0; i < contentResults.length; i++) {
+        var transactionIndex = 0;
+
+        for (var i = 0; i < contentResults.length; i++, transactionIndex++) {
+          var currentTransaction = contentResults[i];
+
           if (contentResults[i].get('entityId') === entityId) {
-            selectedTransaction = contentResults[i];
-            return i;
+            selectedTransaction = currentTransaction;
+            return transactionIndex;
           }
         }
+
+        return -1;
       }
 
       function resetFiltersAndShowSelectedTransaction(accountsController) {
         function getTransactionIndex() {
           accountsController.removeObserver('contentResults', getTransactionIndex);
           var contentResults = accountsController.get('contentResults');
-          var transactionIndex = contentResults.indexOf(selectedTransaction);
+          var transactionIndex = findTransactionIndex(contentResults);
           showSelectedTransaction(accountsController, contentResults, transactionIndex);
         }
 
@@ -60,8 +66,34 @@
         var container = containerView.get('element');
 
         Ember.run.later(function () {
-          $(container).scrollTop(recordHeight * transactionIndex);
-          rowView.gridView.uncheckAllBut(selectedTransaction);
+          var skipSplits = ynabToolKit.options.toggleSplits && ynabToolKit.toggleSplits.setting === 'hide';
+          var transactionScrollTo = recordHeight * transactionIndex;
+
+          $(container).scrollTop(transactionScrollTo);
+
+          // if the toggle splits feature is enabled and we're hiding splits, then we need to recalculate
+          // the actual scroll position of the transaction we're linking to.
+          if (skipSplits) {
+            Ember.run.later(function () {
+              var newIndex = transactionIndex;
+              for (var i = containerView.get('displayStart'); i < transactionIndex; i++) {
+                if (contentResults[i].get('parentEntityId')) {
+                  newIndex--;
+                }
+              }
+
+              // there is a weird interaction with this feature and the toggle splits (i think) that causes
+              // the transaction to still be hidden (just out of view at viewable transaction - 1). Unfortunately
+              // getting that transaction isn't as simple as scrolling one more transaction so we're going
+              // to scroll 5 more transactions. this isn't perfect, it's as magic number as it gets but it works until
+              // i can pinpoint the actual issue here.
+              var newTransactionScrollTo = recordHeight * (newIndex - 5);
+              rowView.gridView.uncheckAllBut(selectedTransaction);
+              $(container).scrollTop(newTransactionScrollTo);
+            }, 250);
+          } else {
+            rowView.gridView.uncheckAllBut(selectedTransaction);
+          }
         }, 250);
       }
 
@@ -71,7 +103,7 @@
             initialize();
           }
 
-          if (waitingForAccountsPage && changedNodes.has('ynab-grid-body') > -1) {
+          if (waitingForAccountsPage && changedNodes.has('ynab-grid-body')) {
             waitingForAccountsPage = false;
             Ember.run.later(findSelectedTransaction, 250);
           }


### PR DESCRIPTION
Github Issue (if applicable): #447

Trello Link (if applicable): n/a

Forum Link (if applicable): n/a

#### Explanation of Bugfix/Feature/Enhancement:
Not sure if `resetFiltersAndShowSelectedTransaction` was ever working but it is now. Also tackled an issue with this feature and toggleSplits enabled at same time. It's not super pretty by any means but gets the job done for sure.


#### Recommended Release Notes:
- Fixed an issue where activity->transaction link didn't work with filtered account data.
- Fixed an issue where activity->transaction failed to scroll to the transaction with toggle splits on and hiding split transactions.