### PR TITLE
Added "spare change" calculator.

### DIFF
--- a/source/common/res/features/spare-change/main.css
+++ b/source/common/res/features/spare-change/main.css
@@ -1,0 +1,25 @@
+.ynab-toolkit-accounts-header-balances-spare-change {
+	box-sizing: border-box;
+	color: rgb(91, 190, 114);
+	display: block;
+	flex-basis: auto;
+	flex-grow: 0;
+	flex-shrink: 1;
+	font-family: Lato, Arial, "Helvetica Neue", Helvetica, sans-serif;
+	font-size: 18px;
+	font-weight: bold;
+	height: 37px;
+	letter-spacing: normal;
+	margin-left: 0px;
+	margin-right: 0px;
+	margin-top: 13.5px;
+	overflow-x: hidden;
+	overflow-y: hidden;
+	text-align: right;
+	text-rendering: auto;
+	text-size-adjust: 100%;
+	width: 70.5625px;
+	word-spacing: 0px;
+	-webkit-box-flex: 1;
+	-webkit-font-smoothing: subpixel-antialiased
+}

--- a/source/common/res/features/spare-change/main.js
+++ b/source/common/res/features/spare-change/main.js
@@ -34,16 +34,10 @@
         }
       }
 
-      function insertHeaderAndUpdateValue() {
-        insertHeader();
-        updateValue();
-      }
-
       function updateSpareChangeHeader() {
         if (selectedTransactions.length > 0) {
-          Ember.run.later(function () {
-            insertHeaderAndUpdateValue();
-          }, 250);
+          insertHeader();
+          updateValue();
         } else {
           removeHeader();
         }
@@ -125,9 +119,11 @@
       }
 
       function onYnabGridyBodyChanged() {
-        setSelectedTransactions();
-        updateSpareChangeCalculation();
-        updateSpareChangeHeader();
+        Ember.run.later(function () {
+          setSelectedTransactions();
+          updateSpareChangeCalculation();
+          updateSpareChangeHeader();
+        }, 250);
       }
 
       function onYnabSelectionChanged() {

--- a/source/common/res/features/spare-change/main.js
+++ b/source/common/res/features/spare-change/main.js
@@ -174,7 +174,7 @@
 
         observe: function invoke(changedNodes) {
           if (changedNodes.has('ynab-grid-body') && !currentlyRunning) {
-            ynabToolKit.runningBalance.invoke();
+            ynabToolKit.spareChange.invoke();
           }
         }
       };

--- a/source/common/res/features/spare-change/main.js
+++ b/source/common/res/features/spare-change/main.js
@@ -7,9 +7,7 @@
       function setSelectedTransactions() {
         var accountController = ynabToolKit.shared.containerLookup('controller:accounts');
         var visibleTransactionDisplayItems = accountController.get('visibleTransactionDisplayItems');
-        selectedTransactions = visibleTransactionDisplayItems.filter(function (item) {
-          return item.isChecked && item.get('outflow');
-        });
+        selectedTransactions = visibleTransactionDisplayItems.filter(i => i.isChecked && i.get('outflow'));
       }
 
       function getSelectedAccount() {
@@ -19,9 +17,7 @@
         if (selectedAccountId) {
           var accountController = ynabToolKit.shared.containerLookup('controller:accounts');
           var selectedAccounts = accountController.get('activeAccounts');
-          var selectedAccount = selectedAccounts.find(function (account) {
-            return account.itemId === selectedAccountId;
-          });
+          var selectedAccount = selectedAccounts.find(a => a.itemId === selectedAccountId);
 
           return selectedAccount;
         }

--- a/source/common/res/features/spare-change/settings.json
+++ b/source/common/res/features/spare-change/settings.json
@@ -1,0 +1,14 @@
+{
+         "name": "spareChange",
+         "type": "checkbox",
+      "default": false,
+      "section": "accounts",
+        "title": "Show Spare Change",
+  "description": "Imagine if you paid for all purchases in whole dollars. Shows a total of the spare change you would accumulate for the selected transactions.",
+      "actions": {
+                  "true": [
+                    "injectCSS", "main.css",
+                    "injectScript", "main.js"
+                  ]
+                }
+}


### PR DESCRIPTION
Github Issue (if applicable): N/A

Trello Link (if applicable): N/A

Forum Link (if applicable): N/A

#### Explanation of Enhancement:
Imagine if you paid for all purchases in whole dollars. Shows a total of the spare change you would accumulate for the selected transactions.

The spare change total is displayed on the right in the header of account view. It's displayed directly to the left of the "Selected Total" if present.

This is useful because the spare change calculator functions as a virtual "change jar". We used to throw all of our change into a jar and eventually deposit it in the bank every few months. Now you can do something similar with the spare change calculation.


#### Recommended Release Notes:
Spare change calculator:  Imagine if you paid for all purchases in whole dollars. Shows a total of the spare change you would accumulate for the selected transactions. Think of it like a virtual "change jar".