### PR TITLE
resize-inspector remembers width of inspector and handles window resizing

### DIFF
--- a/source/common/res/features/resize-inspector/main.js
+++ b/source/common/res/features/resize-inspector/main.js
@@ -3,17 +3,15 @@
     ynabToolKit.resizeInspector = (function () {
       // Supporting functions,
       // or variables, etc
+
       return {
-        sectionWidth: '',
-        sectionWidthCollapsed: '',
+        asideWidth: '',
 
         invoke() {
-          let sectionWidth = ynabToolKit.shared.getToolkitStorageKey('budget-resize-inspector');
-          let sectionWidthCollapsed = parseInt(ynabToolKit.shared.getToolkitStorageKey('budget-resize-inspector')) + 220;
+          let asideWidth = ynabToolKit.shared.getToolkitStorageKey('budget-resize-inspector');
 
-          if (typeof sectionWidth !== 'undefined' && sectionWidth !== null) {
-            ynabToolKit.resizeInspector.sectionWidth = sectionWidth;
-            ynabToolKit.resizeInspector.sectionWidthCollapsed = parseInt(sectionWidth) + 220;
+          if (typeof asideWidth !== 'undefined' && asideWidth !== null) {
+            ynabToolKit.resizeInspector.asideWidth = asideWidth;
           }
 
           if ($('.ember-view.content .budget-inspector').length > 0) {
@@ -26,28 +24,19 @@
                 resizeHeight: false,
                 maxWidth: 1400,
                 onDragEnd: () => {
-                  let width = $('section').css('width').match(/.[^px]*/);
+                  asideWidth = parseInt($('aside').width());
 
-                  if (!$('.layout.collapsed').length) {
-                    // save values based on non-collapsed layout
-                    ynabToolKit.shared.setToolkitStorageKey('budget-resize-inspector', width);
-                    ynabToolKit.resizeInspector.sectionWidth = width;
-                    ynabToolKit.resizeInspector.sectionWidthCollapsed = parseInt(width) + 220;
-                  } else {
-                    // save values based on collapsed layout
-                    ynabToolKit.shared.setToolkitStorageKey('budget-resize-inspector', parseInt(width) - 220);
-                    ynabToolKit.resizeInspector.sectionWidth = parseInt(width) - 220;
-                    ynabToolKit.resizeInspector.sectionWidthCollapsed = width;
-                  }
+                  ynabToolKit.shared.setToolkitStorageKey('budget-resize-inspector', asideWidth);
+                  ynabToolKit.resizeInspector.asideWidth = asideWidth;
                 }
               });
 
-              if (sectionWidth !== '') {
-                if (ynabToolKit.options.collapseSideMenu && $('.layout.collapsed').length) {
-                  $('section').css('width', sectionWidthCollapsed);
-                } else {
-                  $('section').css('width', sectionWidth);
-                }
+              if (asideWidth !== '') {
+                $('section').css('width', ynabToolKit.resizeInspector.getContentSize());
+                // react to changed window size
+                $(window).resize(function () {
+                  $('section').css('width', ynabToolKit.resizeInspector.getContentSize());
+                });
               }
             }
           } else {
@@ -56,11 +45,18 @@
         },
 
         getContentSize() {
-          return ynabToolKit.resizeInspector.sectionWidth;
+          var headerWidth = parseInt($('header').css('width').match(/.[^px]*/));
+          var resizeHandleWidth = 13;
+          var sectionWidth = parseInt(headerWidth) - parseInt(resizeHandleWidth) - ynabToolKit.resizeInspector.asideWidth - 21.2; // don't know why 21.2, but it works
+          if ($('.layout.collapsed').length) {
+            // calculate non-collapsed layout
+            sectionWidth -= 220;
+          }
+          return sectionWidth;
         },
 
         getContentSizeCollapsed() {
-          return ynabToolKit.resizeInspector.sectionWidthCollapsed;
+          return ynabToolKit.resizeInspector.getContentSize() + 220;
         },
 
         observe(changedNodes) {


### PR DESCRIPTION
fixes #690

Github Issue (if applicable): #690

Trello Link (if applicable): sorry, could not find any

Forum Link (if applicable): none

#### Explanation of Bugfix/Feature/Enhancement:
The resize-inspector saved the width of the categories, not of the inspector. Before, when resizing the window, the inspector would either become larger or disappear outside of the window. Now, the inspector stays the same size that it is set to, regardless of resized windows.


#### Recommended Release Notes:
Fixed Resizing of Inspector to remember inspector size when window size changed