### PR TITLE
Fixed loading localised strings. They were appending to empty object instead of YNAB internal localisation object. So strings missing in localisation were removed and visible as errors in interface.

### DIFF
--- a/source/common/res/features/l10n/main.js
+++ b/source/common/res/features/l10n/main.js
@@ -78,7 +78,7 @@
             });
           }
 
-          Ember.I18n.translations = jQuery.extend(true, {}, ynabToolKit.l10nData);
+          Ember.I18n.translations = jQuery.extend(true, Ember.I18n.translations, ynabToolKit.l10nData);
         },
 
         budgetHeader() {


### PR DESCRIPTION
Github Issue (if applicable): #572
#### Explanation of Bugfix/Feature/Enhancement:

Fix loading localised strings. They were appending to empty object instead of YNAB internal localisation object. So strings missing in localisation was removed and visible as errors in interface.

This is really fix for #572.
