### PR TITLE
fix bug in check credit balances feature

### DIFF
--- a/source/common/res/features/check-credit-balances/main.js
+++ b/source/common/res/features/check-credit-balances/main.js
@@ -30,6 +30,11 @@
         },
 
         getDebtAccounts() {
+          if (ynabToolKit.checkCreditBalances.budgetView === null) {
+            ynabToolKit.checkCreditBalances.budgetView = ynab.YNABSharedLib.
+            getBudgetViewModel_AllBudgetMonthsViewModel()._result;
+          }
+
           var categoryEntityId = ynabToolKit.checkCreditBalances.budgetView
             .categoriesViewModel.debtPaymentMasterCategory.entityId;
 

--- a/source/common/res/features/check-credit-balances/main.js
+++ b/source/common/res/features/check-credit-balances/main.js
@@ -23,6 +23,7 @@
         inMonth() {
           var today = new Date();
           var selectedMonth = ynabToolKit.shared.parseSelectedMonth();
+          if (selectedMonth === null) return false;
 
           // check for current month or future month
           return selectedMonth.getMonth() >= today.getMonth() && selectedMonth.getYear() >= today.getYear();
@@ -178,9 +179,7 @@
       };
     }()); // Keep feature functions contained within this object
 
-    var href = window.location.href;
-    href = href.replace('youneedabudget.com', '');
-    if (/budget/.test(href)) {
+    if (ynabToolKit.shared.getCurrentRoute() === 'budget.index') {
       ynabToolKit.checkCreditBalances.invoke();
     }
   } else {


### PR DESCRIPTION
Github Issue (if applicable): #653

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:

- Fix for not checking the return value of parseSelectedMonth(), causing exception on user/budgets route 
- Fix a bug where the feature was checking the window.href for a "budget" string, but the "users/budgets" route (which is actually just a list of budgets, and not a budget itself), shouldn't have this feature invoked.

#### Recommended Release Notes:
