### PR TITLE
Handle sub-categories with a note

### DIFF
--- a/source/common/res/features/budget-balance-to-zero/main.js
+++ b/source/common/res/features/budget-balance-to-zero/main.js
@@ -5,12 +5,17 @@
         budgetView: ynab.YNABSharedLib.getBudgetViewModel_AllBudgetMonthsViewModel()._result,
 
         invoke() {
-          var categories = ynabToolKit.budgetBalanceToZero.getCategories();
-          var categoryName = ynabToolKit.budgetBalanceToZero.getInspectorName();
+          let categories = ynabToolKit.budgetBalanceToZero.getCategories();
+          let categoryName = ynabToolKit.budgetBalanceToZero.getInspectorName();
+          let masterCategoryViewId = $('ul.is-checked').prevAll('ul.is-master-category').attr('id');
+          let masterCategory = ynabToolKit.shared.getEmberView(masterCategoryViewId).get('data');
+          let masterCategoryId = masterCategory.get('categoryId');
 
           categories.forEach(function (f) {
-            if (f.name === categoryName) {
+            if (f.name === categoryName && f.masterCategoryId === masterCategoryId) {
               ynabToolKit.budgetBalanceToZero.updateInspectorButton(f);
+
+              return false;
             }
           });
         },

--- a/source/common/res/features/budget-balance-to-zero/main.js
+++ b/source/common/res/features/budget-balance-to-zero/main.js
@@ -90,7 +90,10 @@
           var categories = $('.is-sub-category.is-checked');
 
           $(categories).each(function () {
-            var accountName = $(this).find('.budget-table-cell-name div.button-truncate').prop('title');
+            var accountName = $(this).find('.budget-table-cell-name div.button-truncate')
+                                     .prop('title')
+                                     .match(/.[^\n]*/)[0];
+
             if (accountName === name) {
               var input = $(this).find('.budget-table-cell-budgeted div.currency-input').click()
                                  .find('input');

--- a/source/common/res/features/check-credit-balances/main.js
+++ b/source/common/res/features/check-credit-balances/main.js
@@ -150,7 +150,9 @@
           var debtPaymentCategories = $('.is-debt-payment-category.is-sub-category');
 
           $(debtPaymentCategories).each(function () {
-            var accountName = $(this).find('.budget-table-cell-name div.button-truncate').prop('title');
+            var accountName = $(this).find('.budget-table-cell-name div.button-truncate')
+                                     .prop('title')
+                                     .match(/.[^\n]*/)[0];
             if (accountName === name) {
               var input = $(this).find('.budget-table-cell-budgeted div.currency-input').click()
                                  .find('input');


### PR DESCRIPTION
The note for a sub-category is appended to the title attribute separated by a NL. When comparing the name, the value in front of the NL is the what's needed not the whole title value. 

Github Issue (if applicable): #528 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Comparing the whole title value resulted in failing compares which further resulted in the features not working as intended IF there was a note associated with the sub-category.


#### Recommended Release Notes:
Features Budget Balance to Zero and Paid in Full Credit Card Assist were affected by this change.