### PR TITLE
Fixes for popup calculator

### DIFF
--- a/source/common/res/features/popup-calculator/settings.json
+++ b/source/common/res/features/popup-calculator/settings.json
@@ -5,10 +5,14 @@
       "section": "general",
         "title": "Popup Calculator",
   "description": "markdown",
-      "actions": {
-                    "true": [
-                      "injectCSS", "main.css",
-                      "injectScript", "main.js"
-                    ]
-                 }
+  "actions": {
+                "true": [
+                  "injectCSS", "main.css",
+                  "injectScript", "main.js",
+                  "injectScript", "account/main.js",
+                  "injectCSS", "account/main.css",
+                  "injectCSS", "budget/main.css",
+                  "injectScript", "budget/main.js"
+                ]
+             }
 }


### PR DESCRIPTION
The changes to the "actions" section from an earlier PR were regressed. I added them back.

Github Issue (if applicable): #677

Trello Link (if applicable):

Forum Link (if applicable):
https://forum.youneedabudget.com/discussion/52962/pop-up-calculator#latest

#### Explanation of Bugfix/Feature/Enhancement:
Last PR regressed the changes from a previous PR.


#### Recommended Release Notes:
Popup Calculator should now display as expected.