### PR TITLE
Fix bug in Stealing From Next Feature 

### DIFF
--- a/source/common/res/features/stealing-from-next-month/main.js
+++ b/source/common/res/features/stealing-from-next-month/main.js
@@ -24,10 +24,12 @@
         invoke() {
           let budgetController = ynabToolKit.shared.containerLookup('controller:budget');
           let budgetViewModel = budgetController.get('budgetViewModel');
-          let nextMonth = budgetViewModel.get('monthlyBudgetCalculationForNextMonth');
+          if (budgetViewModel) {
+            let nextMonth = budgetViewModel.get('monthlyBudgetCalculationForNextMonth');
 
-          nextMonth.addObserver('availableToBudget', onNextMonthCalculationChanged);
-          onNextMonthCalculationChanged.call(nextMonth);
+            nextMonth.addObserver('availableToBudget', onNextMonthCalculationChanged);
+            onNextMonthCalculationChanged.call(nextMonth);
+          }
         },
 
         onRouteChanged(currentRoute) {


### PR DESCRIPTION
Add a truthy check of return value from budgetController() to fix null/undefined exception.

Github Issue (if applicable): #653 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
feature throws error when budget controller doesn't exist (like on non-budget pages).


#### Recommended Release Notes:
