### PR TITLE
Gate addition of import notifications

### DIFF
--- a/source/common/res/features/import-notification/main.js
+++ b/source/common/res/features/import-notification/main.js
@@ -4,9 +4,11 @@
       $('.import-notification').remove();
       $('.nav-account-row').each(function (index, row) {
         var account = ynabToolKit.shared.getEmberView($(row).attr('id')).get('data');
-        var transactions = ynab.utilities.TransactionImportUtilities.getImportTransactionsForAccount(account);
-        if (transactions.length >= 1) {
-          $(row).find('.nav-account-notification').append('<a class="notification import-notification">' + transactions.length + '</a>');
+        if( account.getDirectConnectEnabled()) {
+          var transactions = ynab.utilities.TransactionImportUtilities.getImportTransactionsForAccount(account);
+          if (transactions.length >= 1) {
+            $(row).find('.nav-account-notification').append('<a class="notification import-notification">' + transactions.length + '</a>');
+          }
         }
       });
     };

--- a/source/common/res/features/import-notification/main.js
+++ b/source/common/res/features/import-notification/main.js
@@ -4,7 +4,7 @@
       $('.import-notification').remove();
       $('.nav-account-row').each(function (index, row) {
         var account = ynabToolKit.shared.getEmberView($(row).attr('id')).get('data');
-        if( account.getDirectConnectEnabled()) {
+        if (account.getDirectConnectEnabled()) {
           var transactions = ynab.utilities.TransactionImportUtilities.getImportTransactionsForAccount(account);
           if (transactions.length >= 1) {
             $(row).find('.nav-account-notification').append('<a class="notification import-notification">' + transactions.length + '</a>');


### PR DESCRIPTION
Github Issue (if applicable): #345 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:

Currently, if an account used to have Direct Connect enabled, but it was disabled while transactions were pending import, the Toolkit erroneously displays a notification by that account which can never be cleared.  With this change, import notifications will never be shown for an account where Direct Connect is not used.

NOTE:  I have tested making this call from the console, but haven't built a test instance of the plug-in to test cross-browser.

#### Recommended Release Notes:

Bugfix:  Import notifications no longer show for accounts where importing has been disabled.