### PR TITLE
forgot to rename the class in the css file

### DIFF
--- a/sauce/features/accounts/adjustable-column-widths/index.js
+++ b/sauce/features/accounts/adjustable-column-widths/index.js
@@ -123,6 +123,10 @@ export class AdjustableColumnWidths extends Feature {
         return;
       }
 
+      if ($(`.${resizableClass} .toolkit-draggable`, '.ynab-grid-header').length) {
+        return;
+      }
+
       $(`.${resizableClass}`, '.ynab-grid-header')
         .click((event) => {
           if (this.elementWasDragged) {
@@ -136,7 +140,6 @@ export class AdjustableColumnWidths extends Feature {
           $('<div class="toolkit-draggable"></div>')
             .click((event) => event.stopPropagation())
             .mousedown((event) => {
-              console.log('mousedown', resizableClass);
               this.isMouseDown = true;
               this.currentX = event.clientX;
               this.currentResizableClass = resizableClass;

--- a/sauce/features/accounts/running-balance/index.css
+++ b/sauce/features/accounts/running-balance/index.css
@@ -1,9 +1,9 @@
-.ynab-toolkit-grid-cell-running-balance {
+.ynab-grid-cell-toolkit-running-balance {
 	text-align: right;
 	width: 10%;
 }
 
-.ynab-toolkit-grid-cell-running-balance span.negative {
+.ynab-grid-cell-toolkit-running-balance span.negative {
 	color: #d33c2d;
 	font-weight: bold;
 }


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Enhancement:
Forgot to change the classname in the css file which was making running balance column pretty big...also added a check so we don't double add the draggable elements.

I tried doing:

```
extends Feature {
   elementWasDragged = false
   ...
```

and removing the constructor but eslint didn't seem to like that? I thought you could only do this in TypeScript?