### PR TITLE
auto does a bit better job on small screens

### DIFF
--- a/source/common/res/features/toggle-splits/main.css
+++ b/source/common/res/features/toggle-splits/main.css
@@ -3,5 +3,5 @@
 }
 
 .toolkit-accounts-toolbar-left {
-    width: 50% !important;
+    width: auto !important;
 }


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Enhancement:
This is just a different change to what we already pushed out. It appears that using `width: auto` is a bit better than specifying 50%.


#### Recommended Release Notes:
