### PR TITLE
Issue#718

### DIFF
--- a/source/common/res/features/collapse-side-menu/main.js
+++ b/source/common/res/features/collapse-side-menu/main.js
@@ -47,6 +47,10 @@
             }
           }
 
+          // if (changedNodes.has('sidebar-onboarding-close') && $('.collapsed-buttons').length) {
+          //   $('.collapsed-buttons').remove();
+          // }
+
           if (changedNodes.has('nav-main')) {
             var numNavLinks = $('.nav-main').children().length;
             var collapseIndex = $('.nav-main').children()
@@ -84,12 +88,7 @@
         setUpCollapsedButtons() {
           var expandBtns = ynabToolKit.collapseSideMenu.getUnCollapseBtnGroup();
 
-          if (!$('.collapsed-buttons').length) {
-            $('.sidebar').prepend(expandBtns);
-          } else {
-            $('.collapsed-buttons').remove();
-            $('.sidebar').prepend(expandBtns);
-          }
+          $('.sidebar').prepend(expandBtns);
 
           if ($('.sidebar-contents').is(':visible')) {
             $('.collapsed-buttons').hide();
@@ -99,11 +98,14 @@
         getUnCollapseBtnGroup() {
           var navChildren = $('.nav-main').children();
           var navChildrenLength = navChildren.length;
+          var collapsedBtnContainer = $('.collapsed-buttons');
 
-          var collapsedBtnContainer =
-            $('<div>', {
-              class: 'collapsed-buttons'
-            });
+          if (collapsedBtnContainer.length) {
+            collapsedBtnContainer.children().remove();
+            collapsedBtnContainer.hide();
+          } else {
+            collapsedBtnContainer = $('<div>', { class: 'collapsed-buttons', style: 'display: none' });
+          }
 
           var clickFunction = function () {
             ynabToolKit.collapseSideMenu.originalButtons[this.className.replace(' active', '')].click();
@@ -185,7 +187,7 @@
           $('.budget-header').animate({ left: originalSizes.headerLeft });
           if ($('.budget-content').is(':visible')) {
             if (ynabToolKit.options.resizeInspector) {
-              $('.budget-content').animate({ width: ynabToolKit.resizeInspector.getContentSize() }, 400, 'swing', function () {
+              $('.budget-content').animate({ width: ynabToolKit.resizeInspector.getContentSize(true) }, 400, 'swing', function () {
                 $('.navlink-collapse').removeClass('collapsed').addClass('expanded');
               });
             } else {

--- a/source/common/res/features/resize-inspector/main.js
+++ b/source/common/res/features/resize-inspector/main.js
@@ -32,13 +32,13 @@
               });
 
               if (asideWidth !== '') {
-                $('section').css('width', ynabToolKit.resizeInspector.getContentSize());
+                $('section').css('width', ynabToolKit.resizeInspector.getContentSize(false));
                 // react to changed window size
                 $(window).resize(function () {
                   if ($('.layout.collapsed').length) {
                     $('section').css('width', ynabToolKit.resizeInspector.getContentSizeCollapsed());
                   } else {
-                    $('section').css('width', ynabToolKit.resizeInspector.getContentSize());
+                    $('section').css('width', ynabToolKit.resizeInspector.getContentSize(false));
                   }
                 });
               }
@@ -48,11 +48,13 @@
           }
         },
 
-        getContentSize() {
+        getContentSize(externalCall) {
           var headerWidth = parseInt($('header').css('width').match(/.[^px]*/));
           var resizeHandleWidth = 13;
           var sectionWidth = parseInt(headerWidth) - parseInt(resizeHandleWidth) - ynabToolKit.resizeInspector.asideWidth - 21.2; // don't know why 21.2, but it works
-          if ($('.layout.collapsed').length) {
+
+          // Only subtract the 220 if this function was called externally.
+          if ($('.layout.collapsed').length & externalCall) {
             // calculate non-collapsed layout
             sectionWidth -= 220;
           }
@@ -60,7 +62,7 @@
         },
 
         getContentSizeCollapsed() {
-          return ynabToolKit.resizeInspector.getContentSize() + 220;
+          return ynabToolKit.resizeInspector.getContentSize(false) + 220;
         },
 
         observe(changedNodes) {


### PR DESCRIPTION
Github Issue (if applicable): #718

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Fixed code to not display both sets of buttons after clicking the "Hide Quick Start" link.
Fixed code to honor the inspector window width when navigating to the Budget from other areas such Reports, etc when the sidebar is collapsed.


#### Recommended Release Notes:
The correct set of buttons will display after clicking the "Hide Quick Start" link and the inspector window width will be honored when navigating between different screens when the sidebar is collapsed.