### PR TITLE
BUGFIX: Cautious flag doesn't play well with the positive class.

### DIFF
--- a/sauce/features/budget/target-balance-warning/index.js
+++ b/sauce/features/budget/target-balance-warning/index.js
@@ -22,6 +22,10 @@ export default class TargetBalanceWarning extends Feature {
         const currencyElement = $('.budget-table-cell-available .user-data.currency', element);
 
         if (available < targetBalance && !currencyElement.hasClass('cautious')) {
+          if (currencyElement.hasClass('positive')) {
+            currencyElement.removeClass('positive');
+          }
+
           currencyElement.addClass('cautious');
         }
       }


### PR DESCRIPTION
Github Issue (if applicable): #769

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Highlight all positive green and warn on target balance not met were conflicting because `.positive` and `.cautious` don't play well together on the same element. Now we check if the `.positive` class is on the element and remove it when adding `.cautious`.


#### Recommended Release Notes:
