### PR TITLE
Issue #237 Reload after "budget quick switching"

### DIFF
--- a/source/common/res/features/budget-balance-to-zero/main.js
+++ b/source/common/res/features/budget-balance-to-zero/main.js
@@ -26,10 +26,15 @@
             return [];
           }
 
+          // After using Budget Quick Switch, budgetView needs to be reset to the new budget.
+          if (ynabToolKit.budgetBalanceToZero.budgetView.categoriesViewModel === null) {
+            ynabToolKit.budgetBalanceToZero.budgetView = ynab.YNABSharedLib.
+              getBudgetViewModel_AllBudgetMonthsViewModel()._result;
+          }
           var categories = [];
-          var masterCategories = [];
           var masterCats = ynabToolKit.budgetBalanceToZero.budgetView
-            .categoriesViewModel.masterCategoriesCollection._internalDataArray;
+          .categoriesViewModel.masterCategoriesCollection._internalDataArray;
+          var masterCategories = [];
 
           masterCats.forEach(function (c) {
             // Filter out "special" categories


### PR DESCRIPTION
Github Issue (if applicable): #237

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
If the Budget Quick Switch feature of the Toolkit is used to change budgets, the budgetView variable needs to be be reset. Watching for changed nodes isn't enough because the quick switch doesn't leave the budget screen.

#### Recommended Release Notes:

