### PR TITLE
Override the YNAB width of the left toolbar div

### DIFF
--- a/source/common/res/features/toggle-splits/main.css
+++ b/source/common/res/features/toggle-splits/main.css
@@ -1,3 +1,7 @@
 .split-transaction {
   font-weight: bold;
 }
+
+.toolkit-accounts-toolbar-left {
+    width: 50% !important;
+}

--- a/source/common/res/features/toggle-splits/main.js
+++ b/source/common/res/features/toggle-splits/main.js
@@ -46,6 +46,8 @@
               .append(' ' + buttonText)
               .insertAfter('.accounts-toolbar .undo-redo-container');
 
+            $('.accounts-toolbar-left').addClass('toolkit-accounts-toolbar-left');
+
             $('.accounts-toolbar-left').find('#toggle-splits').click(function () {
               if (ynabToolKit.toggleSplits.setting === 'hide') {
                 showSubTransactions();


### PR DESCRIPTION
Changed the left toolbar div width to be 50% which gives enough room for the toggle splits button.

Github Issue (if applicable): #646 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Updated the left toolbar width to allow room for the toggle splits button to be displayed.


#### Recommended Release Notes:
Updated the left toolbar width to allow room for the toggle splits button to be displayed.