### PR TITLE
Grid header checkbox now clears on clear selection

### DIFF
--- a/source/common/res/features/accounts-clear-selection/main.js
+++ b/source/common/res/features/accounts-clear-selection/main.js
@@ -8,6 +8,8 @@
 
         try {
           accountsController.get('areChecked').setEach('isChecked', 0);
+          let gridHeader = ynabToolKit.shared.getEmberView($('.ynab-grid-header').attr('id'));
+          gridHeader.childViews[0].set('isChecked', false);
           accountsController.send('closeModal');
         } catch (e) {
           accountsController.send('closeModal');


### PR DESCRIPTION
Github Issue (if applicable): #735

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Fixes grid header checkbox not unchecking after user performs "Clear Selection" from an Account's Edit dropdown.


#### Recommended Release Notes:
