### PR TITLE
Fix import notification

### DIFF
--- a/source/common/res/features/import-notification/main.js
+++ b/source/common/res/features/import-notification/main.js
@@ -1,11 +1,12 @@
 (function poll() {
-  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true && typeof ynab.utilities.TransactionImportUtilities !== 'undefined') {
+  if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true && typeof ynab.managers.TransactionImporter !== 'undefined') {
     ynabToolKit.importNotification = function () {
       $('.import-notification').remove();
       $('.nav-account-row').each(function (index, row) {
         var account = ynabToolKit.shared.getEmberView($(row).attr('id')).get('data');
         if (account.getDirectConnectEnabled()) {
-          var transactions = ynab.utilities.TransactionImportUtilities.getImportTransactionsForAccount(account);
+          var importStartDate = ynab.managers.TransactionImporter.getImportStartDateForAccount(account);
+          var transactions = ynab.YNABSharedLib.defaultInstance.entityManager.getPendingDirectImportTransactionsByAccountId(account.entityId, importStartDate);
           if (transactions.length >= 1) {
             $(row).find('.nav-account-notification').append('<a class="notification import-notification">' + transactions.length + '</a>');
           }


### PR DESCRIPTION
Github Issue (if applicable): #775

#### Explanation of Bugfix/Feature/Enhancement:

YNAB removed `ynab.utilities.TransactionImportUtilities` that this feature was relying on. This commit updates the feature so it uses `getPendingDirectImportTransactionsByAccountId` on the `entityManager` instead (which is how YANB currently retrives the import count).

This idea is taken from YNAB (minified) source:

    n.prototype.getImportTransactionsForAccount = function(e, t) {
        void 0 === t && (t = !1);
        var n = null;
        t || (n = this.getImportStartDateForAccount(e));
        var r = this._entityManager.
          getPendingDirectImportTransactionsByAccountId(
            e.getEntityId(), n
          );
        return r
    }

#### Recommended Release Notes:

Fix problem with Import Notifications functionality.