### PR TITLE
Add .currency to pacing column values

### DIFF
--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -143,8 +143,8 @@
                 }
 
                 $(this).append('<li class="budget-table-cell-available budget-table-cell-pacing"><span title="' + tooltip +
-                               '" class="budget-table-cell-pacing-display ' + temperature + ' ' +
-                               (deemphasized ? 'deemphasized' : '') + (showIndicator ? ' indicator' : '') +
+                               '" class="budget-table-cell-pacing-display currency ' + temperature +
+                               (deemphasized ? ' deemphasized' : '') + (showIndicator ? ' indicator' : '') +
                                '" data-name="' + masterCategoryDisplayName + '_' + subCategoryDisplayName + '">' +
                                ynabToolKit.shared.formatCurrency(display, true) + '</span></li>');
               });


### PR DESCRIPTION
Adding `.currency` allows the Privacy Mode filter to blur the values. This resolves #666.

Also adjusted the whitespace in the class string to prevent redundant whitespace.

Github Issue (if applicable): #666 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:

Allow Privacy Mode to blur Pacing column values

#### Recommended Release Notes:

Bug fix