### PR TITLE
depending on YNABFEATURES instead of the dom because of race conditio…

### DIFF
--- a/source/common/res/features/accounts-transaction-search/main.js
+++ b/source/common/res/features/accounts-transaction-search/main.js
@@ -145,7 +145,7 @@
       }
 
       function hasNativeSearch() {
-        return $('.transaction-search').length !== 0;
+        return window.YNABFEATURES.get('register-search');
       }
 
       return {


### PR DESCRIPTION
This actually stops the toolkit search bar from appearing if the user has search enabled on their account.