### PR TITLE
Add pacing column to layout for current month only.

### DIFF
--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -21,7 +21,7 @@
       function inCurrentMonth() {
         var today = new Date();
         var selectedMonth = ynabToolKit.shared.parseSelectedMonth();
-        return selectedMonth.getMonth() === today.getMonth() && selectedMonth.getYear() === today.getYear();
+        return (selectedMonth === null) ? false : selectedMonth.getMonth() === today.getMonth() && selectedMonth.getYear() === today.getYear();
       }
 
       function getDeemphasizedCategoriesSetting() {

--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -69,8 +69,9 @@
           var allTransactions = tv.getVisibleTransactionDisplayItemsForMonth(month);
 
           if ($('.ember-view .budget-header').length) {
-            if (inCurrentMonth()) {
-              // Make room for the column
+            let currentMonth = inCurrentMonth();
+
+            if (currentMonth) { // Make room for the column
               $('#ynab-toolkit-pacing-style').remove();
               $('<style type="text/css" id="ynab-toolkit-pacing-style"> .budget-table-cell-available { width: 10% !important; } </style>').appendTo('head');
             } else {
@@ -80,97 +81,101 @@
 
             $('.budget-table-cell-pacing').remove();
 
-            $('.budget-table-header .budget-table-cell-available').after('<li class="budget-table-cell-pacing">' +
-              ((ynabToolKit.l10nData && ynabToolKit.l10nData['toolkit.pacing']) || 'PACING') + '</li>');
+            // Only add pacing column if in the current month otherwise the hidden column can cause problems for
+            // other features that are not expecting the column to be present but not hidden.
+            if (currentMonth) {
+              $('.budget-table-header .budget-table-cell-available').after('<li class="budget-table-cell-pacing">' +
+                ((ynabToolKit.l10nData && ynabToolKit.l10nData['toolkit.pacing']) || 'PACING') + '</li>');
 
-            var deemphasizedCategories = getDeemphasizedCategories();
+              var deemphasizedCategories = getDeemphasizedCategories();
 
-            var showIndicator = ynabToolKit.options.pacing;
-            if (showIndicator === '2') {
-              showIndicator = true;
-            } else {
-              showIndicator = false;
-            }
-
-            // Select all budget table rows but not the uncategorized category and not master categories.
-            $('.budget-table-row')
-              .not('.budget-table-uncategorized-transactions')
-              .not('.is-master-category')
-              .each(function () {
-                var available = ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat($(this).find('.budget-table-cell-available').text());
-                var activity = -ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat($(this).find('.budget-table-cell-activity').text());
-                var budgeted = available + activity;
-                var burned = activity / budgeted;
-                var pace = burned / timeSpent();
-
-                let masterCategoryViewId = $(this).prevAll('.is-master-category').attr('id');
-                let masterCategory = ynabToolKit.shared.getEmberView(masterCategoryViewId).get('data');
-                let masterCategoryId = masterCategory.get('categoryId');
-                var masterCategoryDisplayName = masterCategory.get('displayName');
-
-                let subCategoryViewId = $(this).attr('id');
-                let subCategory = ynabToolKit.shared.getEmberView(subCategoryViewId).get('data');
-                let subCategoryId = subCategory.get('categoryId');
-                var subCategoryDisplayName = subCategory.get('displayName');
-
-                var transactionCount = allTransactions.filter(function (el) {
-                  return el.outflow > 0 &&
-                    el.masterCategoryId === masterCategoryId &&
-                    el.subCategoryId === subCategoryId;
-                }).length;
-
-                var temperature;
-                if (pace > 1) {
-                  temperature = 'cautious';
-                } else {
-                  temperature = 'positive';
-                }
-
-                var deemphasized = masterCategory.get('isDebtPaymentCategory') || $.inArray(masterCategoryDisplayName + '_' + subCategoryDisplayName, deemphasizedCategories) >= 0;
-                var display = Math.round((budgeted * timeSpent() - activity) * 1000);
-                var tooltip;
-
-                if (display >= 0) {
-                  tooltip = 'In ' + transactionCount + ' transaction' + (transactionCount !== 1 ? 's' : '') +
-                    ' you have spent ' + ynabToolKit.shared.formatCurrency(display, false) +
-                    ' less than your available budget for this category ' + Math.round(timeSpent() * 100) +
-                    '% of the way through the month.&#13;&#13;' + (deemphasized ? 'Click to unhide.' : 'Click to hide.');
-                } else if (display < 0) {
-                  tooltip = 'In ' + transactionCount + ' transaction' + (transactionCount !== 1 ? 's' : '') +
-                    ' you have spent ' + ynabToolKit.shared.formatCurrency(-display, false) +
-                    ' more than your available budget for this category ' + Math.round(timeSpent() * 100) +
-                    '% of the way through the month.&#13;&#13;' + (deemphasized ? 'Click to unhide.' : 'Click to hide.');
-                }
-
-                $(this).append('<li class="budget-table-cell-available budget-table-cell-pacing"><span title="' + tooltip +
-                               '" class="budget-table-cell-pacing-display ' + temperature + ' ' +
-                               (deemphasized ? 'deemphasized' : '') + (showIndicator ? ' indicator' : '') +
-                               '" data-name="' + masterCategoryDisplayName + '_' + subCategoryDisplayName + '">' +
-                               ynabToolKit.shared.formatCurrency(display, true) + '</span></li>');
-              });
-
-            $('.budget-table-cell-pacing-display').click(function (e) {
-              var latestDemphasizedCategories = getDeemphasizedCategories();
-              var name = $(this).data('name');
-
-              if ($.inArray(name, latestDemphasizedCategories) >= 0) {
-                latestDemphasizedCategories.splice($.inArray(name, latestDemphasizedCategories), 1);
-                ynab.utilities.ConsoleUtilities.logWithColor(ynab.constants.LogLevels.Debug, 'Re-emphasizing category ' + name + ', new hide list ' + JSON.stringify(latestDemphasizedCategories));
-                setDeemphasizedCategories(latestDemphasizedCategories);
-                $(this).removeClass('deemphasized');
+              var showIndicator = ynabToolKit.options.pacing;
+              if (showIndicator === '2') {
+                showIndicator = true;
               } else {
-                latestDemphasizedCategories.push(name);
-                ynab.utilities.ConsoleUtilities.logWithColor(ynab.constants.LogLevels.Debug, 'De-emphasizing category ' + name + ', new hide list ' + JSON.stringify(latestDemphasizedCategories));
-                setDeemphasizedCategories(latestDemphasizedCategories);
-                $(this).addClass('deemphasized');
+                showIndicator = false;
               }
 
-              if (['pacing', 'both'].indexOf(ynabToolKit.options.budgetProgressBars) !== -1) {
-                ynabToolKit.shared.invokeExternalFeature('budgetProgressBars');
-              }
+              // Select all budget table rows but not the uncategorized category and not master categories.
+              $('.budget-table-row')
+                .not('.budget-table-uncategorized-transactions')
+                .not('.is-master-category')
+                .each(function () {
+                  var available = ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat($(this).find('.budget-table-cell-available').text());
+                  var activity = -ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat($(this).find('.budget-table-cell-activity').text());
+                  var budgeted = available + activity;
+                  var burned = activity / budgeted;
+                  var pace = burned / timeSpent();
 
-              e.stopPropagation();
-            });
+                  let masterCategoryViewId = $(this).prevAll('.is-master-category').attr('id');
+                  let masterCategory = ynabToolKit.shared.getEmberView(masterCategoryViewId).get('data');
+                  let masterCategoryId = masterCategory.get('categoryId');
+                  var masterCategoryDisplayName = masterCategory.get('displayName');
+
+                  let subCategoryViewId = $(this).attr('id');
+                  let subCategory = ynabToolKit.shared.getEmberView(subCategoryViewId).get('data');
+                  let subCategoryId = subCategory.get('categoryId');
+                  var subCategoryDisplayName = subCategory.get('displayName');
+
+                  var transactionCount = allTransactions.filter(function (el) {
+                    return el.outflow > 0 &&
+                      el.masterCategoryId === masterCategoryId &&
+                      el.subCategoryId === subCategoryId;
+                  }).length;
+
+                  var temperature;
+                  if (pace > 1) {
+                    temperature = 'cautious';
+                  } else {
+                    temperature = 'positive';
+                  }
+
+                  var deemphasized = masterCategory.get('isDebtPaymentCategory') || $.inArray(masterCategoryDisplayName + '_' + subCategoryDisplayName, deemphasizedCategories) >= 0;
+                  var display = Math.round((budgeted * timeSpent() - activity) * 1000);
+                  var tooltip;
+
+                  if (display >= 0) {
+                    tooltip = 'In ' + transactionCount + ' transaction' + (transactionCount !== 1 ? 's' : '') +
+                      ' you have spent ' + ynabToolKit.shared.formatCurrency(display, false) +
+                      ' less than your available budget for this category ' + Math.round(timeSpent() * 100) +
+                      '% of the way through the month.&#13;&#13;' + (deemphasized ? 'Click to unhide.' : 'Click to hide.');
+                  } else if (display < 0) {
+                    tooltip = 'In ' + transactionCount + ' transaction' + (transactionCount !== 1 ? 's' : '') +
+                      ' you have spent ' + ynabToolKit.shared.formatCurrency(-display, false) +
+                      ' more than your available budget for this category ' + Math.round(timeSpent() * 100) +
+                      '% of the way through the month.&#13;&#13;' + (deemphasized ? 'Click to unhide.' : 'Click to hide.');
+                  }
+
+                  $(this).append('<li class="budget-table-cell-available budget-table-cell-pacing"><span title="' + tooltip +
+                                 '" class="budget-table-cell-pacing-display ' + temperature + ' ' +
+                                 (deemphasized ? 'deemphasized' : '') + (showIndicator ? ' indicator' : '') +
+                                 '" data-name="' + masterCategoryDisplayName + '_' + subCategoryDisplayName + '">' +
+                                 ynabToolKit.shared.formatCurrency(display, true) + '</span></li>');
+                });
+
+              $('.budget-table-cell-pacing-display').click(function (e) {
+                var latestDemphasizedCategories = getDeemphasizedCategories();
+                var name = $(this).data('name');
+
+                if ($.inArray(name, latestDemphasizedCategories) >= 0) {
+                  latestDemphasizedCategories.splice($.inArray(name, latestDemphasizedCategories), 1);
+                  ynab.utilities.ConsoleUtilities.logWithColor(ynab.constants.LogLevels.Debug, 'Re-emphasizing category ' + name + ', new hide list ' + JSON.stringify(latestDemphasizedCategories));
+                  setDeemphasizedCategories(latestDemphasizedCategories);
+                  $(this).removeClass('deemphasized');
+                } else {
+                  latestDemphasizedCategories.push(name);
+                  ynab.utilities.ConsoleUtilities.logWithColor(ynab.constants.LogLevels.Debug, 'De-emphasizing category ' + name + ', new hide list ' + JSON.stringify(latestDemphasizedCategories));
+                  setDeemphasizedCategories(latestDemphasizedCategories);
+                  $(this).addClass('deemphasized');
+                }
+
+                if (['pacing', 'both'].indexOf(ynabToolKit.options.budgetProgressBars) !== -1) {
+                  ynabToolKit.shared.invokeExternalFeature('budgetProgressBars');
+                }
+
+                e.stopPropagation();
+              });
+            }
           }
         },
 


### PR DESCRIPTION
Github Issue (if applicable): #651

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
The pacing column is only relevant to the current month. The old code was adding the pacing column to the layout but hiding it. That had a ripple effect on other toolkit features.


#### Recommended Release Notes:
Pacing column will be displayed for current month only. This means that column widths will vary when moving backward and forward between the current month and other months.