### PR TITLE
Check that ynabGridContainer is defined before referencing it

### DIFF
--- a/source/common/res/features/accounts-row-height/main.js
+++ b/source/common/res/features/accounts-row-height/main.js
@@ -14,20 +14,24 @@
           // register.
           if (ynabToolKit.options.activityTransactionLink) {
             let ynabGridContainer = ynabToolKit.shared.getEmberView($('.ynab-grid-container').attr('id'));
-            let recordHeight = ynabGridContainer.get('recordHeight');
 
-            // The second check is to minimize the times that recordHeight is changed because
-            // each time it's changed YNAB reacts to it and that contributes to the scrolling
-            // jumpyness.
-            if (ynabToolKit.options.accountsRowHeight === '1' && recordHeight !== compactHeight) {
-              ynabGridContainer.set('recordHeight', compactHeight);
-            } else if (ynabToolKit.options.accountsRowHeight === '2' && recordHeight !== slimHeight) {
-              ynabGridContainer.set('recordHeight', slimHeight);
+            // Will be undefined when YNAB is loaded going directly to the budget screen.
+            if (typeof ynabGridContainer !== 'undefined') {
+              let recordHeight = ynabGridContainer.get('recordHeight');
+
+              // The second check is to minimize the times that recordHeight is changed because
+              // each time it's changed YNAB reacts to it and that contributes to the scrolling
+              // jumpyness.
+              if (ynabToolKit.options.accountsRowHeight === '1' && recordHeight !== compactHeight) {
+                ynabGridContainer.set('recordHeight', compactHeight);
+              } else if (ynabToolKit.options.accountsRowHeight === '2' && recordHeight !== slimHeight) {
+                ynabGridContainer.set('recordHeight', slimHeight);
+              }
             }
-          }
 
-          // Add our class so our CSS can take effect.
-          $('.ynab-grid-body-row-top > .ynab-grid-cell').addClass('toolkit-ynab-grid-cell');
+            // Add our class so our CSS can take effect.
+            $('.ynab-grid-body-row-top > .ynab-grid-cell').addClass('toolkit-ynab-grid-cell');
+          }
         },
 
         observe: function invoke(changedNodes) {


### PR DESCRIPTION
When YNAB is loaded directly to the budget screen, the DOM element with class ynab-grid-container doesn't exist yet the code was not taking that into consideration. This code change fixes that.

Github Issue (if applicable): #653

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Ensure variable is defined before referencing it.


#### Recommended Release Notes:
Corrects an internal logic error that produced a console error when YNAB is loaded straight to the budget screen.