### PR TITLE
Issue#339.3 More changes to fix budget switching issues

### DIFF
--- a/source/common/res/features/budget-category-info/main.js
+++ b/source/common/res/features/budget-category-info/main.js
@@ -175,12 +175,24 @@
              */
             loadCategories = true;
           }
+        },
+
+        addBudgetVersionIdObserver() {
+          let applicationController = ynabToolKit.shared.containerLookup('controller:application');
+          applicationController.addObserver('budgetVersionId', function () {
+            Ember.run.scheduleOnce('afterRender', this, resetBudgetViewBudgetCategoryInfo);
+          });
+
+          function resetBudgetViewBudgetCategoryInfo() {
+            loadCategories = true;
+          }
         }
       };
     }()); // Keep feature functions contained within this object
 
     // Run once and activate setTimeOut()
     ynabToolKit.budgetCategoryInfo.invoke();
+    ynabToolKit.budgetCategoryInfo.addBudgetVersionIdObserver();
   } else {
     setTimeout(poll, 250);
   }

--- a/source/common/res/features/budget-progress-bars/main.js
+++ b/source/common/res/features/budget-progress-bars/main.js
@@ -134,7 +134,6 @@
           target.style.background = '';
         }
       }
-
       return {
         invoke() {
           var categories = $('.budget-table ul').not('.budget-table-uncategorized-transactions');
@@ -233,12 +232,24 @@
           if (currentRoute.indexOf('budget') !== -1) {
             loadCategories = true;
           }
+        },
+
+        addBudgetVersionIdObserver() {
+          let applicationController = ynabToolKit.shared.containerLookup('controller:application');
+          applicationController.addObserver('budgetVersionId', function () {
+            Ember.run.scheduleOnce('afterRender', this, resetBudgetViewBudgetProgressBars);
+          });
+
+          function resetBudgetViewBudgetProgressBars() {
+            loadCategories = true;
+          }
         }
       };
     }()); // Keep feature functions contained within this object
 
     // Run once and activate setTimeOut()
     ynabToolKit.budgetProgressBars.invoke();
+    ynabToolKit.budgetProgressBars.addBudgetVersionIdObserver();
   } else {
     setTimeout(poll, 250);
   }


### PR DESCRIPTION
Github Issue (if applicable): #339 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Added code to be aware of when the budget version ID changes.


#### Recommended Release Notes:
Switching budgets should no longer prevent the Budget Progress Bars and Add Goals Indication features from working properly.