### PR TITLE
BUGFIX: #523 Budget Rows Progress Bars

### DIFF
--- a/source/common/res/features/budget-progress-bars/main.js
+++ b/source/common/res/features/budget-progress-bars/main.js
@@ -160,7 +160,7 @@
             var budgetedCell;
             if ($(this).hasClass('is-master-category')) {
               masterCategoryName = $(this).find('div.budget-table-cell-name-row-label-item>div>div[title]');
-              masterCategoryName = (masterCategoryName !== 'undefined') ? $(masterCategoryName).attr('title') : '';
+              masterCategoryName = (masterCategoryName !== 'undefined') ? ($(masterCategoryName).attr('title') + '_') : '';
             }
 
             if ($(this).hasClass('is-sub-category')) {
@@ -171,7 +171,7 @@
                 return;
               }
 
-              subCategoryName = masterCategoryName + '_' + subCategoryName;
+              subCategoryName = masterCategoryName + subCategoryName;
 
               switch (ynabToolKit.options.budgetProgressBars) {
                 case 'goals':


### PR DESCRIPTION
Github Issue (if applicable): #523 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Changed the logic where the master category is being located to include appending the underscore if a master category is found. This allows the master category var to always be concatenated to the subcategory name with no risk of a leading underscore.


#### Recommended Release Notes:

Uncategorized Transactions are no longer a subcategory. Changed logic to add the underscore to the end of the master category when one is found rather than always expecting one.