### PR TITLE
add select option to display goal amount in budget with or without overbudget warning

### DIFF
--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -3,7 +3,7 @@ import * as toolkitHelper from 'helpers/toolkit';
 
 export class DisplayTargetGoalAmount extends Feature {
   shouldInvoke() {
-    return toolkitHelper.getCurrentRouteName().indexOf('budget') !== -1;
+    return toolkitHelper.getCurrentRouteName().indexOf('budget') !== -1 && this.settings.enabled !== '0';
   }
 
   invoke() {
@@ -34,23 +34,23 @@ export class DisplayTargetGoalAmount extends Feature {
       const budgetedAmount = monthlySubCategoryBudget.get('budgeted');
       if (goalType === 'MF') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(monthlyFunding));
-        if (budgetedAmount > monthlyFunding) {
+        if (budgetedAmount > monthlyFunding && this.settings.enabled === '1') {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
-        } else if (budgetedAmount === monthlyFunding) {
+        } else if (budgetedAmount >= monthlyFunding) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#00b300' });
         }
       } else if (goalType === 'TB') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalance));
-        if (budgetedAmount > targetBalance) {
+        if (budgetedAmount > targetBalance && this.settings.enabled === '1') {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
-        } else if (budgetedAmount === targetBalance) {
+        } else if (budgetedAmount >= targetBalance) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#00b300' });
         }
       } else if (goalType === 'TBD') {
         $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').text(toolkitHelper.formatCurrency(targetBalanceDate));
-        if (budgetedAmount > targetBalanceDate) {
+        if (budgetedAmount > targetBalanceDate && this.settings.enabled === '1') {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#ff4545' });
-        } else if (budgetedAmount === targetBalanceDate) {
+        } else if (budgetedAmount >= targetBalanceDate) {
           $('#' + emberId + '.budget-table-row.is-sub-category div.budget-table-cell-goal').css({ color: '#00b300' });
         }
       }

--- a/sauce/features/budget/display-goal-amount/settings.js
+++ b/sauce/features/budget/display-goal-amount/settings.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: 'DisplayTargetGoalAmount',
   type: 'select',
-  default: false,
+  default: '0',
   section: 'budget',
   title: 'Display Target Goal Amount And Overbudget Warning',
   description: 'Adds a \'Goal\' column which displays the target goal amount for every category with a goal, and a warning in red if you have budgeted beyond your goal.',

--- a/sauce/features/budget/display-goal-amount/settings.js
+++ b/sauce/features/budget/display-goal-amount/settings.js
@@ -1,8 +1,13 @@
 module.exports = {
   name: 'DisplayTargetGoalAmount',
-  type: 'checkbox',
+  type: 'select',
   default: false,
   section: 'budget',
   title: 'Display Target Goal Amount And Overbudget Warning',
-  description: 'Adds a \'Goal\' column which displays the target goal amount for every category with a goal, and a warning in red if you have budgeted beyond your goal.'
+  description: 'Adds a \'Goal\' column which displays the target goal amount for every category with a goal, and a warning in red if you have budgeted beyond your goal.',
+  options: [
+    { name: 'Do not display goal amount (default)', value: '0' },
+    { name: 'Display goal amount and warn of overbudget with red', value: '1' },
+    { name: 'Display goal amount but show overbudget as green', value: '2' }
+  ]
 };


### PR DESCRIPTION
Github Issue (if applicable): #827

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Converts setting from checkbox to select to support two different features: 1) display "overbudgeted" goals red, and 2) display "exceeded" goal in green. See explanation in #827 


#### Recommended Release Notes:
Made display goal warning of overbudgeting optional