### PR TITLE
When you clicked the native reports after being on the toolkit reports, the navigation bar didn't update correctly. Now it does.

### DIFF
--- a/source/common/res/features/reports/main.js
+++ b/source/common/res/features/reports/main.js
@@ -520,6 +520,7 @@
           // Did they switch away from our tab?
           if (changedNodes.has('navlink-budget active') ||
               changedNodes.has('navlink-accounts active') ||
+              changedNodes.has('navlink-reports active') ||
               changedNodes.has('nav-account-row is-selected')) {
             // The user has left the reports page.
             // We're no longer the active page.


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Enhancement:

We weren't checking if navlink-reports was active.
#### Recommended Release Notes:

When you clicked the native reports after being on the toolkit reports, the navigation bar didn't update correctly. Now it does.
