### PR TITLE
Collapsed Sidebar Icons disappear - Bug #468

### DIFF
--- a/source/common/res/features/collapse-side-menu/main.js
+++ b/source/common/res/features/collapse-side-menu/main.js
@@ -87,7 +87,9 @@
             $('.sidebar').prepend(expandBtns);
           }
 
-          $('.collapsed-buttons').hide();
+          if ($('.sidebar-contents').is(':visible')) {
+             $('.collapsed-buttons').hide();
+          }
         },
 
         getUnCollapseBtnGroup() {

--- a/source/common/res/features/collapse-side-menu/main.js
+++ b/source/common/res/features/collapse-side-menu/main.js
@@ -88,7 +88,7 @@
           }
 
           if ($('.sidebar-contents').is(':visible')) {
-             $('.collapsed-buttons').hide();
+            $('.collapsed-buttons').hide();
           }
         },
 


### PR DESCRIPTION
Github Issue (if applicable): #468 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
When changing active icon/button the setUpCollapsedButtons was being ran again and the class collapse-buttons was being hidden. 

Code will now stop the collapsed buttons from hiding when the sidebar is collapsed and the active button is changed.


#### Recommended Release Notes:

