### PR TITLE
BUGFIX: Enter in register now 

### DIFF
--- a/source/common/res/features/enter-in-register-now/main.js
+++ b/source/common/res/features/enter-in-register-now/main.js
@@ -33,15 +33,16 @@
         if (!canEnterNow) return;
 
         $('.modal-account-edit-transaction-list .modal-list')
-          .prepend(`<li>
-                      <button class="button-list ynab-toolkit-enter-in-register-now">
-                        <i class="flaticon stroke share-2"></i>
-                        Enter In Register Now
-                      </button>
-                    </li>`)
-          .click(() => {
-            enterTransactionInRegisterNow(selectedTransactions);
-          });
+          .prepend(
+            $(`<li>
+                <button class="button-list ynab-toolkit-enter-in-register-now">
+                  <i class="flaticon stroke share-2"></i>
+                  Enter In Register Now
+                </button>
+              </li>`).click(() => {
+                enterTransactionInRegisterNow(selectedTransactions);
+              })
+          );
       }
 
       return {


### PR DESCRIPTION
Github Issue (if applicable): #481 

Trello Link (if applicable): n/a

Forum Link (if applicable): n/a

#### Explanation of Bugfix/Feature/Enhancement:
Just a chaining issue with jQuery -- on click was getting added to the entire list of elements in the modal, no bueno.


#### Recommended Release Notes:
Fixed an issue where scheduled transactions would get "entered now" when you tried to delete them.