### PR TITLE
remvoing the top 1em from budget-table

### DIFF
--- a/source/common/res/features/budget-rows-height/slim-fonts.css
+++ b/source/common/res/features/budget-rows-height/slim-fonts.css
@@ -1,7 +1,3 @@
-.budget-table {
-  top: 1em !important;
-}
-
 .budget-content ul, .budget-table-row.is-dragging {
   height: 1.6em;
 }

--- a/source/common/res/features/budget-rows-height/slim.css
+++ b/source/common/res/features/budget-rows-height/slim.css
@@ -1,7 +1,3 @@
-.budget-table {
-  top: 1em !important;
-}
-
 .budget-content ul, .budget-table-row.is-dragging {
   height: 1.6em;
 }


### PR DESCRIPTION
Github Issue (if applicable): #620 

#### Explanation of Bugfix/Feature/Enhancement:
There was a top: 1em !important on the budget table for slim/slim-font styles.

I've removed it and now the top row is no longer cut off.


#### Recommended Release Notes:
Fixed a bug where the top row of your budget table was cut off when using the slim rows options.
