### PR TITLE
Remove comma so parseFloat recognizes numbers with a thousands seperator

### DIFF
--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -17,8 +17,6 @@
           calcValue = '0.00';
         }
 
-        calcValue = calcValue.replace(/,/g, ''); // Removes thousand seperator, probably not i18n compatable
-
         popupCalc.value(calcValue);
 
         if ($('#toolkitPopupCalc').length) {
@@ -222,7 +220,7 @@
               result = '';
             }
 
-            if (result.indexOf('.') !== -1 && key === '.') {
+            if (result.toString().indexOf('.') !== -1 && key === '.') { // Prevents multiple decimal points
               key = '';
             }
 
@@ -295,8 +293,8 @@
             }
           },
           value: function (key) {
-            value1 = key;
-            result = key;
+            value1 = ynabToolKit.shared.unformatCurrency(key);
+            result = ynabToolKit.shared.unformatCurrency(key);
           },
           display: function () {
             return reveal;

--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -17,6 +17,8 @@
           calcValue = '0.00';
         }
 
+        calcValue = calcValue.replace(/,/g, ''); // Removes thousand seperator, probably not i18n compatable
+
         popupCalc.value(calcValue);
 
         if ($('#toolkitPopupCalc').length) {

--- a/source/common/res/features/shared/main.js
+++ b/source/common/res/features/shared/main.js
@@ -151,6 +151,12 @@ ynabToolKit.shared = (function () {
       return new Ember.Handlebars.SafeString(formatted);
     },
 
+	// This function returns an unformated number
+    unformatCurrency(number) {
+      var unformatted = ynab.unformat(number);
+      return unformatted;
+    },
+
     appendFormattedCurrencyHtml(jQueryElement, number) {
       var formatted = ynab.formatCurrency(number);
       var currency = ynab.YNABSharedLib.currencyFormatter.getCurrency();


### PR DESCRIPTION
Github Issue (if applicable):
Trello Link (if applicable):
Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
popup calc is grabbing the localized value from the account. parseFloat would fail to parse something like "1,234.56" correctly. "1,234.56" + 2 would result in 1 + 2 = 3.

#### Recommended Release Notes:
Calculator now correctly handles a starting value with commas