### PR TITLE
New feature: accounts-clear-selection in the account register.

### DIFF
--- a/source/common/res/features/accounts-clear-selection/main.js
+++ b/source/common/res/features/accounts-clear-selection/main.js
@@ -1,0 +1,55 @@
+(function poll() {
+  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true) {
+    let menuText = ynabToolKit.l10nData && ynabToolKit.l10nData['toolkit.accountsClearSelection'] || 'Clear Selection';
+
+    ynabToolKit.accountsClearSelection = (function () {
+      function uncheckTransactions() {
+        let accountsController = ynabToolKit.shared.containerLookup('controller:accounts');
+
+        try {
+          accountsController.get('areChecked').setEach('isChecked', 0);
+          accountsController.send('closeModal');
+        } catch (e) {
+          accountsController.send('closeModal');
+          ynabToolKit.shared.showFeatureErrorModal('Clear Selection');
+        }
+      }
+
+      function addOptionToContextMenu() {
+        // Note that ${menuText} was intentionally placed on the same line as the <i> tag to
+        // prevent the leading space that occurs as a result of using a multi-line string.
+        // Using a dedent function would allow it to be placed on its own line which would be
+        // more natural.
+        //
+        // The second <li> functions as a separator on the menu after the feature menu item.
+        $('.modal-account-edit-transaction-list .modal-list')
+          .prepend(
+            $(`<li>
+                <button class="button-list ynab-toolkit-clear-selection">
+                  <i class="flaticon stroke minus-2"></i>${menuText}
+                </button>
+              </li>
+              <li><hr /><li>`).click(() => {
+                uncheckTransactions();
+              })
+          );
+      }
+
+      return {
+        invoke() {
+          addOptionToContextMenu();
+        },
+
+        observe(changedNodes) {
+          if (changedNodes.has('ynab-u modal-popup\nmodal-account-edit-transaction-list ember-view modal-overlay active')) {
+            ynabToolKit.accountsClearSelection.invoke();
+          }
+        }
+      };
+    }());
+
+    ynabToolKit.accountsClearSelection.invoke();
+  } else {
+    setTimeout(poll, 250);
+  }
+}());

--- a/source/common/res/features/accounts-clear-selection/settings.json
+++ b/source/common/res/features/accounts-clear-selection/settings.json
@@ -1,0 +1,13 @@
+{
+         "name": "accountsClearSelection",
+         "type": "checkbox",
+      "default": false,
+      "section": "accounts",
+        "title": "Clear Selection",
+  "description": "Adds an option to the transaction edit drop-down menu to clear the current selection.",
+      "actions": {
+                    "true": [
+                      "injectScript", "main.js"
+                    ]
+                 }
+}


### PR DESCRIPTION
Github Issue (if applicable): #XXX

Trello Link (if applicable):
https://trello.com/c/dsJqcgoX

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Adds an item to the Edit Transaction drop-down menu which clears the current selection.

#### Recommended Release Notes:
Easily clear the selection of transactions from the Edit Transaction menu even if the selected transaction are not visible. No more scrolling to find all those selected transactions! 