### PR TITLE
Display Target Goal Amount

### DIFF
--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -39,23 +39,23 @@ export default class DisplayTargetGoalAmount extends Feature {
       if (goalType === 'MF') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(monthlyFunding));
         if (budgetedAmount <= monthlyFunding) {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#65bb5f' });
         } else {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'red' });
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
         }
       } else if (goalType === 'TB') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalance));
         if (budgetedAmount <= targetBalance) {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#65bb5f' });
         } else {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'red' });
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
         }
       } else if (goalType === 'TBD') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalanceDate));
         if (budgetedAmount <= targetBalanceDate) {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#65bb5f' });
         } else {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'red' });
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
         }
       }
     });

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -21,8 +21,7 @@ export default class DisplayTargetGoalAmount extends Feature {
 
     $('.budget-table-row.is-sub-category li.budget-table-cell-name').append(
       $('<div>', { class: 'budget-table-cell-goal' }).css({
-        background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)', position: 'absolute', 'font-size': '80%', color: 'gray',
-        'padding-left': '.75em', 'padding-right': '1px', 'line-height': '2.55em'
+        background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)', position: 'absolute', 'font-size': '80%', 'padding-left': '.75em', 'padding-right': '1px', 'line-height': '2.55em'
       })
     );
 
@@ -30,17 +29,34 @@ export default class DisplayTargetGoalAmount extends Feature {
       const emberId = element.id;
       const viewData = toolkitHelper.getEmberView(emberId).data;
       const { subCategory } = viewData;
+      const { monthlySubCategoryBudget } = viewData;
       const { monthlySubCategoryBudgetCalculation } = viewData;
       const goalType = subCategory.get('goalType');
       const monthlyFunding = subCategory.get('monthlyFunding');
       const targetBalance = subCategory.get('targetBalance');
       const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
+      const budgetedAmount = monthlySubCategoryBudget.get('budgeted');
       if (goalType === 'MF') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(monthlyFunding));
+        if (budgetedAmount <= monthlyFunding) {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
+        } else {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'red' });
+        }
       } else if (goalType === 'TB') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalance));
+        if (budgetedAmount <= targetBalance) {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
+        } else {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'red' });
+        }
       } else if (goalType === 'TBD') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalanceDate));
+        if (budgetedAmount <= targetBalanceDate) {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
+        } else {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'red' });
+        }
       }
     });
   }
@@ -52,14 +68,11 @@ export default class DisplayTargetGoalAmount extends Feature {
       this.invoke();
     }
 
-    if (changedNodes.has('budget-table-row is-sub-category is-checked')
+    if (changedNodes.has('budget-table-row is-sub-category') || changedNodes.has('budget-table-row is-sub-category is-checked')
       || changedNodes.has('budget-table-cell-goal')) {
       $('.budget-table-row.is-sub-category li.budget-table-cell-name .budget-table-cell-goal').css({
-        background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)', color: 'gray'
-      });
-      $('.budget-table-row.is-checked li.budget-table-cell-name .budget-table-cell-goal').css({
-        background: '#005a6e', color: '#fff'
-      });
+        background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)' });
+      $('.budget-table-row.is-checked li.budget-table-cell-name .budget-table-cell-goal').css({ background: '#005a6e' });
     }
   }
 

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -17,19 +17,25 @@ export default class DisplayTargetGoalAmount extends Feature {
       const emberId = element.id;
       const viewData = toolkitHelper.getEmberView(emberId).data;
       const { subCategory } = viewData;
+      const { monthlySubCategoryBudgetCalculation } = viewData;
+      const goalType = subCategory.get('goalType');
       const monthlyFunding = subCategory.get('monthlyFunding');
       const targetBalance = subCategory.get('targetBalance');
-      if (targetBalance === 0 || targetBalance === null) {
+      const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
+      if (goalType === 'MF') {
         $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + monthlyFunding / 1000);
-      } else if (monthlyFunding === 0 || monthlyFunding === null) {
+      } else if (goalType === 'TB') {
         $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + targetBalance / 1000);
+      } else if (goalType === 'TBD') {
+        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + targetBalanceDate / 1000);
       }
     });
   }
 
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
-    if (changedNodes.has('fieldset') && changedNodes.has('budget-inspector-goals')) {
+    console.log(changedNodes);
+    if (changedNodes.has('fieldset') && changedNodes.has('budget-inspector-goals') || changedNodes.has('budget-table-cell-goal')) {
       $('.budget-table-cell-goal').remove();
       this.invoke();
     }

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -25,11 +25,11 @@ export default class DisplayTargetGoalAmount extends Feature {
       const targetBalance = subCategory.get('targetBalance');
       const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
       if (goalType === 'MF') {
-        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + ynab.YNABSharedLib.currencyFormatter.format(monthlyFunding));
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(monthlyFunding));
       } else if (goalType === 'TB') {
-        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + ynab.YNABSharedLib.currencyFormatter.format(targetBalance));
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalance));
       } else if (goalType === 'TBD') {
-        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + ynab.YNABSharedLib.currencyFormatter.format(targetBalanceDate));
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalanceDate));
       }
     });
   }

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -1,0 +1,48 @@
+import Feature from 'core/feature';
+import * as toolkitHelper from 'helpers/toolkit';
+
+export default class DisplayTargetGoalAmount extends Feature {
+  constructor() {
+    super();
+  }
+
+  shouldInvoke() {
+    return toolkitHelper.getCurrentRouteName().indexOf('budget') !== -1;
+  }
+
+  invoke() {
+    // var i = 1;
+    $('.budget-table-header .budget-table-cell-name').after('<li class=\'budget-table-cell-goal\' style=\'font-size: .75em; text-align: right;\'>GOAL</li>');
+    $('.budget-table-row.is-master-category li.budget-table-cell-name').after('<li class=\'budget-table-cell-goal\' style=\'text-align: right;\'></li>');
+    $('.budget-table-row.is-sub-category li.budget-table-cell-name').after('<li class=\'budget-table-cell-goal\' style=\'text-align: right; font-size: 80%; color: gray;\'></li>');
+    $('.budget-table-row.is-sub-category').each((index, element) => {
+      const emberId = element.id;
+      const viewData = toolkitHelper.getEmberView(emberId).data;
+      const { subCategory } = viewData;
+      const monthlyFunding = subCategory.get('monthlyFunding');
+      const targetBalance = subCategory.get('targetBalance');
+      if (!monthlyFunding && !targetBalance) {
+        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$0.00');
+      } else if (monthlyFunding === 0) {
+        // console.log(i + ': ' + subCategory.get('name') + subCategory.get('targetBalance') / 1000); i++;
+        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + targetBalance / 1000);
+      } else if (targetBalance === 0) {
+        // console.log(i + ': ' + subCategory.get('name') + subCategory.get('monthlyFunding') / 1000); i++;
+        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + monthlyFunding / 1000);
+      }
+    });
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+    if (changedNodes.has('fieldset') && changedNodes.has('budget-inspector-goals')) {
+      $('.budget-table-cell-goal').remove();
+      this.invoke();
+    }
+  }
+
+  onRouteChanged() {
+    if (!this.shouldInvoke()) return;
+    this.invoke();
+  }
+}

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -39,21 +39,21 @@ export default class DisplayTargetGoalAmount extends Feature {
       if (goalType === 'MF') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(monthlyFunding));
         if (budgetedAmount <= monthlyFunding) {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#65bb5f' });
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
         } else {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
         }
       } else if (goalType === 'TB') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalance));
         if (budgetedAmount <= targetBalance) {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#65bb5f' });
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
         } else {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
         }
       } else if (goalType === 'TBD') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalanceDate));
         if (budgetedAmount <= targetBalanceDate) {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#65bb5f' });
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
         } else {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
         }

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -11,9 +11,7 @@ export default class DisplayTargetGoalAmount extends Feature {
   }
 
   invoke() {
-    // var i = 1;
     $('.budget-table-header .budget-table-cell-name').after('<li class=\'budget-table-cell-goal\' style=\'font-size: .75em; text-align: right;\'>GOAL</li>');
-    $('.budget-table-row.is-master-category li.budget-table-cell-name').after('<li class=\'budget-table-cell-goal\' style=\'text-align: right;\'></li>');
     $('.budget-table-row.is-sub-category li.budget-table-cell-name').after('<li class=\'budget-table-cell-goal\' style=\'text-align: right; font-size: 80%; color: gray;\'></li>');
     $('.budget-table-row.is-sub-category').each((index, element) => {
       const emberId = element.id;
@@ -21,14 +19,10 @@ export default class DisplayTargetGoalAmount extends Feature {
       const { subCategory } = viewData;
       const monthlyFunding = subCategory.get('monthlyFunding');
       const targetBalance = subCategory.get('targetBalance');
-      if (!monthlyFunding && !targetBalance) {
-        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$0.00');
-      } else if (monthlyFunding === 0) {
-        // console.log(i + ': ' + subCategory.get('name') + subCategory.get('targetBalance') / 1000); i++;
-        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + targetBalance / 1000);
-      } else if (targetBalance === 0) {
-        // console.log(i + ': ' + subCategory.get('name') + subCategory.get('monthlyFunding') / 1000); i++;
+      if (targetBalance === 0 || targetBalance === null) {
         $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + monthlyFunding / 1000);
+      } else if (monthlyFunding === 0 || monthlyFunding === null) {
+        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + targetBalance / 1000);
       }
     });
   }

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -14,7 +14,7 @@ export default class DisplayTargetGoalAmount extends Feature {
     $('.budget-table-header .budget-table-cell-name').css('position', 'relative');
     $('.budget-table-row.is-sub-category li.budget-table-cell-name').css('position', 'relative');
     $('.budget-table-header .budget-table-cell-name').append('<div class=\'budget-table-cell-goal\' style=\'position: absolute; right: 0; top: 6px;\'>GOAL</div>');
-    $('.budget-table-row.is-sub-category li.budget-table-cell-name').append('<div class=\'budget-table-cell-goal\' style=\'background: -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 30%); position: absolute; font-size: 80%; color: gray; padding-left: 2em; line-height: 2.55em;\'></div>');
+    $('.budget-table-row.is-sub-category li.budget-table-cell-name').append('<div class=\'budget-table-cell-goal\' style=\'background: -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%); position: absolute; font-size: 80%; color: gray; padding-left: .75em; padding-right: 1px; line-height: 2.55em;\'></div>');
     $('.budget-table-row.is-sub-category').each((index, element) => {
       const emberId = element.id;
       const viewData = toolkitHelper.getEmberView(emberId).data;
@@ -25,18 +25,19 @@ export default class DisplayTargetGoalAmount extends Feature {
       const targetBalance = subCategory.get('targetBalance');
       const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
       if (goalType === 'MF') {
-        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + monthlyFunding / 1000);
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + ynab.YNABSharedLib.currencyFormatter.format(monthlyFunding));
       } else if (goalType === 'TB') {
-        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + targetBalance / 1000);
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + ynab.YNABSharedLib.currencyFormatter.format(targetBalance));
       } else if (goalType === 'TBD') {
-        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + targetBalanceDate / 1000);
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + ynab.YNABSharedLib.currencyFormatter.format(targetBalanceDate));
       }
     });
   }
 
   observe(changedNodes) {
+    console.log(changedNodes);
     if (!this.shouldInvoke()) return;
-    if (changedNodes.has('fieldset') && changedNodes.has('budget-inspector-goals')) {
+    if (changedNodes.has('budget-table-cell-budgeted')) {
       $('.budget-table-cell-goal').remove();
       this.invoke();
     }

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -11,8 +11,10 @@ export default class DisplayTargetGoalAmount extends Feature {
   }
 
   invoke() {
-    $('.budget-table-header .budget-table-cell-name').after('<li class=\'budget-table-cell-goal\' style=\'font-size: .75em; text-align: right;\'>GOAL</li>');
-    $('.budget-table-row.is-sub-category li.budget-table-cell-name').after('<li class=\'budget-table-cell-goal\' style=\'text-align: right; font-size: 80%; color: gray;\'></li>');
+    $('.budget-table-header .budget-table-cell-name').css('position', 'relative');
+    $('.budget-table-row.is-sub-category li.budget-table-cell-name').css('position', 'relative');
+    $('.budget-table-header .budget-table-cell-name').append('<div class=\'budget-table-cell-goal\' style=\'position: absolute; right: 0; top: 6px;\'>GOAL</div>');
+    $('.budget-table-row.is-sub-category li.budget-table-cell-name').append('<div class=\'budget-table-cell-goal\' style=\'background: -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 30%); position: absolute; font-size: 80%; color: gray; padding-left: 2em; line-height: 2.55em;\'></div>');
     $('.budget-table-row.is-sub-category').each((index, element) => {
       const emberId = element.id;
       const viewData = toolkitHelper.getEmberView(emberId).data;
@@ -23,19 +25,18 @@ export default class DisplayTargetGoalAmount extends Feature {
       const targetBalance = subCategory.get('targetBalance');
       const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
       if (goalType === 'MF') {
-        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + monthlyFunding / 1000);
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + monthlyFunding / 1000);
       } else if (goalType === 'TB') {
-        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + targetBalance / 1000);
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + targetBalance / 1000);
       } else if (goalType === 'TBD') {
-        $('#' + emberId + '.budget-table-row.is-sub-category li.budget-table-cell-goal').text('$' + targetBalanceDate / 1000);
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text('$' + targetBalanceDate / 1000);
       }
     });
   }
 
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
-    console.log(changedNodes);
-    if (changedNodes.has('fieldset') && changedNodes.has('budget-inspector-goals') || changedNodes.has('budget-table-cell-goal')) {
+    if (changedNodes.has('fieldset') && changedNodes.has('budget-inspector-goals')) {
       $('.budget-table-cell-goal').remove();
       this.invoke();
     }

--- a/sauce/features/budget/display-goal-amount/settings.js
+++ b/sauce/features/budget/display-goal-amount/settings.js
@@ -3,6 +3,6 @@ module.exports = {
   type: 'checkbox',
   default: false,
   section: 'budget',
-  title: 'Display Target Goal Amount',
-  description: 'Displays the target goal amount for every category with a goal.'
+  title: 'Display Target Goal Amount And Overspend Warning',
+  description: 'Displays the target goal amount for every category with a goal, and warns you when you spend over your goal.'
 };

--- a/sauce/features/budget/display-goal-amount/settings.js
+++ b/sauce/features/budget/display-goal-amount/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'DisplayTargetGoalAmount',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Display Target Goal Amount',
+  description: 'Displays the target goal amount for every category with a goal.'
+};


### PR DESCRIPTION
# Feature Request
Firstly my apologies if I have done this wrong. I am new to contributing, but am keen to help.

This feature is for those who use the budget subcategory name to show the target goal amount for each category. 

![image](https://cloud.githubusercontent.com/assets/2720368/25369149/f6fb7e92-29d5-11e7-8da8-a8c684aa5089.png)

This is ok, however when you edit the goal amount, you then have to edit it again in the budget subcategory name.

If anybody is interested, I have created the feature and created a pull request.

When you have budgeted over a target goal amount it turns red, indicating you need to stop spending, or amend your goal.

I have also made it work with the existing Add Goals Indication feature.

![image](https://cloud.githubusercontent.com/assets/2720368/25561807/73660dc2-2dc7-11e7-9f29-85cac9ce4165.png)

