### PR TITLE
Popup calculator updates to work on budget screen

### DIFF
--- a/source/common/res/features/budget-rows-height/compact.css
+++ b/source/common/res/features/budget-rows-height/compact.css
@@ -1,40 +1,40 @@
 .budget-content ul.budget-table-header {
-    height: 1.6em !important;
+  height: 1.6em !important;
 }
 
 .budget-table {
-    top: 1.4em !important;
+  top: 1.4em !important;
 }
 
 .budget-content ul, .budget-table-row.is-dragging {
-    height: 2em !important;
+  height: 2em; /* !important; */
 }
 
-    .budget-table-row.is-master-category .budget-table-cell-add-category .flaticon {
-        top: 0.25em;
-    }
+.budget-table-row.is-master-category .budget-table-cell-add-category .flaticon {
+  top: 0.25em;
+}
 
 .budget-table-row.is-sub-category {
-    height: 1.8em !important;
+  height: 1.8em !important;
 }
 
-    .budget-table-row.is-master-category .budget-table-cell-name {
-        padding-top: 0;
-    }
+.budget-table-row.is-master-category .budget-table-cell-name {
+  padding-top: 0;
+}
 
-    .budget-table-row.is-sub-category > .budget-table-cell-available .positive, .budget-table-row.is-sub-category > .budget-table-cell-available .negative, .budget-table-row.is-sub-category > .budget-table-cell-available .cautious, .budget-table-row.is-sub-category > .budget-table-cell-available .zero {
-        top: 0 !important;
-        padding: 0.1em 0.3em;
-    }
+.budget-table-row.is-sub-category > .budget-table-cell-available .positive, .budget-table-row.is-sub-category > .budget-table-cell-available .negative, .budget-table-row.is-sub-category > .budget-table-cell-available .cautious, .budget-table-row.is-sub-category > .budget-table-cell-available .zero {
+  top: 0 !important;
+  padding: 0.1em 0.3em;
+}
 
-    .budget-table-row.is-sub-category .budget-table-cell-activity {
-        top: 0 !important;
-    }
+.budget-table-row.is-sub-category .budget-table-cell-activity {
+  top: 0 !important;
+}
 
-    .budget-table-cell-budgeted .currency-input span {
-        height: 1.8em;
-    }
+.budget-table-cell-budgeted .currency-input span {
+  height: 1.8em;
+}
 
 .toolkit-goalindicator {
-	line-height: 1.8em !important;
+  line-height: 1.8em !important;
 }

--- a/source/common/res/features/budget-rows-height/compact.css
+++ b/source/common/res/features/budget-rows-height/compact.css
@@ -7,7 +7,7 @@
 }
 
 .budget-content ul, .budget-table-row.is-dragging {
-  height: 2em; /* !important; */
+  height: 2em;
 }
 
 .budget-table-row.is-master-category .budget-table-cell-add-category .flaticon {

--- a/source/common/res/features/budget-rows-height/slim-fonts.css
+++ b/source/common/res/features/budget-rows-height/slim-fonts.css
@@ -3,7 +3,7 @@
 }
 
 .budget-content ul, .budget-table-row.is-dragging {
-  height: 1.6em; /* !important;*/
+  height: 1.6em;
 }
 
 .budget-table-row.is-master-category {

--- a/source/common/res/features/budget-rows-height/slim-fonts.css
+++ b/source/common/res/features/budget-rows-height/slim-fonts.css
@@ -1,53 +1,53 @@
 .budget-table {
-    top: 1em !important;
+  top: 1em !important;
 }
 
 .budget-content ul, .budget-table-row.is-dragging {
-    height: 1.6em !important;
+  height: 1.6em; /* !important;*/
 }
 
 .budget-table-row.is-master-category {
-    margin-top: 0px;
+  margin-top: 0px;
 }
 
 .budget-table-row.is-master-category .budget-table-cell-name .budget-table-cell-name-row-label-item {
-    padding-top: 0.1em !important;
+  padding-top: 0.1em !important;
 }
 
 .budget-table-row.is-master-category .budget-table-cell-add-category .flaticon {
-    top: 0.2em;
+  top: 0.2em;
 }
 
 .budget-table-row.is-sub-category {
-    height: 1.6em !important;
-    font-size: 0.78em;
+  height: 1.6em !important;
+  font-size: 0.78em;
 }
 
 .budget-table-row.is-master-category .budget-table-cell-name {
-    padding-top: 0;
-    font-size: 1.05em;
+  padding-top: 0;
+  font-size: 1.05em;
 }
 
 .budget-table-row.is-sub-category > .budget-table-cell-available .positive, .budget-table-row.is-sub-category > .budget-table-cell-available .negative, .budget-table-row.is-sub-category > .budget-table-cell-available .cautious, .budget-table-row.is-sub-category > .budget-table-cell-available .zero {
-    top: 0 !important;
-    padding: 0em 0.4em;
-    font-size: 1em !important;
+  top: 0 !important;
+  padding: 0em 0.4em;
+  font-size: 1em !important;
 }
 
 .budget-table-row.is-sub-category .budget-table-cell-activity {
-    top: 0 !important;
+  top: 0 !important;
 }
 
 .budget-table-cell-budgeted .currency-input span {
-    height: 1.45em;
-    padding: 0.05em;
-    border-width: 1px !important;
+  height: 1.45em;
+  padding: 0.05em;
+  border-width: 1px !important;
 }
 
 .budget-table-cell-budgeted .currency-input input {
-    height: 1.45em !important;
+  height: 1.45em !important;
 }
 
 .toolkit-goalindicator {
-	line-height: 1.8em !important;
+  line-height: 1.8em !important;
 }

--- a/source/common/res/features/budget-rows-height/slim.css
+++ b/source/common/res/features/budget-rows-height/slim.css
@@ -1,53 +1,52 @@
 .budget-table {
-    top: 1em !important;
+  top: 1em !important;
 }
 
 .budget-content ul, .budget-table-row.is-dragging {
-    height: 1.6em !important;
+  height: 1.6em; /* !important;*/
 }
 
 .budget-table-row.is-master-category {
-    margin-top: 0px;
+  margin-top: 0px;
 }
 
 .budget-table-row.is-master-category .budget-table-cell-name .budget-table-cell-name-row-label-item {
-    padding-top: 0.1em !important;
+  padding-top: 0.1em !important;
 }
 
 .budget-table-row.is-master-category .budget-table-cell-add-category .flaticon {
-    top: 0.2em;
+  top: 0.2em;
 }
 
 .budget-table-row.is-sub-category {
-    height: 1.42em !important;
+  height: 1.42em !important;
 }
 
 .budget-table-row.is-master-category .budget-table-cell-name {
-    padding-top: 0;
-    font-size: 1.05em;
+  padding-top: 0;
+  font-size: 1.05em;
 }
 
 .budget-table-row.is-sub-category > .budget-table-cell-available .positive, .budget-table-row.is-sub-category > .budget-table-cell-available .negative, .budget-table-row.is-sub-category > .budget-table-cell-available .cautious, .budget-table-row.is-sub-category > .budget-table-cell-available .zero {
-    top: 0 !important;
-    padding: 0em 0.4em !important;
-    font-size: 1em !important;
+  top: 0 !important;
+  padding: 0em 0.4em !important;
+  font-size: 1em !important;
 }
 
 .budget-table-row.is-sub-category .budget-table-cell-activity {
-    top: 0 !important;
+  top: 0 !important;
 }
 
 .budget-table-cell-budgeted .currency-input span {
-    height: 1.45em;
-    padding: 0.05em;
-    border-width: 1px !important;
+  height: 1.45em;
+  padding: 0.05em;
+  border-width: 1px !important;
 }
 
 .budget-table-cell-budgeted .currency-input input {
-    height: 1.45em !important;
+  height: 1.45em !important;
 }
 
 .toolkit-goalindicator {
-    line-height: 1.3em !important;
+  line-height: 1.3em !important;
 }
-

--- a/source/common/res/features/budget-rows-height/slim.css
+++ b/source/common/res/features/budget-rows-height/slim.css
@@ -3,7 +3,7 @@
 }
 
 .budget-content ul, .budget-table-row.is-dragging {
-  height: 1.6em; /* !important;*/
+  height: 1.6em;
 }
 
 .budget-table-row.is-master-category {

--- a/source/common/res/features/popup-calculator/account/main.css
+++ b/source/common/res/features/popup-calculator/account/main.css
@@ -1,0 +1,25 @@
+.toolkit-popup-calc-btncol4  { 
+} 
+ 
+.toolkit-popup-calc-button1 { 
+    width: 38px; 
+    box-sizing: border-box; 
+    text-align: center; 
+    margin-bottom: .3em; 
+    margin-left: .3em; 
+    margin-top: .3em; 
+} 
+ 
+.toolkit-popup-calc-button2 { 
+    margin-bottom: .3em; 
+    margin-top: .3em; 
+    padding-bottom: .3em; 
+    padding-top: .3em; 
+} 
+ 
+.toolkit-popup-calc-btnrow  { 
+    margin-top: 0; 
+    margin-bottom: 0; 
+    padding-left: 0; 
+    padding-right: 0; 
+} 

--- a/source/common/res/features/popup-calculator/account/main.js
+++ b/source/common/res/features/popup-calculator/account/main.js
@@ -46,21 +46,16 @@
 
       return {
         $calcBtn: $('<button>', { id: 'toolkit-popup-calc-button', class: 'ember-view button button-primary' })
-                .append($('<i>', { class: 'ember-view flaticon stroke calculator' }))
-                .click(function () {
-                  ynabToolKit.popupCalculator.setButtonRight(parseFloat($('.ynab-grid-actions').position().left) * -1);
-                  ynabToolKit.popupCalculator.showCalculator(true);
-                }),
+                  .append($('<i>', { class: 'ember-view flaticon stroke calculator' }))
+                  .click(function () {
+                    ynabToolKit.popupCalculator.setButtonRight(parseFloat($('.ynab-grid-actions').position().left) * -1);
+                    ynabToolKit.popupCalculator.showCalculator(true);
+                  }),
         invoke: function invoke() {
-          // ynabToolKit.popupCalculator.accountScreen = true;
-
           if ($('div.ynab-grid-actions').length) {
             // Add the focus event high enough up the DOM to catch new input fields that are added
             // when a new split is added to a split transaction.
             $('.ynab-grid').on('focus.toolkitPopupCalc', '.is-editing input', focusHandler);
-            // head > link:nth-child(41)
-            // /html/head/link[12]
-            // <link rel="stylesheet" type="text/css" href="chrome-extension://fjhilbmiphodljkihbakkgfiedakgldb/res/features/popup-calculator/account/main.css">
             $('link[rel="stylesheet"][href$="/res/features/popup-calculator/account/main.css"]').prop('disabled', false);
             $('link[rel="stylesheet"][href$="/res/features/popup-calculator/budget/main.css"]').prop('disabled', true);
           }

--- a/source/common/res/features/popup-calculator/account/main.js
+++ b/source/common/res/features/popup-calculator/account/main.js
@@ -1,0 +1,82 @@
+(function poll() {
+  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true) {
+    ynabToolKit.accountPopupCalculator = (function () {
+      function focusHandler() {
+        if ($(this).prop('placeholder') === 'outflow' || $(this).prop('placeholder') === 'inflow') {
+          ynabToolKit.popupCalculator.setButtonBottom(-242);
+          ynabToolKit.popupCalculator.setEntryField($('#' + $(this).attr('id')));
+          ynabToolKit.popupCalculator.setInsertAfterElement('div.is-editing div.ynab-grid-actions');
+          ynabToolKit.popupCalculator.setSetValueCallback(setValue);
+          ynabToolKit.popupCalculator.setGetValueCallback(getValue);
+
+          if (!$('#toolkit-popup-calc-button').length) {
+            let $grid = '#' + $('div.ynab-grid-actions').attr('id');
+            ynabToolKit.accountPopupCalculator.$calcBtn.prependTo($($grid));
+
+            $('#toolkit-popup-calc-button').prop('disabled', false);
+            $('#toolkit-popup-calc-button').removeClass('toolkit-popup-calc-button-hide  toolkit-button-primary');
+          }
+        } else {
+          if ($('#toolkit-popup-calc-button').length) {
+            $('#toolkit-popup-calc-button').addClass('toolkit-popup-calc-button-hide');
+            $('#toolkit-popup-calc-button').prop('disabled', true);
+
+            ynabToolKit.accountPopupCalculator.$calcBtn.detach();
+          }
+        }
+      }
+
+      function setValue(field, val) {
+        let $field = field;
+
+        $field.val(val);
+        // eslint-disable-next-line new-cap
+        $field.trigger(jQuery.Event('keyup', {
+          which: 13
+        })); // YNAB will see this and think we updated the field directly
+
+        $field.focus();
+      }
+
+      function getValue(field) {
+        let $field = field;
+
+        return $field.val();
+      }
+
+      return {
+        $calcBtn: $('<button>', { id: 'toolkit-popup-calc-button', class: 'ember-view button button-primary' })
+                .append($('<i>', { class: 'ember-view flaticon stroke calculator' }))
+                .click(function () {
+                  ynabToolKit.popupCalculator.setButtonRight(parseFloat($('.ynab-grid-actions').position().left) * -1);
+                  ynabToolKit.popupCalculator.showCalculator(true);
+                }),
+        invoke: function invoke() {
+          // ynabToolKit.popupCalculator.accountScreen = true;
+
+          if ($('div.ynab-grid-actions').length) {
+            // Add the focus event high enough up the DOM to catch new input fields that are added
+            // when a new split is added to a split transaction.
+            $('.ynab-grid').on('focus.toolkitPopupCalc', '.is-editing input', focusHandler);
+            // head > link:nth-child(41)
+            // /html/head/link[12]
+            // <link rel="stylesheet" type="text/css" href="chrome-extension://fjhilbmiphodljkihbakkgfiedakgldb/res/features/popup-calculator/account/main.css">
+            $('link[rel="stylesheet"][href$="/res/features/popup-calculator/account/main.css"]').prop('disabled', false);
+            $('link[rel="stylesheet"][href$="/res/features/popup-calculator/budget/main.css"]').prop('disabled', true);
+          }
+        },
+
+        observe: function observe(changedNodes) {
+          if (changedNodes.has('accounts-toolbar-edit-transaction ember-view button') ||
+              changedNodes.has('ynab-grid-add-rows')) {
+            ynabToolKit.accountPopupCalculator.invoke();
+          }
+        }
+      };
+    }());
+
+    ynabToolKit.accountPopupCalculator.invoke();
+  } else {
+    setTimeout(poll, 250);
+  }
+}());

--- a/source/common/res/features/popup-calculator/budget/main.css
+++ b/source/common/res/features/popup-calculator/budget/main.css
@@ -1,0 +1,67 @@
+.budget-table-cell-activity { 
+  width: 17% !important; 
+} 
+ 
+.toolkit-popup-calc-button { 
+  width: 1.75% !important; 
+  overflow: visible !important; 
+} 
+ 
+.toolkit-popup-calc-overflow { 
+  overflow: visible !important; 
+} 
+ 
+.toolkit-button-primary { 
+    padding: .1em .1em; 
+    margin-right: 0em; 
+    border-radius: 0em; 
+    border: 1px solid transparent; 
+    color: #fff; 
+    /*background-color: #009cc2;*/ 
+    background-color: #005a6e; 
+    font-size: 1em; 
+} 
+ 
+.toolkit-popup-calc-btnrow  { 
+    height: 2.7em !important; 
+} 
+ 
+.toolkit-popup-calc-btncol4  { 
+    margin-right: 0em !important; 
+} 
+ 
+.toolkit-popup-calc-button1 { 
+    width: 38px; 
+    box-sizing: border-box; 
+    text-align: center; 
+    margin-bottom: .3em; 
+    margin-left: .3em; 
+    margin-top: .3em; 
+    margin-right: .2em; 
+} 
+ 
+.toolkit-popup-calc-button2 { 
+    margin-bottom: .3em; 
+    margin-top: .3em; 
+    margin-right: .3em; 
+    padding-bottom: .3em; 
+    padding-top: .3em; 
+} 
+ 
+.toolkit-calc-actions { 
+    position: absolute; 
+    background-color: #005a6e; 
+    /* background-color: #003440; dark */ 
+    border-bottom-left-radius: .4em; 
+    border-bottom-right-radius: .4em; 
+    padding: .3125em .05em .3125em .3125em; 
+    right: 0; 
+    bottom: 0; 
+    text-align: center; 
+    margin-right: .3em; 
+} 
+ 
+.toolkit-popup-calc-postition { 
+  position: relative; 
+  overflow: visible; 
+} 

--- a/source/common/res/features/popup-calculator/budget/main.js
+++ b/source/common/res/features/popup-calculator/budget/main.js
@@ -37,8 +37,6 @@
       }
 
       function clickSubCatHandler() {
-        // console.log('clickSubCatHandler::$this.id: ' + $(this).attr('id'));
-
         let subCat = '#' + $(this).attr('id');
         // If the ID for the current ID is not the same as the last ID, rearrange the class names needed to hide/show the calculator icon.
         if (subCat !== ynabToolKit.budgetPopupCalculator.lastSubCat) {
@@ -57,8 +55,6 @@
       }
 
       function clickMstrCatHandler() {
-        // console.log('clickMstrCatHandler::$this.id: ' + $(this).attr('id'));
-
         $('div.budget-table > ul > li.toolkit-popup-calc-button.toolkit-popup-calc-button-show')
           .addClass('toolkit-popup-calc-button-hide')
           .removeClass('toolkit-popup-calc-button-show');

--- a/source/common/res/features/popup-calculator/budget/main.js
+++ b/source/common/res/features/popup-calculator/budget/main.js
@@ -1,0 +1,168 @@
+(function poll() {
+  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true) {
+    ynabToolKit.budgetPopupCalculator = (function () {
+      function clickCalcHandler(event, $who) {
+        let who = $who.attr('id').substring(26);
+        let ele = '#toolkit-popup-calc-' + who;
+
+        $('#ember' + who).addClass('toolkit-popup-calc-overflow');
+
+        event.stopPropagation();
+        ynabToolKit.popupCalculator.setEntryField($who.closest('ul').find('li.budget-table-cell-budgeted > div').attr('id'));
+        ynabToolKit.popupCalculator.setPopupButton($who.attr('id'));
+        ynabToolKit.popupCalculator.setButtonRight(ynabToolKit.budgetPopupCalculator.buttonRight);
+        ynabToolKit.popupCalculator.setButtonBottom(ynabToolKit.budgetPopupCalculator.buttonBottom);
+        ynabToolKit.popupCalculator.setAppendToElement(ele);
+        ynabToolKit.popupCalculator.setSetValueCallback(setValue);
+        ynabToolKit.popupCalculator.setGetValueCallback(getValue);
+        ynabToolKit.popupCalculator.setDeleteOnDismiss(true);
+        ynabToolKit.popupCalculator.showCalculator(false);
+      }
+
+      function clickSubCatCheckBox() {
+        console.log('clickSubCatCheckBox:: checked? ' + $(this).hasClass('is-checked'));
+        if ($(this).hasClass('is-checked')) {
+          $(this) // hide the calculator button on my sibling
+            .closest('li')
+            .siblings('li.toolkit-popup-calc-button')
+            .addClass('toolkit-popup-calc-button-hide')
+            .removeClass('toolkit-popup-calc-button-show');
+        } else {
+          $(this) // show the calculator button on my sibling
+            .closest('li')
+            .siblings('li.toolkit-popup-calc-button')
+            .addClass('toolkit-popup-calc-button-show')
+            .removeClass('toolkit-popup-calc-button-hide');
+        }
+      }
+
+      function clickSubCatHandler() {
+        // console.log('clickSubCatHandler::$this.id: ' + $(this).attr('id'));
+
+        let subCat = '#' + $(this).attr('id');
+        // If the ID for the current ID is not the same as the last ID, rearrange the class names needed to hide/show the calculator icon.
+        if (subCat !== ynabToolKit.budgetPopupCalculator.lastSubCat) {
+          ynabToolKit.budgetPopupCalculator.lastSubCat = subCat;
+
+          $(this) // hide the calculator button on my siblings
+            .siblings()
+            .children('li.toolkit-popup-calc-button')
+            .addClass('toolkit-popup-calc-button-hide')
+            .removeClass('toolkit-popup-calc-button-show');
+          $(this) // show the calculator button for me
+            .children('.toolkit-popup-calc-button')
+            .addClass('toolkit-popup-calc-button-show')
+            .removeClass('toolkit-popup-calc-button-hide');
+        }
+      }
+
+      function clickMstrCatHandler() {
+        // console.log('clickMstrCatHandler::$this.id: ' + $(this).attr('id'));
+
+        $('div.budget-table > ul > li.toolkit-popup-calc-button.toolkit-popup-calc-button-show')
+          .addClass('toolkit-popup-calc-button-hide')
+          .removeClass('toolkit-popup-calc-button-show');
+
+        ynabToolKit.budgetPopupCalculator.lastSubCat = '';
+      }
+
+      function setValue(field, val) {
+        let input = $('#' + field).click().find('input');
+
+        $(input).val(val);
+
+        if (!ynabToolKit.options.warnOnQuickBudget) {
+          // only seems to work if the confirmation doesn't pop up?
+          // haven't figured out a way to properly blur otherwise
+          input.blur();
+        }
+      }
+
+      function getValue(field) {
+        let input = $('#' + field).click().find('input');
+        let val = $(input).val();
+
+        if (!ynabToolKit.options.warnOnQuickBudget) {
+          // only seems to work if the confirmation doesn't pop up?
+          // haven't figured out a way to properly blur otherwise
+          input.blur();
+        }
+
+        return val;
+      }
+
+      return {
+        lastSubCat: '',
+        $mstCatLI: $('<li>', { class: 'toolkit-popup-calc-mstcat-col', style: 'width: 1.75% !important' }),
+        buttonBottom: -247,
+        buttonRight: 22,
+        invoke: function invoke() {
+          if (!$('.budget-table-header > li.budget-table-cell-calc').length) {
+            $('.budget-table-header .budget-table-cell-budgeted').after('<li class="budget-table-cell-calc" style="width: 1.75% !important">&nbsp;</li>');
+          }
+
+          if ($('div.budget-table').length && !$('.budget-table-row > li.toolkit-popup-calc-button').length) {
+            $('link[rel="stylesheet"][href$="/res/features/popup-calculator/budget/main.css"]').prop('disabled', false);
+            $('link[rel="stylesheet"][href$="/res/features/popup-calculator/account/main.css"]').prop('disabled', true);
+
+            $('div.budget-table').on('click.toolkitPopupCalcSubCatChk', '.budget-table-row.is-sub-category > li > div > button.ynab-checkbox-button', clickSubCatCheckBox);
+            $('div.budget-table').on('click.toolkitPopupCalcSubCat', 'ul.budget-table-row.is-sub-category', clickSubCatHandler);
+            $('div.budget-table').on('click.toolkitPopupCalcMstCat', '.budget-table-row.is-master-category', clickMstrCatHandler);
+            $('div.budget-header').on('click.toolkitPopupCalcGblCat', 'li > div.ynab-checkbox', clickMstrCatHandler);
+
+            ynabToolKit.budgetPopupCalculator.$mstCatLI.insertAfter($('.budget-table-row.is-master-category > li.budget-table-cell-budgeted'));
+            ynabToolKit.budgetPopupCalculator.$mstCatLI.insertAfter($('.budget-table-row.budget-table-uncategorized-transactions > li.budget-table-cell-budgeted'));
+
+            $('.budget-table-row').each(function () {
+              if ($(this).hasClass('is-master-category') || $(this).hasClass('budget-table-uncategorized-transactions')) {
+                return;
+              }
+
+              let id = $(this).attr('id').substring(5); // The elements we add below will use the numeric portion of the ember generated id.
+
+              $('#' + $(this).attr('id') + ' > li.budget-table-cell-budgeted')
+                .after($('<li>', { class: 'toolkit-popup-calc-button toolkit-popup-calc-button-hide' })
+                  .append($('<button>', { id: 'toolkit-popup-calc-button-' + id, class: 'ember-view button button-primary toolkit-button-primary' })
+                    .append($('<i>', { class: 'ember-view flaticon stroke calculator' }))
+                      .click(function (event) {
+                        clickCalcHandler(event, $(this));
+                      }))
+                  .append($('<div>', { id: 'toolkit-popup-calc-' + id, class: 'toolkit-popup-calc-postition' })));
+            });
+
+            switch (ynabToolKit.options.budgetRowsHeight) {
+              case '0':
+                ynabToolKit.budgetPopupCalculator.buttonBottom = -247;
+                ynabToolKit.budgetPopupCalculator.buttonRight = 20;
+                break;
+              case '1':
+                ynabToolKit.budgetPopupCalculator.buttonBottom = -244;
+                ynabToolKit.budgetPopupCalculator.buttonRight = 18;
+                break;
+              case '2':
+                ynabToolKit.budgetPopupCalculator.buttonBottom = -242;
+                ynabToolKit.budgetPopupCalculator.buttonRight = 16;
+                break;
+              case '3':
+                ynabToolKit.budgetPopupCalculator.buttonBottom = -217;
+                ynabToolKit.budgetPopupCalculator.buttonRight = 16;
+                break;
+            }
+          }
+        },
+
+        observe: function observe(changedNodes) {
+          if (changedNodes.has('budget-content  resizable') ||
+              changedNodes.has('budget-table-header') ||
+              changedNodes.has('inspector-quick-budget')) {
+            ynabToolKit.budgetPopupCalculator.invoke();
+          }
+        }
+      };
+    }());
+
+    ynabToolKit.budgetPopupCalculator.invoke();
+  } else {
+    setTimeout(poll, 250);
+  }
+}());

--- a/source/common/res/features/popup-calculator/main.css
+++ b/source/common/res/features/popup-calculator/main.css
@@ -6,6 +6,10 @@
     visibility: hidden;
 }
 
+.toolkit-popup-calc-show {
+    visibility: visible;
+}
+
 .toolkit-popup-calc-hide {
     visibility: hidden;
 }
@@ -14,27 +18,16 @@
     display: inline-block;
 }
 
-.toolkit-popup-calc-button1 {
-    width: 38px;
-    box-sizing: border-box;
-    text-align: center;
-    margin-bottom: .3em;
-    margin-left: .3em;
-    margin-top: .3em;
+.toolkit-popup-calc-div-inline-flex > li {
+    display: -webkit-inline-flex; /* Safari */
+    display: inline-flex;
 }
-
-.toolkit-popup-calc-button2 {
-    margin-bottom: .3em;
-    margin-top: .3em;
-    padding-bottom: .3em;
-    padding-top: .3em;
-}
-
-.toolkit-popup-calc-btnrow  {
-    margin-top: 0;
-    margin-bottom: 0;
-    padding-left: 0;
-    padding-right: 0;
+.toolkit-button-primary {
+    padding: .3em .6em;
+    border-radius: .4em;
+    border: 2px solid transparent;
+    color: #fff;
+    background-color: #009cc2;
 }
 
 #toolkitPopupCalcInput  {
@@ -42,4 +35,13 @@
     margin-bottom: .3em;
     width: 176px;
 		text-align: right;
+}
+
+.xtoolkit-button-primary {
+    padding: .1em .1em;
+    /*margin-right: .4em;*/
+    border-radius: .1em;
+    border: 1px solid transparent;
+    color: #fff;
+    background-color: #009cc2;
 }

--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -13,6 +13,10 @@
       let calcValue = 0;
       let setValueCallback = '';
       let getValueCallback = '';
+      let decimalDigits = ynab.YNABSharedLib.currencyFormatter.getCurrency().decimal_digits;
+      let decimalSeparator = ynab.YNABSharedLib.currencyFormatter.getCurrency().decimal_separator;
+      // let groupSeparator = ynab.YNABSharedLib.currencyFormatter.getCurrency().group_separator; // needed?
+      let separatorCode = decimalSeparator.charCodeAt(0);
 
       return {
         setDeleteOnDismiss(val) {
@@ -80,7 +84,7 @@
           // origValue = ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat(getValueCallback($field));
 
           if (origValue === '') {
-            origValue = '0.00';
+            origValue = '0' + decimalSeparator + '0'.repeat(decimalDigits);
           }
 
           popupCalc.value(origValue);
@@ -238,19 +242,16 @@
           }
 
           $(document).on('keyup.toolkitPopupCalc', (e) => {
-            console.log('e.which: ' + e.which + ', is symbol: ' + e.which.toString().includes('+,-./'));
             if (e.which === 27) { // ESC key?
               dismissCalculator();
-            } else if ((e.which > 45 && e.which < 58) ||   // keyboard
-                       (e.which > 95 && e.which < 112) ||  // numpad
-                       (e.which > 186 && e.which < 192) || // keyboard symbols + , - . /
-                        e.which === 8 ||                   // backspace
-                        e.which === 13) {                  // numpad enter
-                        // e.which === 187 || // keyboard plus (shift key plus equal key)
-                        // e.which === 188 || // keyboard comma
-                        // e.which === 189 || // keyboard minus
-                        // e.which === 190 || // keyboard period (decimal point)
-                        // e.which === 191) { // keyboard forward slash (divide)
+            } else if ((e.which > 45 && e.which < 58) ||  // keyboard
+                       (e.which > 95 && e.which < 112) || // numpad
+                        e.which === separatorCode ||      // keyboard period (190) or comma (188) or ???
+                        e.which === 187 ||                // keyboard plus (shift key plus equal key)
+                        e.which === 189 ||                // keyboard minus
+                        e.which === 191 ||                // keyboard forward slash (divide)
+                        e.which === 8 ||                  // backspace
+                        e.which === 13) {                 // numpad enter
               doCalculation(e.key);
 
               if (e.which === 13 || e.which === 18) { // Enter key?
@@ -302,7 +303,7 @@
               result = '';
             }
 
-            if (value2.toString().includes('.') && key === '.') {
+            if (value2.toString().includes(decimalSeparator) && key === decimalSeparator) {
               key = '';
             }
 
@@ -315,6 +316,10 @@
               reveal = false;
               format = false;
             } else {
+              if (decimalSeparator !== '.') {
+                value2 = ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat(value2);
+              }
+
               switch (oper) {
                 case '+' :
                   result = parseFloat(value1) + parseFloat(value2);
@@ -385,7 +390,9 @@
             return format;
           },
           backspace: function () {
-            value1 = value1.slice(0, value1.length - 1);
+            if (value1.length > 0) {
+              value1 = value1.slice(0, value1.length - 1);
+            }
             value2 = '';
             result = '';
             format = false;

--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -3,204 +3,287 @@
     ynabToolKit.popupCalculator = (function () {
       let popupCalc = new Calculator();
       let $field = '';
+      let btnRight = 0;
+      let btnBottom = -242;
+      let afterElement = '';
+      let appendElement = '';
+      let deleteOnDismiss = false;
+      let origValue = '';
+      let popupButton = 'toolkit-popup-calc-button';
+      let calcValue = 0;
+      let setValueCallback = '';
+      let getValueCallback = '';
 
-      function showCalculator() {
-        $('#toolkit-popup-calc-button').prop('disabled', true);
+      return {
+        setDeleteOnDismiss(val) {
+          deleteOnDismiss = val;
 
-        popupCalc.reset();
+          return;
+        },
 
-        $field = ynabToolKit.popupCalculator.$field;
+        setInsertAfterElement(val) {
+          afterElement = val;
+          appendElement = '';
 
-        let calcValue = $field.val();
+          return;
+        },
 
-        if (calcValue === '') {
-          calcValue = '0.00';
-        }
+        setAppendToElement(val) {
+          appendElement = val;
+          afterElement = '';
 
-        popupCalc.value(calcValue);
+          return;
+        },
 
-        if ($('#toolkitPopupCalc').length) {
-          $('#toolkitPopupCalcInput').val(calcValue);
-          $('#toolkitPopupCalc').removeClass('toolkit-popup-calc-hide');
-          $('#toolkit-popup-calc-button').addClass('toolkit-popup-calc-button-hide');
-        } else {
-          let btnRight = parseFloat($('.ynab-grid-actions').position().left) * -1;
+        setButtonRight(val) {
+          btnRight = val;
 
-          $('<div>', { id: 'toolkitPopupCalc', class: 'ember-view ynab-grid-actions', style: 'right: ' + btnRight + 'px; bottom: -242px;' })
-            .append($('<input>', { id: 'toolkitPopupCalcInput', readonly: 'readonly', class: 'ember-view ember-text-field' })
-              .val(calcValue))
-            .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtnC', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('C')
-                .click(() => {
-                  doCalculation('C');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtnN', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('+/-')
-                .click(() => {
-                  doCalculation('N');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtnB', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('<-')
-                .click(() => {
-                  doCalculation('Delete');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtnD', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('/')
-                .click(() => {
-                  doCalculation('/');
-                }))))
-            .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn7', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('7')
-                .click(() => {
-                  doCalculation('7');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn8', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('8')
-                .click(() => {
-                  doCalculation('8');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn9', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('9')
-                .click(() => {
-                  doCalculation('9');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtnM', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('X')
-                .click(() => {
-                  doCalculation('*');
-                }))))
-            .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn4', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('4')
-                .click(() => {
-                  doCalculation('4');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn5', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('5')
-                .click(() => {
-                  doCalculation('5');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn6', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('6')
-                .click(() => {
-                  doCalculation('6');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtnS', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('-')
-                .click(() => {
-                  doCalculation('-');
-                }))))
-            .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn1', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('1')
-                .click(() => {
-                  doCalculation('1');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn2', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('2')
-                .click(() => {
-                  doCalculation('2');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn3', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('3')
-                .click(() => {
-                  doCalculation('3');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtnA', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('+')
-                .click(() => {
-                  doCalculation('+');
-                }))))
-            .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn0', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('0')
-                .click(() => {
-                  doCalculation('0');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtnP', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('.')
-                .click(() => {
-                  doCalculation('.');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtnE', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('=')
-                .click(() => {
-                  doCalculation('=');
-                })))
-              .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
-                .append($('<button>', { id: 'toolkitBtn%', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
-                .append('%')
-                .click(() => {
-                  doCalculation('%');
-                }))))
-            .append($('<button>', { id: 'toolkitBtnOk', class: 'ember-view button button-primary toolkit-popup-calc-button2' })
-              .append('OK')
-              .click(() => {
-                doCalculation('OK');
-                dismissCalculator();
-              }))
-            .append($('<button>', { id: 'toolkitBtnCan', class: 'ember-view button button-primary toolkit-popup-calc-button2' })
-              .append('Cancel')
-              .click(() => {
-                dismissCalculator();
-              }))
-            .insertAfter('div.is-editing div.ynab-grid-actions');
-        }
+          return;
+        },
 
-        $(document).on('keyup.toolkitPopupCalc', (e) => {
-          if (e.which === 27) { // ESC key?
-            dismissCalculator();
-          } else if ((e.which > 45 && e.which < 58) || // keyboard
-                     (e.which > 95 && e.which < 112) || // numpad
-                      e.which === 8 ||  // backspace
-                      e.which === 13 || // numpad enter
-                      e.which === 187) { // keyboard enter
-            doCalculation(e.key);
+        setButtonBottom(val) {
+          btnBottom = val;
 
-            if (e.which === 13 || e.which === 18) { // Enter key?
-              dismissCalculator();
+          return;
+        },
+
+        setPopupButton(val) {
+          popupButton = val;
+
+          return;
+        },
+
+        setEntryField(val) {
+          $field = val;
+
+          return;
+        },
+
+        getEntryField() {
+          return $field;
+        },
+
+        setSetValueCallback(callback) {
+          setValueCallback = callback;
+        },
+
+        setGetValueCallback(callback) {
+          getValueCallback = callback;
+        },
+
+        showCalculator(budgetScreen) {
+          $('#' + popupButton).prop('disabled', true);
+
+          popupCalc.reset();
+
+          origValue = getValueCallback($field);
+          // origValue = ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat(getValueCallback($field));
+
+          if (origValue === '') {
+            origValue = '0.00';
+          }
+
+          popupCalc.value(origValue);
+
+          if ($('#toolkitPopupCalc').length) {
+            $('#toolkitPopupCalcInput').val(origValue);
+            $('#toolkitPopupCalc').removeClass('toolkit-popup-calc-hide');
+          } else {
+            let actionsClass = (budgetScreen) ? 'ynab-grid-actions' : 'toolkit-calc-actions';
+            let $calc = $('<div>', { id: 'toolkitPopupCalc', class: 'ember-view ' + actionsClass, style: 'right: ' + btnRight + 'px; bottom: ' + btnBottom + 'px;' })
+              .append($('<input>', { id: 'toolkitPopupCalcInput', readonly: 'readonly', class: 'ember-view ember-text-field' })
+                .val(origValue))
+              .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtnC', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('C')
+                  .click(() => {
+                    doCalculation('C');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtnN', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('+/-')
+                  .click(() => {
+                    doCalculation('N');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtnB', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('<-')
+                  .click(() => {
+                    doCalculation('Delete');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtnD', class: 'ember-view button button-primary toolkit-popup-calc-button1 toolkit-popup-calc-btncol4' })
+                  .append('/')
+                  .click(() => {
+                    doCalculation('/');
+                  }))))
+              .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn7', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('7')
+                  .click(() => {
+                    doCalculation('7');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn8', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('8')
+                  .click(() => {
+                    doCalculation('8');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn9', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('9')
+                  .click(() => {
+                    doCalculation('9');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtnM', class: 'ember-view button button-primary toolkit-popup-calc-button1 toolkit-popup-calc-btncol4' })
+                  .append('X')
+                  .click(() => {
+                    doCalculation('*');
+                  }))))
+              .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn4', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('4')
+                  .click(() => {
+                    doCalculation('4');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn5', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('5')
+                  .click(() => {
+                    doCalculation('5');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn6', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('6')
+                  .click(() => {
+                    doCalculation('6');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtnS', class: 'ember-view button button-primary toolkit-popup-calc-button1 toolkit-popup-calc-btncol4' })
+                  .append('-')
+                  .click(() => {
+                    doCalculation('-');
+                  }))))
+              .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn1', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('1')
+                  .click(() => {
+                    doCalculation('1');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn2', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('2')
+                  .click(() => {
+                    doCalculation('2');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn3', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('3')
+                  .click(() => {
+                    doCalculation('3');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtnA', class: 'ember-view button button-primary toolkit-popup-calc-button1 toolkit-popup-calc-btncol4' })
+                  .append('+')
+                  .click(() => {
+                    doCalculation('+');
+                  }))))
+              .append($('<ul>', { class: 'toolkit-popup-calc-btnrow' })
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn0', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('0')
+                  .click(() => {
+                    doCalculation('0');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtnP', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('.')
+                  .click(() => {
+                    doCalculation('.');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtnE', class: 'ember-view button button-primary toolkit-popup-calc-button1' })
+                  .append('=')
+                  .click(() => {
+                    doCalculation('=');
+                  })))
+                .append($('<li>', { class: 'toolkit-popup-calc-btnrow' })
+                  .append($('<button>', { id: 'toolkitBtn%', class: 'ember-view button button-primary toolkit-popup-calc-button1 toolkit-popup-calc-btncol4' })
+                  .append('%')
+                  .click(() => {
+                    doCalculation('%');
+                  }))))
+              .append($('<button>', { id: 'toolkitBtnOk', class: 'ember-view button button-primary toolkit-popup-calc-button2' })
+                .append('OK')
+                .click(() => {
+                  doCalculation('OK');
+                  dismissCalculator();
+                }))
+              .append($('<button>', { id: 'toolkitBtnCan', class: 'ember-view button button-primary toolkit-popup-calc-button2' })
+                .append('Cancel')
+                .click(() => {
+                  dismissCalculator();
+                }));
+
+            if (afterElement !== '') {
+              $calc.insertAfter(afterElement);
+            } else {
+              $calc.appendTo(appendElement);
             }
           }
-        });
 
-        // Handle mouse clicks outside the drop-down modal. Namespace the
-        // click event so we can remove our specific instance.
-        $(document).on('click.toolkitPopupCalc', (e) => {
-          if (e.target.id !== 'toolkitPopupCalc') {
-            dismissCalculator();
+          $(document).on('keyup.toolkitPopupCalc', (e) => {
+            console.log('e.which: ' + e.which + ', is symbol: ' + e.which.toString().includes('+,-./'));
+            if (e.which === 27) { // ESC key?
+              dismissCalculator();
+            } else if ((e.which > 45 && e.which < 58) ||   // keyboard
+                       (e.which > 95 && e.which < 112) ||  // numpad
+                       (e.which > 186 && e.which < 192) || // keyboard symbols + , - . /
+                        e.which === 8 ||                   // backspace
+                        e.which === 13) {                  // numpad enter
+                        // e.which === 187 || // keyboard plus (shift key plus equal key)
+                        // e.which === 188 || // keyboard comma
+                        // e.which === 189 || // keyboard minus
+                        // e.which === 190 || // keyboard period (decimal point)
+                        // e.which === 191) { // keyboard forward slash (divide)
+              doCalculation(e.key);
+
+              if (e.which === 13 || e.which === 18) { // Enter key?
+                dismissCalculator();
+              }
+            }
+          });
+
+          // Handle mouse clicks outside the drop-down modal. Namespace the
+          // click event so we can remove our specific instance.
+          $(document).on('click.toolkitPopupCalc', (e) => {
+            if (e.target.id !== 'toolkitPopupCalc') {
+              dismissCalculator();
+            }
+          });
+
+          function dismissCalculator() {
+            if (deleteOnDismiss) {
+              $('#toolkitPopupCalc').remove();
+            } else {
+              $('#toolkitPopupCalc').addClass('toolkit-popup-calc-hide');
+            }
+
+            $('#' + popupButton).removeClass('toolkit-popup-calc-button-hide');
+            $('#' + popupButton).prop('disabled', false);
+
+            $(document).off('click.toolkitPopupCalc');
+            $(document).off('keyup.toolkitPopupCalc');
+
+            calcValue = '';
           }
-        });
-
-        function dismissCalculator() {
-          $('#toolkitPopupCalc').addClass('toolkit-popup-calc-hide');
-          $('#toolkit-popup-calc-button').removeClass('toolkit-popup-calc-button-hide');
-          $('#toolkit-popup-calc-button').prop('disabled', false);
-
-          $(document).off('click.toolkitPopupCalc');
-          $(document).off('keyup.toolkitPopupCalc');
         }
-      }
+      };
 
       function Calculator() {
         let oper = '';
@@ -217,6 +300,10 @@
 
             if (result === '0' || result === ynab.YNABSharedLib.currencyFormatter.format(ynab.YNABSharedLib.currencyFormatter.convertToMilliDollars(result))) {
               result = '';
+            }
+
+            if (value2.toString().includes('.') && key === '.') {
+              key = '';
             }
 
             result = value2 + key + ''; // ensure concatenation
@@ -288,8 +375,8 @@
             }
           },
           value: function (key) {
-            value1 = key;
-            result = key;
+            value1 = ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat(key);
+            result = value1;
           },
           display: function () {
             return reveal;
@@ -310,25 +397,18 @@
             result = '';
             value1 = '';
             value2 = '';
+            calcValue = '';
           }
         };
       }
 
       function doCalculation(calcVerb) {
-        let calcValue;
-
         switch (calcVerb) {
           case 'Enter' : // keypad <enter>
           case 'OK' :    // button OK
             calcValue = popupCalc.eval();
-            $field.val(ynab.YNABSharedLib.currencyFormatter.format(ynab.YNABSharedLib.currencyFormatter.convertToMilliDollars(calcValue)));
-            // eslint-disable-next-line new-cap
-            $field.trigger(jQuery.Event('keyup', {
-              which: 13
-            })); // YNAB will see this and think the updated the field directly
 
-            $field.focus();
-
+            setValueCallback($field, ynab.YNABSharedLib.currencyFormatter.format(ynab.YNABSharedLib.currencyFormatter.convertToMilliDollars(calcValue)));
             break;
           case 'Delete' :    // button <-
           case 'Backspace' : // keyboard <-
@@ -367,57 +447,10 @@
             $('#toolkitPopupCalcInput').val(calcValue);
           }
         }
+
+        event.stopPropagation();
       }
-
-      function focusHandler() {
-        if ($(this).prop('placeholder') === 'outflow' || $(this).prop('placeholder') === 'inflow') {
-          ynabToolKit.popupCalculator.$field = $('#' + $(this).attr('id'));
-
-          if (!$('#toolkit-popup-calc-button').length) {
-            let $grid = '#' + $('div.ynab-grid-actions').attr('id');
-            ynabToolKit.popupCalculator.$calcBtn.prependTo($($grid));
-
-            $('#toolkit-popup-calc-button').prop('disabled', false);
-            $('#toolkit-popup-calc-button').removeClass('toolkit-popup-calc-button-hide');
-          }
-        } else {
-          if ($('#toolkit-popup-calc-button').length) {
-            $('#toolkit-popup-calc-button').addClass('toolkit-popup-calc-button-hide');
-            $('#toolkit-popup-calc-button').prop('disabled', true);
-
-            ynabToolKit.popupCalculator.$calcBtn.detach();
-          }
-        }
-      }
-
-      return {
-        $field: '',
-        $calcBtn: $('<button>', { id: 'toolkit-popup-calc-button', class: 'ember-view button button-primary' })
-                .append($('<i>', { class: 'ember-view flaticon stroke calculator' }))
-                .click(function () {
-                  showCalculator();
-                }),
-        invoke: function invoke() {
-          if ($('div.ynab-grid-actions').length) {
-            // Add the focus event high enough up the DOM to catch new input fields that are added
-            // when a new split is added to a split transaction.
-            $('.ynab-grid').on('focus.toolkitPopupCalc', '.is-editing input', focusHandler);
-          }
-        },
-
-        observe: function observe(changedNodes) {
-          if (changedNodes.has('accounts-toolbar-edit-transaction ember-view button') ||
-              changedNodes.has('ynab-grid-add-rows')) {
-            ynabToolKit.popupCalculator.invoke();
-          }
-        }
-      };
     }());
-
-    let router = ynabToolKit.shared.containerLookup('router:main');
-    if (router.get('currentPath').indexOf('accounts') > -1) {
-      ynabToolKit.popupCalculator.invoke();
-    }
   } else {
     setTimeout(poll, 250);
   }

--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -81,7 +81,6 @@
           popupCalc.reset();
 
           origValue = getValueCallback($field);
-          // origValue = ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat(getValueCallback($field));
 
           if (origValue === '') {
             origValue = '0' + decimalSeparator + '0'.repeat(decimalDigits);

--- a/source/common/res/features/popup-calculator/settings.json
+++ b/source/common/res/features/popup-calculator/settings.json
@@ -2,9 +2,9 @@
          "name": "popupCalculator",
          "type": "checkbox",
       "default": false,
-      "section": "accounts",
+      "section": "general",
         "title": "Add popup calculator to account and budget screens",
-  "description": "Account screen: when adding or editing a transaction a button will be added to the left of the 'Save and add another' or 'Save' button that when clicked will display a full calculator.\nBudget screen: Adds a button when editing a value in the BUDGETED column",
+  "description": "<b>Account screen:</b> when adding or editing a transaction a button will be added to the left of the 'Save and add another' or 'Save' button that when clicked will display a full calculator.<br /><b>Budget screen:</b> Adds a button to the right of the BUDGETED column when the sub-category is selected.",
       "actions": {
                     "true": [
                       "injectCSS", "main.css",

--- a/source/common/res/features/popup-calculator/settings.json
+++ b/source/common/res/features/popup-calculator/settings.json
@@ -3,12 +3,16 @@
          "type": "checkbox",
       "default": false,
       "section": "accounts",
-        "title": "Add a popup calculator",
-  "description": "When adding or editing a transaction a button will be added to the left of the 'Save and add another' or 'Save' button that when clicked will display a full calculator.",
+        "title": "Add popup calculator to account and budget screens",
+  "description": "Account screen: when adding or editing a transaction a button will be added to the left of the 'Save and add another' or 'Save' button that when clicked will display a full calculator.\nBudget screen: Adds a button when editing a value in the BUDGETED column",
       "actions": {
                     "true": [
                       "injectCSS", "main.css",
-                      "injectScript", "main.js"
+                      "injectScript", "main.js",
+                      "injectScript", "account/main.js",
+                      "injectCSS", "account/main.css",
+                      "injectCSS", "budget/main.css",
+                      "injectScript", "budget/main.js"
                     ]
                  }
 }


### PR DESCRIPTION
Github Issue (if applicable): #638, #660 - fixed these issues while I was updating the code.

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Pop-up calculator will now work on the budget screen for the BUDGETED column of a sub-category.

Note! I added some html tags to the option description that will require approval and merging of a separate pull request that updates options.js. Without that PR, the description for this option will look quite odd.


#### Recommended Release Notes:
Moved feature to the General section of the Options page. Pop-up calculator will now work on the budget screen for the BUDGETED column of a sub-category. 