### PR TITLE
adding target-balance warning

### DIFF
--- a/sauce/features/budget/target-balance-warning/index.js
+++ b/sauce/features/budget/target-balance-warning/index.js
@@ -21,7 +21,7 @@ export default class TargetBalanceWarning extends Feature {
         const targetBalance = subCategory.get('targetBalance');
         const currencyElement = $('.budget-table-cell-available .user-data.currency', element);
 
-        if (available !== targetBalance && !currencyElement.hasClass('cautious')) {
+        if (available < targetBalance && !currencyElement.hasClass('cautious')) {
           currencyElement.addClass('cautious');
         }
       }
@@ -30,6 +30,7 @@ export default class TargetBalanceWarning extends Feature {
 
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
+
     if (changedNodes.has('budget-table-cell-available-div user-data')) {
       this.invoke();
     }

--- a/sauce/features/budget/target-balance-warning/index.js
+++ b/sauce/features/budget/target-balance-warning/index.js
@@ -1,0 +1,42 @@
+import Feature from 'core/feature';
+import * as toolkitHelper from 'helpers/toolkit';
+
+export default class TargetBalanceWarning extends Feature {
+  constructor() {
+    super();
+  }
+
+  shouldInvoke() {
+    return toolkitHelper.getCurrentRouteName().indexOf('budget') !== -1;
+  }
+
+  invoke() {
+    $('.budget-table-row.is-sub-category').each((index, element) => {
+      const emberId = element.id;
+      const viewData = toolkitHelper.getEmberView(emberId).data;
+      const { subCategory } = viewData;
+
+      if (subCategory.get('goalType') === ynab.constants.SubCategoryGoalType.TargetBalance) {
+        const available = viewData.get('available');
+        const targetBalance = subCategory.get('targetBalance');
+        const currencyElement = $('.budget-table-cell-available .user-data.currency', element);
+
+        if (available !== targetBalance && !currencyElement.hasClass('cautious')) {
+          currencyElement.addClass('cautious');
+        }
+      }
+    });
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+    if (changedNodes.has('budget-table-cell-available-div user-data')) {
+      this.invoke();
+    }
+  }
+
+  onRouteChanged() {
+    if (!this.shouldInvoke()) return;
+    this.invoke();
+  }
+}

--- a/sauce/features/budget/target-balance-warning/settings.js
+++ b/sauce/features/budget/target-balance-warning/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'TargetBalanceWarning',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Warn When Target Balance is Not Reached',
+  description: 'Will highlight balances of categories with Target Balances that have not yet been met.'
+};


### PR DESCRIPTION
Github Issue (if applicable): n/a

Trello Link (if applicable): https://trello.com/c/KsoIeNLc

#### Explanation of Bugfix/Feature/Enhancement:
Super simple feature to highlight target balance goals with `cautious` when they are unmet.


#### Recommended Release Notes:
Added option to highlight category balances when they do not reach your Target Balance Goals.