### PR TITLE
Fix fluid size for collapsable side menu

### DIFF
--- a/source/common/res/features/collapse-side-menu/main.css
+++ b/source/common/res/features/collapse-side-menu/main.css
@@ -3,6 +3,11 @@
 	left: 40px;
 }
 
+.layout.collapsed .content .scroll-wrap {
+	width: inherit;
+	min-width: 838px;
+}
+
 .collapsed-buttons .active button {
 	background-color: #194853;
 	color: #fff;


### PR DESCRIPTION
The collapsable side menu allows you to save some space, but unfortunately there's a media query for `max-width: 1100px` where there's a `width: 838px;`. This results in a size of 838 pixels, even if there's space for 1100. 

This fixes the by setting it, the scroll wrap, as a `min-width` instead, allowing for a fluid resize of the layout when it's between 838 and 1100 pixels wide, while overriding the width to be inherited.

#### Recommended Release Notes:
* Fixes fixed width with collapsed side menu for certain narrow view