### PR TITLE
Display goal amount feature

### DIFF
--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -36,23 +36,30 @@ export default class DisplayTargetGoalAmount extends Feature {
       const targetBalance = subCategory.get('targetBalance');
       const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
       const budgetedAmount = monthlySubCategoryBudget.get('budgeted');
+      const activity = Math.abs(monthlySubCategoryBudgetCalculation.get('budgetedCashOutflows'));
       if (goalType === 'MF') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(monthlyFunding));
-        if (budgetedAmount <= monthlyFunding) {
+        if (activity === monthlyFunding && activity === budgetedAmount) {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#00b300' });
+        } else if (activity < monthlyFunding) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
         } else {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
         }
       } else if (goalType === 'TB') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalance));
-        if (budgetedAmount <= targetBalance) {
+        if (activity === targetBalance && activity === budgetedAmount) {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#00b300' });
+        } else if (activity < targetBalance) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
         } else {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
         }
       } else if (goalType === 'TBD') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalanceDate));
-        if (budgetedAmount <= targetBalanceDate) {
+        if (activity === targetBalanceDate && activity === budgetedAmount) {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#00b300' });
+        } else if (activity < targetBalanceDate) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
         } else {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
@@ -67,8 +74,9 @@ export default class DisplayTargetGoalAmount extends Feature {
       $('.budget-table-cell-goal').remove();
       this.invoke();
     }
-
-    if (changedNodes.has('budget-table-row is-sub-category') || changedNodes.has('budget-table-row is-sub-category is-checked') || changedNodes.has('budget-table-cell-goal')) {
+    console.log(changedNodes);
+    if (changedNodes.has('budget-table-row is-sub-category') || changedNodes.has('budget-table-row is-sub-category is-checked') || changedNodes.has('budget-table-cell-goal currency')) {
+      console.log('yes');
       $('.budget-table-row.is-sub-category li.budget-table-cell-name .budget-table-cell-goal').css({
         background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)' });
       $('.budget-table-row.is-checked li.budget-table-cell-name .budget-table-cell-goal').css({ background: '#005a6e' });

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -1,0 +1,82 @@
+import Feature from 'core/feature';
+import * as toolkitHelper from 'helpers/toolkit';
+
+export default class DisplayTargetGoalAmount extends Feature {
+  constructor() {
+    super();
+  }
+
+  shouldInvoke() {
+    return toolkitHelper.getCurrentRouteName().indexOf('budget') !== -1;
+  }
+
+  invoke() {
+    $('.budget-table-header .budget-table-cell-name').css('position', 'relative');
+    $('.budget-table-row.is-sub-category li.budget-table-cell-name').css('position', 'relative');
+
+    $('.budget-table-header .budget-table-cell-name').append(
+      $('<div>', { class: 'budget-table-cell-goal' }).css(
+        { position: 'absolute', right: 0, top: '6px' }).append('GOAL')
+    );
+
+    $('.budget-table-row.is-sub-category li.budget-table-cell-name').append(
+      $('<div>', { class: 'budget-table-cell-goal' }).css({
+        background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)', position: 'absolute', 'font-size': '80%', 'padding-left': '.75em', 'padding-right': '1px', 'line-height': '2.55em'
+      })
+    );
+
+    $('.budget-table-row.is-sub-category').each((index, element) => {
+      const emberId = element.id;
+      const viewData = toolkitHelper.getEmberView(emberId).data;
+      const { subCategory } = viewData;
+      const { monthlySubCategoryBudget } = viewData;
+      const { monthlySubCategoryBudgetCalculation } = viewData;
+      const goalType = subCategory.get('goalType');
+      const monthlyFunding = subCategory.get('monthlyFunding');
+      const targetBalance = subCategory.get('targetBalance');
+      const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
+      const budgetedAmount = monthlySubCategoryBudget.get('budgeted');
+      if (goalType === 'MF') {
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(monthlyFunding));
+        if (budgetedAmount <= monthlyFunding) {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
+        } else {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
+        }
+      } else if (goalType === 'TB') {
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalance));
+        if (budgetedAmount <= targetBalance) {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
+        } else {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
+        }
+      } else if (goalType === 'TBD') {
+        $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalanceDate));
+        if (budgetedAmount <= targetBalanceDate) {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
+        } else {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
+        }
+      }
+    });
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+    if (changedNodes.has('budget-table-cell-budgeted')) {
+      $('.budget-table-cell-goal').remove();
+      this.invoke();
+    }
+
+    if (changedNodes.has('budget-table-row is-sub-category') || changedNodes.has('budget-table-row is-sub-category is-checked') || changedNodes.has('budget-table-cell-goal')) {
+      $('.budget-table-row.is-sub-category li.budget-table-cell-name .budget-table-cell-goal').css({
+        background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)' });
+      $('.budget-table-row.is-checked li.budget-table-cell-name .budget-table-cell-goal').css({ background: '#005a6e' });
+    }
+  }
+
+  onRouteChanged() {
+    if (!this.shouldInvoke()) return;
+    this.invoke();
+  }
+}

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -36,33 +36,33 @@ export default class DisplayTargetGoalAmount extends Feature {
       const targetBalance = subCategory.get('targetBalance');
       const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
       const budgetedAmount = monthlySubCategoryBudget.get('budgeted');
-      const activity = Math.abs(monthlySubCategoryBudgetCalculation.get('budgetedCashOutflows'));
+      const activity = Math.abs(monthlySubCategoryBudgetCalculation.get('cashOutflows'));
       if (goalType === 'MF') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(monthlyFunding));
-        if (activity === monthlyFunding && activity === budgetedAmount) {
+        if (activity <= monthlyFunding && budgetedAmount >= monthlyFunding) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#00b300' });
-        } else if (activity < monthlyFunding) {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
-        } else {
+        } else if (activity > monthlyFunding) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
+        } else {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
         }
       } else if (goalType === 'TB') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalance));
-        if (activity === targetBalance && activity === budgetedAmount) {
+        if (activity <= targetBalance && budgetedAmount >= targetBalance) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#00b300' });
-        } else if (activity < targetBalance) {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
-        } else {
+        } else if (activity > targetBalance) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
+        } else {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
         }
       } else if (goalType === 'TBD') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalanceDate));
-        if (activity === targetBalanceDate && activity === budgetedAmount) {
+        if (activity <= targetBalanceDate && budgetedAmount >= targetBalanceDate) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#00b300' });
-        } else if (activity < targetBalanceDate) {
-          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
-        } else {
+        } else if (activity > targetBalanceDate) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
+        } else {
+          $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: 'grey' });
         }
       }
     });
@@ -74,9 +74,7 @@ export default class DisplayTargetGoalAmount extends Feature {
       $('.budget-table-cell-goal').remove();
       this.invoke();
     }
-    console.log(changedNodes);
     if (changedNodes.has('budget-table-row is-sub-category') || changedNodes.has('budget-table-row is-sub-category is-checked') || changedNodes.has('budget-table-cell-goal currency')) {
-      console.log('yes');
       $('.budget-table-row.is-sub-category li.budget-table-cell-name .budget-table-cell-goal').css({
         background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)' });
       $('.budget-table-row.is-checked li.budget-table-cell-name .budget-table-cell-goal').css({ background: '#005a6e' });

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -20,7 +20,7 @@ export default class DisplayTargetGoalAmount extends Feature {
     );
 
     $('.budget-table-row.is-sub-category li.budget-table-cell-name').append(
-      $('<div>', { class: 'budget-table-cell-goal' }).css({
+      $('<div>', { class: 'budget-table-cell-goal currency' }).css({
         background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)', position: 'absolute', 'font-size': '80%', 'padding-left': '.75em', 'padding-right': '1px', 'line-height': '2.55em'
       })
     );

--- a/sauce/features/budget/display-goal-amount/settings.js
+++ b/sauce/features/budget/display-goal-amount/settings.js
@@ -3,6 +3,6 @@ module.exports = {
   type: 'checkbox',
   default: false,
   section: 'budget',
-  title: 'Display Target Goal Amount And Overspend Warning',
-  description: 'Displays the target goal amount for every category with a goal, and warns you when you spend over your goal.'
+  title: 'Display Target Goal Amount And Overbudget Warning',
+  description: 'Adds a \'Goal\' column which displays the target goal amount for every category with a goal, and a warning in red if you have budgeted beyond your goal.'
 };

--- a/sauce/features/budget/display-goal-amount/settings.js
+++ b/sauce/features/budget/display-goal-amount/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'DisplayTargetGoalAmount',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Display Target Goal Amount And Overspend Warning',
+  description: 'Displays the target goal amount for every category with a goal, and warns you when you spend over your goal.'
+};


### PR DESCRIPTION
Sorry, I managed to remove the fork and orphan the old pull request.

# Feature Request
Firstly my apologies if I have done this wrong. I am new to contributing, but am keen to help.

This feature is for those who use the budget subcategory name to show the target goal amount for each category. 

![image](https://cloud.githubusercontent.com/assets/2720368/25369149/f6fb7e92-29d5-11e7-8da8-a8c684aa5089.png)

This is ok, however when you edit the goal amount, you then have to edit it again in the budget subcategory name.

If anybody is interested, I have created the feature and created a pull request.

When you have budgeted over a target goal amount it turns red, indicating you need to stop spending, or amend your goal.

I have also made it work with the existing Add Goals Indication feature.

![image](https://cloud.githubusercontent.com/assets/2720368/25561807/73660dc2-2dc7-11e7-9f29-85cac9ce4165.png)

