### PR TITLE
Budget to zero button not showing in the Budget Inspector

### DIFF
--- a/source/common/res/features/budget-balance-to-zero/main.js
+++ b/source/common/res/features/budget-balance-to-zero/main.js
@@ -27,7 +27,7 @@
           }
 
           // After using Budget Quick Switch, budgetView needs to be reset to the new budget.
-          if (ynabToolKit.budgetBalanceToZero.budgetView.categoriesViewModel === null) {
+          if (ynabToolKit.budgetBalanceToZero.budgetView === null) {
             ynabToolKit.budgetBalanceToZero.budgetView = ynab.YNABSharedLib.
               getBudgetViewModel_AllBudgetMonthsViewModel()._result;
           }


### PR DESCRIPTION
The code change for Issue #237 was comparing one field too many. Said field was null resulting in "throwing" back to the "catch" in feedChanges.js. Removed the extra field in the compare.

Github Issue (if applicable): #665 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Previous fix was bad preventing the button from showing in the inspector.


#### Recommended Release Notes:
