### PR TITLE
Changes related to switching budgets and uncategorized transactions.

### DIFF
--- a/source/common/res/features/budget-category-info/main.js
+++ b/source/common/res/features/budget-category-info/main.js
@@ -66,7 +66,7 @@
 
       return {
         invoke() {
-          var categories = $('.budget-table ul');
+          var categories = $('.budget-table ul').not('.budget-table-uncategorized-transactions');
           var masterCategoryName = '';
 
           if (subCats === null || subCats.length === 0 || loadCategories) {
@@ -92,11 +92,6 @@
             if ($(this).hasClass('is-sub-category')) {
               var subCategoryName = $(this).find('li.budget-table-cell-name>div>div')[0].title.match(/.[^\n]*/);
               var classes = [];
-
-              // skip uncategorized
-              if (subCategoryName === 'Uncategorized Transactions') {
-                return;
-              }
 
               // add budgeted
               var budgeted = $(this).find('.budget-table-cell-budgeted .currency').text();

--- a/source/common/res/features/budget-progress-bars/main.js
+++ b/source/common/res/features/budget-progress-bars/main.js
@@ -55,49 +55,47 @@
       }
 
       function addGoalProgress(subCategoryName, target) {
-        if (subCategoryName !== 'Uncategorized Transactions') {
-          var calculation = getCalculation(subCategoryName);
+        var calculation = getCalculation(subCategoryName);
 
-          var status = 0;
-          var hasGoal = false;
+        var status = 0;
+        var hasGoal = false;
 
-          switch (calculation.goalType) {
-            case 'TB' :
-            case 'TBD' :
-              hasGoal = true;
+        switch (calculation.goalType) {
+          case 'TB' :
+          case 'TBD' :
+            hasGoal = true;
 
-              if (calculation.balance >= calculation.targetBalance) {
-                status = 100;
-              } else {
-                status = calculation.balance / (calculation.balance + calculation.goalOverallLeft);
-              }
+            if (calculation.balance >= calculation.targetBalance) {
+              status = 100;
+            } else {
+              status = calculation.balance / (calculation.balance + calculation.goalOverallLeft);
+            }
 
-              break;
-            case 'MF' :
-              hasGoal = true;
+            break;
+          case 'MF' :
+            hasGoal = true;
 
-              if (calculation.balance >= calculation.goalTarget) {
-                status = 100;
-              } else {
-                status = 1 - calculation.goalUnderFunded / calculation.goalTarget;
-              }
+            if (calculation.balance >= calculation.goalTarget) {
+              status = 100;
+            } else {
+              status = 1 - calculation.goalUnderFunded / calculation.goalTarget;
+            }
 
-              break;
-            default:
-              if (calculation.upcomingTransactions < 0) {
-                // hasGoal = true;
-                // status = 0 - calculation.balance / calculation.upcomingTransactions;
-              }
-          }
+            break;
+          default:
+            if (calculation.upcomingTransactions < 0) {
+              // hasGoal = true;
+              // status = 0 - calculation.balance / calculation.upcomingTransactions;
+            }
+        }
 
-          if (hasGoal) {
-            status = status > 1 ? 1 : status;
-            status = status < 0 ? 0 : status;
-            var percent = Math.round(parseFloat(status) * 100);
-            target.style.background = 'linear-gradient(to right, rgba(22, 163, 54, 0.3) ' + percent + '%, white ' + percent + '%)';
-          } else {
-            target.style.removeProperty('linear-gradient'); // only remove the style property we added!
-          }
+        if (hasGoal) {
+          status = status > 1 ? 1 : status;
+          status = status < 0 ? 0 : status;
+          var percent = Math.round(parseFloat(status) * 100);
+          target.style.background = 'linear-gradient(to right, rgba(22, 163, 54, 0.3) ' + percent + '%, white ' + percent + '%)';
+        } else {
+          target.style.removeProperty('linear-gradient'); // only remove the style property we added!
         }
       }
 
@@ -110,7 +108,7 @@
       function addPacingProgress(subCategoryName, target) {
         var deEmphasizedCategories = JSON.parse(localStorage.getItem('ynab_toolkit_pacing_deemphasized_categories')) || [];
 
-        if (subCategoryName !== 'Uncategorized Transactions' && deEmphasizedCategories.indexOf(subCategoryName) === -1) {
+        if (deEmphasizedCategories.indexOf(subCategoryName) === -1) {
           var calculation = getCalculation(subCategoryName);
 
           var budgeted = calculation.balance - calculation.budgetedCashOutflows - calculation.budgetedCreditOutflows;
@@ -139,7 +137,7 @@
 
       return {
         invoke() {
-          var categories = $('.budget-table ul');
+          var categories = $('.budget-table ul').not('.budget-table-uncategorized-transactions');
           var masterCategoryName = '';
 
           if (subCats === null || subCats.length === 0 || loadCategories) {
@@ -165,11 +163,6 @@
 
             if ($(this).hasClass('is-sub-category')) {
               var subCategoryName = $(this).find('li.budget-table-cell-name>div>div')[0].title.match(/.[^\n]*/);
-
-              if (subCategoryName === 'Uncategorized Transactions') {
-                // iterate the .each() function
-                return;
-              }
 
               subCategoryName = masterCategoryName + subCategoryName;
 
@@ -232,6 +225,12 @@
              * be rebuilt. Rebuilding at this point won't work becuase the user hasn't completed
              * the update activity at this point.
              */
+            loadCategories = true;
+          }
+        },
+
+        onRouteChanged(currentRoute) {
+          if (currentRoute.indexOf('budget') !== -1) {
             loadCategories = true;
           }
         }


### PR DESCRIPTION
Budget progress bars needed to be aware of switching budgets and reloading the categories. Added onRouteChanged() to accomplish that.

Budget category info (which also feeds the goal indicator feature) had a failing compare when the sub-category was Uncategorized Transactions. Added a .not() to the selector that gathers all the categories to ensure the Uncategorized Transactions category isn't processed.

Github Issue (if applicable): #339 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Several issues were reported in this issue. This PR fixes some of them while others were fixed in other PRs.


#### Recommended Release Notes:
The Add goals indicator, Budget rows progress bars, and Goal indicator warning color features will now work when switching budgets.