### PR TITLE
build the sauce directory before running babel

### DIFF
--- a/build
+++ b/build
@@ -20,14 +20,14 @@ npm run gen-featureIndex --silent || exit
 echo "[   INFO] Checking legacy code style with ESLint..."
 npm run legacy-eslint --silent || exit
 
+# Run webpack to grab all new framework features
+echo "[   INFO] Webpacking new framework..."
+npm run webpack --silent || exit
+
 # Transpile the source/ directory, putting the files in src/ which is where Kango expects to see them.
 echo "[   INFO] Transpiling legacy code with Babel on ES2015 preset..."
 rm -rf src
 npm run legacy-babel --silent || exit
-
-# Run webpack to grab all new framework features
-echo "[   INFO] Webpacking new framework..."
-npm run webpack --silent || exit
 
 # Copy any non JS files across that babel didn't bring with it. Ignore existing files we just transpiled.
 rsync -r --ignore-existing source/* src/

--- a/build.bat
+++ b/build.bat
@@ -15,14 +15,14 @@ call npm run gen-featureIndex --silent || goto :errexit
 echo [   INFO] Checking code style with ESLint...
 call npm run legacy-eslint --silent || goto :errexit
 
+rem Run webpack to grab all new framework features
+echo [   INFO] Webpacking new framework...
+call npm run webpack --silent || goto :errexit
+
 rem Transpile the source/ directory, putting the files in src/ which is where Kango expects to see them.
 echo [   INFO] Transpiling code with Babel on ES2015 preset...
 rem rd /s /q src
 call npm run legacy-babel --silent || goto :errexit
-
-rem Run webpack to grab all new framework features
-echo [   INFO] Webpacking new framework...
-call npm run webpack --silent || goto :errexit
 
 rem Copy any non JS files across that babel didn't bring with it. Ignore existing files we just transpiled.
 echo [   INFO] Copying non JS files...


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Enhancement:
Webpack was running after babel and the bundle wasn't getting pulled over like I thought it was in the rsync. Running webpack first will get babel to bring the file over for us! :yeycloud:


#### Recommended Release Notes:
