### PR TITLE
Added exception for rows that are being edited

### DIFF
--- a/source/common/res/features/toggle-splits/main.js
+++ b/source/common/res/features/toggle-splits/main.js
@@ -55,7 +55,7 @@
 
       function hideSubTransactions() {
         ynabToolKit.toggleSplits.setting = 'hide';
-        $('.ynab-grid-body .ynab-grid-body-sub').hide();
+        $('.ynab-grid-body .ynab-grid-body-sub:not(.is-editing)').hide();
         $(".ynab-grid-cell-subCategoryName[title^='Split']").css('font-weight', 700);
         setDisplayEnd();
       }


### PR DESCRIPTION
Github Issue (if applicable): #456 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Just added an exception to the jquery selector to not hide rows that are in editing mode.
```
      function hideSubTransactions() {
        ynabToolKit.toggleSplits.setting = 'hide';
        $('.ynab-grid-body .ynab-grid-body-sub:not(.is-editing)').hide();
        $(".ynab-grid-cell-subCategoryName[title^='Split']").css('font-weight', 700);
        setDisplayEnd();
      }
```

#### Recommended Release Notes:

