### PR TITLE
adding show intercom button

### DIFF
--- a/source/.eslintrc.js
+++ b/source/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
         "$": true,
         "Chart": true,
         "Ember": true,
+        "Intercom": true,
         "KangoAPI": true,
         "chrome": true,
         "ensureDefaultsAreSet": true,

--- a/source/common/res/features/show-intercom/main.js
+++ b/source/common/res/features/show-intercom/main.js
@@ -1,0 +1,35 @@
+(function poll() {
+  // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
+  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.pageReady === true) {
+    ynabToolKit.showIntercom = (function () {
+      return {
+        invoke() {
+          let $modal = $('.modal-user-prefs .modal');
+          let $modalList = $('.modal-user-prefs .modal-list');
+
+          if ($('.ynab-toolkit-show-intercom', $modalList).length) return;
+
+          $(`<li class="ynab-toolkit-show-intercom">
+              <button>
+                <i class="flaticon stroke warning-2"></i>
+                Show Intercom
+              </button>
+             </li>
+          `).click(() => {
+            Intercom('show'); // eslint-disable-line new-cap
+          }).appendTo($modalList);
+
+          $modal.css({ height: '+=10px' });
+        },
+
+        observe(changedNodes) {
+          if (changedNodes.has('ynab-u modal-popup modal-user-prefs ember-view modal-overlay active')) {
+            ynabToolKit.showIntercom.invoke();
+          }
+        }
+      };
+    }()); // Keep feature functions contained within this object
+  } else {
+    setTimeout(poll, 250);
+  }
+}());

--- a/source/common/res/features/show-intercom/settings.json
+++ b/source/common/res/features/show-intercom/settings.json
@@ -1,0 +1,13 @@
+{
+         "name": "showIntercom",
+         "type": "checkbox",
+      "default": true,
+      "section": "general",
+        "title": "Show Intercom",
+  "description": "It's easy to just click 'X' on the intercom announcements when they show up and forget to read what was there. This feature add an option to the account-options popup (click your e-mail at the bottom left of the screen) to show the intercom again.",
+      "actions": {
+                    "true": [
+                      "injectScript", "main.js"
+                    ]
+                 }
+}


### PR DESCRIPTION
Github Issue (if applicable): n/a

Trello Link (if applicable): n/a

Forum Link (if applicable): http://forum.youneedabudget.com/discussion/comment/649169#Comment_649169

#### Explanation of Bugfix/Feature/Enhancement:
Adds a "Show Intercom" button to the user profile modal that shows the intercom incase people close it without realizing they wanted to read a message.


#### Recommended Release Notes:
You can now unhide the intercom if you accidentally close it.