### PR TITLE
Bug Fix: You can now type decimals when using the pop up calculator.

### DIFF
--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -175,6 +175,7 @@
                      (e.which > 95 && e.which < 112) || // numpad
                       e.which === 8 ||  // backspace
                       e.which === 13 || // numpad enter
+                      e.which === 190 || // numpad enter
                       e.which === 187) { // keyboard enter
             doCalculation(e.key);
 

--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -176,7 +176,7 @@
                       e.which === 8 ||  // backspace
                       e.which === 13 || // numpad enter
                       e.which === 190 || // numpad enter
-                      e.which === 187) { // keyboard enter
+                      e.which === 187) { // decimal
             doCalculation(e.key);
 
             if (e.which === 13 || e.which === 18) { // Enter key?

--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -220,6 +220,10 @@
               result = '';
             }
 
+            if (result.indexOf('.') !== -1 && key === '.') {
+              key = '';
+            }
+
             result = value2 + key + ''; // ensure concatenation
             value2 = result;  // set potential second value
             return result;


### PR DESCRIPTION
Github Issue (if applicable): #596 

#### Explanation of Bugfix/Feature/Enhancement:
Decimal wasn't on the list of characters to listen for

#### Recommended Release Notes:
You can now type decimals when using the pop up calculator.

