### PR TITLE
Chrome sync

### DIFF
--- a/source/common/extension_info.json
+++ b/source/common/extension_info.json
@@ -24,6 +24,6 @@
         "web_navigation": false,
         "notifications": false,
         "cookies": false,
-        "xhr": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*"]
+        "xhr": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*", "storage"]
     }
 }

--- a/source/common/options.js
+++ b/source/common/options.js
@@ -15,7 +15,7 @@ function saveCheckboxOption(elementId) {
   var element = document.getElementById(elementId);
 
   if (element) {
-    setSetting(elementId, element.checked);
+    return setSetting(elementId, element.checked);
   }
 
   console.log("WARNING: Tried to saveCheckboxOption but couldn't find element " + elementId + ' on the page.');
@@ -25,7 +25,7 @@ function saveSelectOption(elementId) {
   var select = document.getElementById(elementId);
 
   if (select) {
-    setSetting(elementId, select.options[select.selectedIndex].value);
+    return setSetting(elementId, select.options[select.selectedIndex].value);
   }
 
   console.log("WARNING: Tried to saveSelectOption but couldn't find element " + elementId + ' on the page.');


### PR DESCRIPTION
Trello Link (if applicable): https://trello.com/c/bse9h25w (related)

#### Explanation of Bugfix/Feature/Enhancement:
Added support for syncing toolkit settings with Chrome Sync. By default, users on Chrome will shift to using Chrome Sync. Existing Kango settings will be synced as soon as a user clicks Save on the options page, and any new features that are released in the future will get synced on Save as well.

#### Recommended Release Notes:
Added Chrome Sync support for syncing toolkit settings across devices.