### PR TITLE
Add Daily Spending Allowance calculator

### DIFF
--- a/source/common/res/features/budget-daily-spending/main.js
+++ b/source/common/res/features/budget-daily-spending/main.js
@@ -31,11 +31,11 @@
         addBudgetVersionIdObserver() {
           let applicationController = ynabToolKit.shared.containerLookup('controller:application');
           applicationController.addObserver('budgetVersionId', function () {
-            Ember.run.scheduleOnce('afterRender', this, resetBudgetViewCheckCreditBalances);
+            Ember.run.scheduleOnce('afterRender', this, resetBudgetViewDailySpending);
           });
 
-          function resetBudgetViewCheckCreditBalances() {
-            ynabToolKit.checkCreditBalances.budgetView = null;
+          function resetBudgetViewDailySpending() {
+            ynabToolKit.dailySpending.budgetView = null;
           }
         },
 
@@ -44,10 +44,15 @@
             return [];
           }
 
+
+
           // After using Budget Quick Switch, budgetView needs to be reset to the new budget.
           if (ynabToolKit.dailySpending.budgetView === null) {
-            ynabToolKit.dailySpending.budgetView = ynab.YNABSharedLib.
-              getBudgetViewModel_AllBudgetMonthsViewModel()._result;
+            try {
+              ynabToolKit.dailySpending.budgetView = ynab.YNABSharedLib.getBudgetViewModel_AllBudgetMonthsViewModel()._result;
+            } catch (e) {
+              return;
+            }
           }
           var categories = [];
           var masterCats = ynabToolKit.dailySpending.budgetView
@@ -117,7 +122,7 @@
       };
     }()); // Keep feature functions contained within this object
     // Run once to activate the budget observer()
-    ynabToolKit.checkCreditBalances.addBudgetVersionIdObserver();
+    ynabToolKit.dailySpending.addBudgetVersionIdObserver();
   } else {
     setTimeout(poll, 250);
   }

--- a/source/common/res/features/budget-daily-spending/main.js
+++ b/source/common/res/features/budget-daily-spending/main.js
@@ -21,8 +21,21 @@
         },
 
         observe(changedNodes) {
-          if (changedNodes.has('budget-inspector')) {
+          if (changedNodes.has('navlink-budget active') ||
+              changedNodes.has('budget-table-cell-available-div user-data') ||
+              changedNodes.has('budget-inspector')) {
             ynabToolKit.dailySpending.invoke();
+          }
+        },
+
+        addBudgetVersionIdObserver() {
+          let applicationController = ynabToolKit.shared.containerLookup('controller:application');
+          applicationController.addObserver('budgetVersionId', function () {
+            Ember.run.scheduleOnce('afterRender', this, resetBudgetViewCheckCreditBalances);
+          });
+
+          function resetBudgetViewCheckCreditBalances() {
+            ynabToolKit.checkCreditBalances.budgetView = null;
           }
         },
 
@@ -103,6 +116,8 @@
         }
       };
     }()); // Keep feature functions contained within this object
+    // Run once to activate the budget observer()
+    ynabToolKit.checkCreditBalances.addBudgetVersionIdObserver();
   } else {
     setTimeout(poll, 250);
   }

--- a/source/common/res/features/budget-daily-spending/main.js
+++ b/source/common/res/features/budget-daily-spending/main.js
@@ -1,0 +1,109 @@
+(function poll() {
+  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.pageReady === true) {
+    ynabToolKit.dailySpending = (function () {
+      return {
+        budgetView: ynab.YNABSharedLib.getBudgetViewModel_AllBudgetMonthsViewModel()._result,
+
+        invoke() {
+          let categories = ynabToolKit.dailySpending.getCategories();
+          let categoryName = ynabToolKit.dailySpending.getInspectorName();
+          let masterCategoryViewId = $('ul.is-checked').prevAll('ul.is-master-category').attr('id');
+          let masterCategory = ynabToolKit.shared.getEmberView(masterCategoryViewId).get('data');
+          let masterCategoryId = masterCategory.get('categoryId');
+
+          categories.forEach(function (f) {
+            if (f.name === categoryName && f.masterCategoryId === masterCategoryId) {
+              ynabToolKit.dailySpending.updateDailySpending(f);
+
+              return false;
+            }
+          });
+        },
+
+        observe(changedNodes) {
+          if (changedNodes.has('budget-inspector')) {
+            ynabToolKit.dailySpending.invoke();
+          }
+        },
+
+        getCategories() {
+          if (ynabToolKit.dailySpending === 'undefined') {
+            return [];
+          }
+
+          // After using Budget Quick Switch, budgetView needs to be reset to the new budget.
+          if (ynabToolKit.dailySpending.budgetView === null) {
+            ynabToolKit.dailySpending.budgetView = ynab.YNABSharedLib.
+              getBudgetViewModel_AllBudgetMonthsViewModel()._result;
+          }
+          var categories = [];
+          var masterCats = ynabToolKit.dailySpending.budgetView
+          .categoriesViewModel.masterCategoriesCollection._internalDataArray;
+          var masterCategories = [];
+
+          masterCats.forEach(function (c) {
+            // Filter out "special" categories
+            if (c.internalName === null) {
+              masterCategories.push(c.entityId);
+            }
+          });
+
+          masterCategories.forEach(function (c) {
+            var accounts = ynabToolKit.dailySpending.budgetView
+              .categoriesViewModel.subCategoriesCollection
+              .findItemsByMasterCategoryId(c);
+
+            Array.prototype.push.apply(categories, accounts);
+          });
+
+          return categories;
+        },
+
+        updateDailySpending(f) {
+          var amount = ynabToolKit.dailySpending.getBalanceAmount(f);
+          var date = new Date();
+          var remainingDays = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate() - date.getDate();
+          var dailySpendingAmount = amount / remainingDays;
+          if (dailySpendingAmount < 0) {
+            dailySpendingAmount = 0;
+          }
+          var fdailySpending = ynabToolKit.shared.formatCurrency(dailySpendingAmount * 1000);
+          var classDt = 'positive';
+          var classSpan = 'positive';
+          if (dailySpendingAmount === 0) {
+            classSpan = 'zero';
+          }
+          if (dailySpendingAmount === 0) {
+            classDt = '';
+          }
+          var available = $('<dl>', { class: 'inspector-overview-available' })
+          .append($('<dt>', { class: classDt })
+                  .append('Daily Spending')
+                  )
+          .append($('<dd>', { class: 'user-data' })
+                  .append($('<span>', { class: 'user-data currency ' + classSpan })
+                          .append(fdailySpending.toString()))
+                  );
+          $('.budget-inspector-category-overview .inspector').append($('<hr>', { class: 'clearfix' }));
+          $('.budget-inspector-category-overview .inspector').append(available);
+        },
+
+        getInspectorName() {
+          return $('.inspector-category-name.user-data').text().trim();
+        },
+
+        getBalanceAmount(f) {
+          var currentMonth = moment(ynabToolKit.shared.parseSelectedMonth())
+            .format('YYYY-MM');
+          var monthlyBudget = ynabToolKit.dailySpending.budgetView
+            .monthlySubCategoryBudgetCalculationsCollection
+            .findItemByEntityId('mcbc/' + currentMonth + '/' + f.entityId);
+
+          return (monthlyBudget.balance * 0.001);
+        }
+      };
+    }()); // Keep feature functions contained within this object
+  } else {
+    setTimeout(poll, 250);
+  }
+}());

--- a/source/common/res/features/budget-daily-spending/main.js
+++ b/source/common/res/features/budget-daily-spending/main.js
@@ -21,9 +21,7 @@
         },
 
         observe(changedNodes) {
-          if (changedNodes.has('navlink-budget active') ||
-              changedNodes.has('budget-table-cell-available-div user-data') ||
-              changedNodes.has('budget-inspector')) {
+          if (changedNodes.has('budget-inspector')) {
             ynabToolKit.dailySpending.invoke();
           }
         },

--- a/source/common/res/features/budget-daily-spending/main.js
+++ b/source/common/res/features/budget-daily-spending/main.js
@@ -77,19 +77,10 @@
           const amount = ynabToolKit.dailySpending.getBalanceAmount(f);
           const date = new Date();
           const remainingDays = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate() - date.getDate();
-          let dailySpendingAmount = amount / remainingDays;
-          if (dailySpendingAmount < 0) {
-            dailySpendingAmount = 0;
-          }
+          const classDt = amount > 0 ? 'positive' : '';
+          const classSpan = amount > 0 ? 'positive' : 'zero';
+          const dailySpendingAmount = amount > 0 ? amount / remainingDays : 0;
           const fdailySpending = ynabToolKit.shared.formatCurrency(dailySpendingAmount * 1000);
-          let classDt = 'positive';
-          let classSpan = 'positive';
-          if (dailySpendingAmount === 0) {
-            classSpan = 'zero';
-          }
-          if (dailySpendingAmount === 0) {
-            classDt = '';
-          }
           const available = $('<dl>', { class: 'inspector-overview-available' })
           .append($('<dt>', { class: classDt })
                   .append('Daily Spending')

--- a/source/common/res/features/budget-daily-spending/main.js
+++ b/source/common/res/features/budget-daily-spending/main.js
@@ -44,8 +44,6 @@
             return [];
           }
 
-
-
           // After using Budget Quick Switch, budgetView needs to be reset to the new budget.
           if (ynabToolKit.dailySpending.budgetView === null) {
             try {

--- a/source/common/res/features/budget-daily-spending/main.js
+++ b/source/common/res/features/budget-daily-spending/main.js
@@ -27,7 +27,7 @@
         },
 
         addBudgetVersionIdObserver() {
-          let applicationController = ynabToolKit.shared.containerLookup('controller:application');
+          const applicationController = ynabToolKit.shared.containerLookup('controller:application');
           applicationController.addObserver('budgetVersionId', function () {
             Ember.run.scheduleOnce('afterRender', this, resetBudgetViewDailySpending);
           });
@@ -50,10 +50,10 @@
               return;
             }
           }
-          var categories = [];
-          var masterCats = ynabToolKit.dailySpending.budgetView
+          let categories = [];
+          const masterCats = ynabToolKit.dailySpending.budgetView
           .categoriesViewModel.masterCategoriesCollection._internalDataArray;
-          var masterCategories = [];
+          const masterCategories = [];
 
           masterCats.forEach(function (c) {
             // Filter out "special" categories
@@ -63,7 +63,7 @@
           });
 
           masterCategories.forEach(function (c) {
-            var accounts = ynabToolKit.dailySpending.budgetView
+            let accounts = ynabToolKit.dailySpending.budgetView
               .categoriesViewModel.subCategoriesCollection
               .findItemsByMasterCategoryId(c);
 
@@ -74,23 +74,23 @@
         },
 
         updateDailySpending(f) {
-          var amount = ynabToolKit.dailySpending.getBalanceAmount(f);
-          var date = new Date();
-          var remainingDays = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate() - date.getDate();
-          var dailySpendingAmount = amount / remainingDays;
+          const amount = ynabToolKit.dailySpending.getBalanceAmount(f);
+          const date = new Date();
+          const remainingDays = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate() - date.getDate();
+          let dailySpendingAmount = amount / remainingDays;
           if (dailySpendingAmount < 0) {
             dailySpendingAmount = 0;
           }
-          var fdailySpending = ynabToolKit.shared.formatCurrency(dailySpendingAmount * 1000);
-          var classDt = 'positive';
-          var classSpan = 'positive';
+          const fdailySpending = ynabToolKit.shared.formatCurrency(dailySpendingAmount * 1000);
+          let classDt = 'positive';
+          let classSpan = 'positive';
           if (dailySpendingAmount === 0) {
             classSpan = 'zero';
           }
           if (dailySpendingAmount === 0) {
             classDt = '';
           }
-          var available = $('<dl>', { class: 'inspector-overview-available' })
+          const available = $('<dl>', { class: 'inspector-overview-available' })
           .append($('<dt>', { class: classDt })
                   .append('Daily Spending')
                   )
@@ -107,9 +107,9 @@
         },
 
         getBalanceAmount(f) {
-          var currentMonth = moment(ynabToolKit.shared.parseSelectedMonth())
+          const currentMonth = moment(ynabToolKit.shared.parseSelectedMonth())
             .format('YYYY-MM');
-          var monthlyBudget = ynabToolKit.dailySpending.budgetView
+          const monthlyBudget = ynabToolKit.dailySpending.budgetView
             .monthlySubCategoryBudgetCalculationsCollection
             .findItemByEntityId('mcbc/' + currentMonth + '/' + f.entityId);
 

--- a/source/common/res/features/budget-daily-spending/settings.json
+++ b/source/common/res/features/budget-daily-spending/settings.json
@@ -1,0 +1,13 @@
+{
+         "name": "dailySpending",
+         "type": "checkbox",
+      "default": true,
+      "section": "budget",
+        "title": "Daily Sepnding Allowance",
+  "description": "Add the daily spending allowance to the inspector of a category budget",
+      "actions": {
+                    "true": [
+                      "injectScript", "main.js"
+                    ]
+                 }
+}

--- a/source/common/res/features/budget-daily-spending/settings.json
+++ b/source/common/res/features/budget-daily-spending/settings.json
@@ -1,7 +1,7 @@
 {
          "name": "dailySpending",
          "type": "checkbox",
-      "default": true,
+      "default": false,
       "section": "budget",
         "title": "Daily Sepnding Allowance",
   "description": "Add the daily spending allowance to the inspector of a category budget",

--- a/source/common/res/features/budget-daily-spending/settings.json
+++ b/source/common/res/features/budget-daily-spending/settings.json
@@ -3,7 +3,7 @@
          "type": "checkbox",
       "default": false,
       "section": "budget",
-        "title": "Daily Sepnding Allowance",
+        "title": "Daily Spending Allowance",
   "description": "Add the daily spending allowance to the inspector of a category budget",
       "actions": {
                     "true": [


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Enhancement:
New Feature: I always wanted this feature for YNAB, so I decided to make it in the toolkit.
This basically calculate how much money you can spend each day on a specific category based on how much balance/available left till the last day of the month.
It add the calculated daily allowance in the category inspector after the "Available" section

#### Recommended Release Notes:
