### PR TITLE
BUGFIX: Split Transaction Shortcut

### DIFF
--- a/source/common/res/features/split-keyboard-shortcut/main.js
+++ b/source/common/res/features/split-keyboard-shortcut/main.js
@@ -13,12 +13,15 @@
 
               var splitIcon = splitButton.html();
               var categoryList = $('.modal-account-categories .modal-list');
-              var liElement = categoryList.find('li.user-data').last().clone();
+              var liElement = $(`<li class="user-data">
+                                      <button class="button-list ">
+                                        <div class="modal-account-categories-category" title="Split Transaction">
+                                          <span class="modal-account-categories-category-name"></span>
+                                        </div>
+                                      </button>
+                                  </li>`);
 
-              liElement.find('.modal-account-categories-category').attr('title', 'Split Transaction');
               liElement.find('.modal-account-categories-category-name').html(splitIcon);
-              liElement.find('.user-data.currency').remove();
-
               categoryList.append('<li class="user-data"><strong class="modal-account-categories-section-item">Actions:</strong></li>');
               categoryList.append(liElement);
 


### PR DESCRIPTION
Github Issue (if applicable): #454 

Trello Link (if applicable): n/a

Forum Link (if applicable): n/a

#### Explanation of Bugfix/Feature/Enhancement:
If the last element in the category list had no sub categories, things got quite funky with this feature, I've removed the dependency on the last element.


#### Recommended Release Notes:
Fixed an issue with the split transaction shortcut that caused it not to work for some users.