### PR TITLE
don't show enter now if native ynab is doing it

### DIFF
--- a/source/common/res/features/enter-in-register-now/main.js
+++ b/source/common/res/features/enter-in-register-now/main.js
@@ -47,6 +47,10 @@
 
       return {
         invoke() {
+          if (window.YNABFEATURES['enter-scheduled-transaction-now']) {
+            return;
+          }
+
           accountsController = ynabToolKit.shared.containerLookup('controller:accounts');
           transactionViewModel = accountsController.get('transactionViewModel');
           addOptionToContextMenu();


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Enhancement:
Pretty self explanatory -- if native enter now is available, don't show ours.


#### Recommended Release Notes:
None. Don't think this is an announced native feature.

