### PR TITLE
Fixed bug where resized inspector ignored collapsed menu

### DIFF
--- a/source/common/res/features/resize-inspector/main.js
+++ b/source/common/res/features/resize-inspector/main.js
@@ -35,7 +35,11 @@
                 $('section').css('width', ynabToolKit.resizeInspector.getContentSize());
                 // react to changed window size
                 $(window).resize(function () {
-                  $('section').css('width', ynabToolKit.resizeInspector.getContentSize());
+                  if ($('.layout.collapsed').length) {
+                    $('section').css('width', ynabToolKit.resizeInspector.getContentSizeCollapsed());
+                  } else {
+                    $('section').css('width', ynabToolKit.resizeInspector.getContentSize());
+                  }
                 });
               }
             }


### PR DESCRIPTION
Github Issue (if applicable): #695 

Trello Link (if applicable): none

Forum Link (if applicable): none

#### Explanation of Bugfix/Feature/Enhancement:
Added awareness to resized inspector for whether menu was collapsed while resizing browser window.


#### Recommended Release Notes:
Fixed bug in Allow Resizing of Inspector when menu is collapsed and browser is resized