### PR TITLE
Fix bug in highlight current month feature

### DIFF
--- a/source/common/res/features/highlight-current-month/main.js
+++ b/source/common/res/features/highlight-current-month/main.js
@@ -6,6 +6,7 @@
       function inCurrentMonth() {
         var today = new Date();
         var selectedMonth = ynabToolKit.shared.parseSelectedMonth();
+        if (selectedMonth === null) return;
         return selectedMonth.getMonth() === today.getMonth() && selectedMonth.getYear() === today.getYear();
       }
 
@@ -29,9 +30,7 @@
       };
     }()); // Keep feature functions contained within this object
 
-    var href = window.location.href;
-    href = href.replace('youneedabudget.com', '');
-    if (/budget/.test(href)) {
+    if (ynabToolKit.shared.getCurrentRoute() === 'budget.index') {
       ynabToolKit.currentMonthIndicator.invoke();
     }
   } else {

--- a/source/common/res/features/highlight-current-month/main.js
+++ b/source/common/res/features/highlight-current-month/main.js
@@ -6,7 +6,7 @@
       function inCurrentMonth() {
         var today = new Date();
         var selectedMonth = ynabToolKit.shared.parseSelectedMonth();
-        if (selectedMonth === null) return;
+        if (selectedMonth === null) return false;
         return selectedMonth.getMonth() === today.getMonth() && selectedMonth.getYear() === today.getYear();
       }
 


### PR DESCRIPTION
Github Issue (if applicable): #653 (partial fix)

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:

If you set a breakpoint at 171 of shared/main.js in parseSelectedMonth and run through all the calls when you load YNAB, you'll see several errors mostly from features not checking the return value is not null. This fixes one of those errors. 

It also fixes a bug where the feature was checking the window.href for a "budget" string, but the "users/budgets" route (which is actually just a list of budgets, and not a budget itself), shouldn't have this feature invoked. I'm not entirely sure about this though, as maybe it should be invoked on other routes besides "budget.index"?

<img width="1280" alt="bug-highlight-current-month" src="https://cloud.githubusercontent.com/assets/776060/21875066/6340211c-d836-11e6-86bb-5885d0c4b763.png">
<img width="1251" alt="bug-highlight-current-month-2" src="https://cloud.githubusercontent.com/assets/776060/21875065/633ea4cc-d836-11e6-9ccd-d56ec6f0c409.png">


#### Recommended Release Notes:
