### PR TITLE
Fix capitalization of ynabToolKit.js in source/common/main.js

### DIFF
--- a/source/common/main.js
+++ b/source/common/main.js
@@ -104,8 +104,8 @@ Promise.all(optionsPromises).then(function () {
   /* Load this to setup behaviors when the DOM updates and shared functions */
   injectScript('res/features/act-on-change/main.js');
 
-  /* Load the ynabToolKit bundle */
-  injectScript('res/features/ynabToolKit.js');
+  /* Load the ynabToolkit bundle */
+  injectScript('res/features/ynabToolkit.js');
 
   ensureDefaultsAreSet().then(applySettingsToDom);
 });


### PR DESCRIPTION
Github Issue (if applicable): N/A

Trello Link (if applicable): N/A

Forum Link (if applicable): N/A

#### Explanation of Bugfix/Feature/Enhancement:
TL;DR: ynabToolKit.js appears to have been mis-capitalized along with the other instances of ToolKit.

So, it's been a while since I've been involved here, and after I updated my git checkout to see the latest changes, I saw there was the Goal Display feature, and got super excited! Unfortunately, I enabled it, and nothing happened! I am testing on a Linux machine, which has case-sensitive filesystems, and so in the debug console I found that it wasn't loading the toolkit.js. Don't know why that one was giving me trouble, as all the other features loaded fine, but once I lowercased the K and rebuilt, it loaded that new feature wonderfully!

#### Recommended Release Notes:
Fixed loading of ynabToolkit.js on case-sensitive filesystems