### PR TITLE
New feature to auto-close the account reconcile popup window after a …

### DIFF
--- a/source/common/res/features/close-reconcile-window/main.js
+++ b/source/common/res/features/close-reconcile-window/main.js
@@ -1,5 +1,5 @@
 (function poll() {
-  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true) {
+  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.pageReady === true) {
     ynabToolKit.closeReconcileWindow = (function () {
       return {
         observe(changedNodes) {

--- a/source/common/res/features/close-reconcile-window/main.js
+++ b/source/common/res/features/close-reconcile-window/main.js
@@ -1,0 +1,21 @@
+(function poll() {
+  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true) {
+    ynabToolKit.closeReconcileWindow = (function () {
+      return {
+        observe(changedNodes) {
+          if (changedNodes.has('modal-account-reconcile-current') && changedNodes.has('flaticon stroke checkmark-2')) {
+            if ($('.modal-account-reconcile-reconciled').length) {
+              setTimeout(function () {
+                $('.modal-account-reconcile-reconciled').fadeOut(function () {
+                  $('.modal-account-reconcile').click();
+                });
+              }, 1500);
+            }
+          }
+        }
+      };
+    }());
+  } else {
+    setTimeout(poll, 250);
+  }
+}());

--- a/source/common/res/features/close-reconcile-window/settings.json
+++ b/source/common/res/features/close-reconcile-window/settings.json
@@ -1,0 +1,13 @@
+{
+  "name": "closeReconcileWindow",
+  "type": "checkbox",
+  "default": false,
+  "section": "accounts",
+  "title": "Auto-Close Reconcile Popup",
+  "description": "Auto-close the \"Account Reconciled!\" popup window after a short time.",
+  "actions": {
+    "true": [
+      "injectScript", "main.js"
+    ]
+  }
+}


### PR DESCRIPTION
…short time.

Github Issue (if applicable): #XXX

Trello Link (if applicable):
https://trello.com/c/wafFBBht/77-auto-close-reconciliation-window-after-few-secs
possibly this one too:
https://trello.com/c/Jtis23QG/76-put-close-button-dialog-on-reconciliation-window

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
After successfully reconciling, the modal popup will close after about a second and a half.


#### Recommended Release Notes:
