### PR TITLE
The size of the budget inspector is now saved and restored across sessions and when moving between an account and the budget. Note that the size is local to the computer and not your YNAB account so you can have different sizes on different computers.

### DIFF
--- a/source/common/res/features/resize-inspector/main.js
+++ b/source/common/res/features/resize-inspector/main.js
@@ -3,9 +3,15 @@
     ynabToolKit.resizeInspector = (function () {
       // Supporting functions,
       // or variables, etc
-
       return {
+        sectionWidth: '',
         invoke() {
+          let sectionWidth = ynabToolKit.shared.getToolkitStorageKey('budget-resize-inspector');
+
+          if (typeof sectionWidth !== 'undefined' && sectionWidth !== null) {
+            ynabToolKit.resizeInspector.sectionWidth = sectionWidth;
+          }
+
           if ($('.ember-view.content .budget-inspector').length > 0) {
             if ($('.resize-inspector').length === 0) {
               $('.ember-view.content .scroll-wrap').addClass('resize-inspector');
@@ -13,16 +19,30 @@
               $('.inspector-resize-handle').css('background-image', 'url(' + window.resizeInspectorAsset + ')');
               $('section').resizable({
                 handleSelector: '.inspector-resize-handle',
-                resizeHeight: false
+                resizeHeight: false,
+                maxWidth: 1400,
+                onDragEnd: () => {
+                  let width = $('section').css('width').match(/.[^px]*/);
+                  ynabToolKit.shared.setToolkitStorageKey('budget-resize-inspector', width);
+                }
               });
+
+              if (sectionWidth !== '') {
+                $('section').css('width', sectionWidth);
+              }
             }
           } else {
             $('.resize-inspector').removeClass('resize-inspector');
           }
         },
 
+        getContentSize() {
+          return ynabToolKit.resizeInspector.sectionWidth;
+        },
+
         observe(changedNodes) {
-          if (changedNodes.has('layout user-logged-in')) {
+          if (changedNodes.has('layout user-logged-in') ||
+              changedNodes.has('navlink-collapse')) {
             // The user has switched screens
             ynabToolKit.resizeInspector.invoke();
           }


### PR DESCRIPTION
Github Issue (if applicable): #113 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Added code to store the size of the budget inspector (actually saving the size of the content section) and restore it across sessions and when moving between an account and the budget. The inspector size is now retained when the collapse menu button is clicked. 

#### Recommended Release Notes:
The size of the budget inspector is now saved and restored across sessions and when moving between an account and the budget. Note that the size is local to the computer and not your YNAB account so you can have different sizes on different computers.