### PR TITLE
BUGFIX: Progress Bars

### DIFF
--- a/source/common/res/features/budget-progress-bars/main.js
+++ b/source/common/res/features/budget-progress-bars/main.js
@@ -164,7 +164,7 @@
             }
 
             if ($(this).hasClass('is-sub-category')) {
-              var subCategoryName = $(this).find('li.budget-table-cell-name>div>div')[0].title;
+              var subCategoryName = $(this).find('li.budget-table-cell-name>div>div')[0].title.match(/.[^\n]*/);
 
               if (subCategoryName === 'Uncategorized Transactions') {
                 // iterate the .each() function


### PR DESCRIPTION
Github Issue (if applicable): #474 

Trello Link (if applicable): n/a

Forum Link (if applicable): http://forum.youneedabudget.com/discussion/52067/nynab-just-got-updated-and-budget-rows-progress-bars-stop-working#latest

#### Explanation of Bugfix/Feature/Enhancement:
I didn't notice that the same method of getting a category name was used in progress bars and failed to make the update there as well.


#### Recommended Release Notes:
Fixed an issue with progress bars related to YNAB's latest update. (For real this time, we think)
