### PR TITLE
BUGFIX: Highlight negatives red wasn't playing well with other css features.

### DIFF
--- a/source/common/res/features/highlight-negatives-negative/main.css
+++ b/source/common/res/features/highlight-negatives-negative/main.css
@@ -1,9 +1,9 @@
 /* row */
 .budget-table-row.toolkit-row-availablenegative .budget-table-cell-available .cautious {
-	background: #d33c2d;
+	background: #d33c2d !important;
 }
 .budget-table-row.toolkit-row-availablenegative .budget-table-cell-available .cautious:hover {
-	background: #b43326;
+	background: #b43326 !important;
 }
 
 /* inspector */


### PR DESCRIPTION
Github Issue (if applicable): #626

#### Explanation of Bugfix/Feature/Enhancement:
Other features had `!important` on their css which was over ruling the generic class for this feature.


#### Recommended Release Notes:
- Fixed a bug where negative balances weren't getting highlighted red even though that feature was enabled.