### PR TITLE
Show pacing in days ahead/behind schedule

### DIFF
--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -151,8 +151,6 @@
                   const showDays = ynabToolKit.options.pacing === '2';
                   const showIndicator = ynabToolKit.options.pacing === '3';
 
-                  var temperature = (pace > 1) ? 'cautious' : 'positive';
-
                   var deemphasized = masterCategory.get('isDebtPaymentCategory') || $.inArray(masterCategoryDisplayName + '_' + subCategoryDisplayName, deemphasizedCategories) >= 0;
                   var display = Math.round((budgeted * timeSpent() - activity) * 1000);
                   const displayInDays = getDaysAheadOfSchedule(display, budgeted, activity);
@@ -162,12 +160,20 @@
                     : ynabToolKit.shared.formatCurrency(display, true);
 
                   const tooltip = getTooltip(display, displayInDays, transactionCount, deemphasized);
-
-                  $(this).append('<li class="budget-table-cell-available budget-table-cell-pacing"><span title="' + tooltip +
-                               '" class="budget-table-cell-pacing-display currency ' + temperature +
-                               (deemphasized ? ' deemphasized' : '') + (showIndicator ? ' indicator' : '') +
-                               '" data-name="' + masterCategoryDisplayName + '_' + subCategoryDisplayName + '">' +
-                               formattedDisplay + '</span></li>');
+                  const deemphasizedClass = deemphasized ? 'deemphasized' : '';
+                  const indicatorClass = showIndicator ? 'indicator' : '';
+                  const temperatureClass = (pace > 1) ? 'cautious' : 'positive';
+                  $(this).append(`
+                    <li class="budget-table-cell-available budget-table-cell-pacing">
+                      <span
+                        title="${tooltip}"
+                        class="budget-table-cell-pacing-display currency ${temperatureClass} ${deemphasizedClass} ${indicatorClass}"
+                        data-name="${masterCategoryDisplayName}_${subCategoryDisplayName}"
+                      >
+                        ${formattedDisplay}
+                      </span>
+                    </li>
+                  `);
                 });
 
               $('.budget-table-cell-pacing-display').click(function (e) {

--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -83,7 +83,7 @@
         const formattedDisplayInDays = Math.abs(displayInDays);
         const transactions = 'transaction' + (transactionCount !== 1 ? 's' : '');
         const percentOfMonth = Math.round(timeSpent() * 100);
-        const trimWords = (paragraph) => paragraph.split(/\s+/).filter(word => word !== '').join(' ');
+        const trimWords = (paragraph) => paragraph.replace(/\s+/g, ' ').trim();
 
         return trimWords(`
           In ${transactionCount} ${transactions}, you have spent ${formattedDisplay} ${moreOrLess} than

--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -90,8 +90,7 @@
           In ${transactionCount} ${transactions}, you have spent ${formattedDisplay} ${moreOrLess} than
           your available budget for this category ${percentOfMonth}% of the way through the month.
           You are ${formattedDisplayInDays} ${days} ${aheadOrBehind} schedule.
-          &#13;&#13;
-          Click to ${hideOrUnhide}.
+          &#13;&#13;Click to ${hideOrUnhide}.
         `);
       }
 

--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -81,14 +81,15 @@
         const hideOrUnhide = deemphasized ? 'unhide' : 'hide';
         const formattedDisplay = ynabToolKit.shared.formatCurrency(Math.abs(display), false);
         const formattedDisplayInDays = Math.abs(displayInDays);
-        const transactions = 'transaction' + (transactionCount !== 1 ? 's' : '');
+        const days = formattedDisplayInDays === 1 ? 'day' : 'days';
+        const transactions = transactionCount === 1 ? 'transaction' : 'transactions';
         const percentOfMonth = Math.round(timeSpent() * 100);
         const trimWords = (paragraph) => paragraph.replace(/\s+/g, ' ').trim();
 
         return trimWords(`
           In ${transactionCount} ${transactions}, you have spent ${formattedDisplay} ${moreOrLess} than
           your available budget for this category ${percentOfMonth}% of the way through the month.
-          You are ${formattedDisplayInDays} days ${aheadOrBehind} schedule.
+          You are ${formattedDisplayInDays} ${days} ${aheadOrBehind} schedule.
           &#13;&#13;
           Click to ${hideOrUnhide}.
         `);
@@ -157,7 +158,8 @@
                   var display = Math.round((budgeted * timeSpent() - activity) * 1000);
                   const displayInDays = getDaysAheadOfSchedule(display, budgeted, activity);
 
-                  const formattedDisplay = showDays ? displayInDays + ' days'
+                  const days = Math.abs(displayInDays) === 1 ? 'day' : 'days';
+                  const formattedDisplay = showDays ? `${displayInDays} ${days}`
                     : ynabToolKit.shared.formatCurrency(display, true);
 
                   const tooltip = getTooltip(display, displayInDays, transactionCount, deemphasized);

--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -5,16 +5,20 @@
       // or variables, etc
       var storePacingLocally = true;
 
-      // Calculate the proportion of the month that has been spent -- only works for the current month
-      function timeSpent() {
-        var today = new Date();
-
+      function getDaysInMonth() {
         var selectedMonth = ynabToolKit.shared.parseSelectedMonth();
         var lastDayOfThisMonth = new Date(selectedMonth.getFullYear(), selectedMonth.getMonth() + 1, 0);
-        var daysInMonth = lastDayOfThisMonth.getDate(); // The date of the last day in the month is the number of days in the month
-        var day = Math.max(today.getDate(), 1);
+        return lastDayOfThisMonth.getDate(); // The date of the last day in the month is the number of days in the month
+      }
 
-        return day / daysInMonth;
+      function getCurrentDayOfMonth() {
+        var today = new Date();
+        return Math.max(today.getDate(), 1);
+      }
+
+      // Calculate the proportion of the month that has been spent -- only works for the current month
+      function timeSpent() {
+        return getCurrentDayOfMonth() / getDaysInMonth();
       }
 
       // Determine whether the selected month is the current month
@@ -62,6 +66,34 @@
         }
       }
 
+      function getDaysAheadOfSchedule(display, budgeted, activity) {
+        if (budgeted === 0) {
+          return 0;
+        }
+        const target = getCurrentDayOfMonth();
+        const actual = (activity / budgeted) * getDaysInMonth();
+        return Math.round((target - actual) * 10) / 10;
+      }
+
+      function getTooltip(display, displayInDays, transactionCount, deemphasized) {
+        const moreOrLess = display >= 0 ? 'less' : 'more';
+        const aheadOrBehind = display >= 0 ? 'ahead of' : 'behind';
+        const hideOrUnhide = deemphasized ? 'unhide' : 'hide';
+        const formattedDisplay = ynabToolKit.shared.formatCurrency(Math.abs(display), false);
+        const formattedDisplayInDays = Math.abs(displayInDays);
+        const transactions = 'transaction' + (transactionCount !== 1 ? 's' : '');
+        const percentOfMonth = Math.round(timeSpent() * 100);
+        const trimWords = (paragraph) => paragraph.split(/\s+/).filter(word => word !== '').join(' ');
+
+        return trimWords(`
+          In ${transactionCount} ${transactions}, you have spent ${formattedDisplay} ${moreOrLess} than
+          your available budget for this category ${percentOfMonth}% of the way through the month.
+          You are ${formattedDisplayInDays} days ${aheadOrBehind} schedule.
+          &#13;&#13;
+          Click to ${hideOrUnhide}.
+        `);
+      }
+
       return {
         invoke() {
           var tv = ynab.YNABSharedLib.getBudgetViewModel_AllBudgetMonthsViewModel()._result.getAllAccountTransactionsViewModel();
@@ -88,13 +120,6 @@
                 ((ynabToolKit.l10nData && ynabToolKit.l10nData['toolkit.pacing']) || 'PACING') + '</li>');
 
               var deemphasizedCategories = getDeemphasizedCategories();
-
-              var showIndicator = ynabToolKit.options.pacing;
-              if (showIndicator === '2') {
-                showIndicator = true;
-              } else {
-                showIndicator = false;
-              }
 
               // Select all budget table rows but not the uncategorized category and not master categories.
               $('.budget-table-row')
@@ -123,34 +148,25 @@
                       el.subCategoryId === subCategoryId;
                   }).length;
 
-                  var temperature;
-                  if (pace > 1) {
-                    temperature = 'cautious';
-                  } else {
-                    temperature = 'positive';
-                  }
+                  const showDays = ynabToolKit.options.pacing === '2';
+                  const showIndicator = ynabToolKit.options.pacing === '3';
+
+                  var temperature = (pace > 1) ? 'cautious' : 'positive';
 
                   var deemphasized = masterCategory.get('isDebtPaymentCategory') || $.inArray(masterCategoryDisplayName + '_' + subCategoryDisplayName, deemphasizedCategories) >= 0;
                   var display = Math.round((budgeted * timeSpent() - activity) * 1000);
-                  var tooltip;
+                  const displayInDays = getDaysAheadOfSchedule(display, budgeted, activity);
 
-                  if (display >= 0) {
-                    tooltip = 'In ' + transactionCount + ' transaction' + (transactionCount !== 1 ? 's' : '') +
-                      ' you have spent ' + ynabToolKit.shared.formatCurrency(display, false) +
-                      ' less than your available budget for this category ' + Math.round(timeSpent() * 100) +
-                      '% of the way through the month.&#13;&#13;' + (deemphasized ? 'Click to unhide.' : 'Click to hide.');
-                  } else if (display < 0) {
-                    tooltip = 'In ' + transactionCount + ' transaction' + (transactionCount !== 1 ? 's' : '') +
-                      ' you have spent ' + ynabToolKit.shared.formatCurrency(-display, false) +
-                      ' more than your available budget for this category ' + Math.round(timeSpent() * 100) +
-                      '% of the way through the month.&#13;&#13;' + (deemphasized ? 'Click to unhide.' : 'Click to hide.');
-                  }
+                  const formattedDisplay = showDays ? displayInDays + ' days'
+                    : ynabToolKit.shared.formatCurrency(display, true);
+
+                  const tooltip = getTooltip(display, displayInDays, transactionCount, deemphasized);
 
                   $(this).append('<li class="budget-table-cell-available budget-table-cell-pacing"><span title="' + tooltip +
                                '" class="budget-table-cell-pacing-display currency ' + temperature +
                                (deemphasized ? ' deemphasized' : '') + (showIndicator ? ' indicator' : '') +
                                '" data-name="' + masterCategoryDisplayName + '_' + subCategoryDisplayName + '">' +
-                               ynabToolKit.shared.formatCurrency(display, true) + '</span></li>');
+                               formattedDisplay + '</span></li>');
                 });
 
               $('.budget-table-cell-pacing-display').click(function (e) {

--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -1,3 +1,4 @@
+
 (function poll() {
   if (typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true) {
     ynabToolKit.insertPacingColumns = (function () {
@@ -148,8 +149,8 @@
                       el.subCategoryId === subCategoryId;
                   }).length;
 
-                  const showDays = ynabToolKit.options.pacing === '2';
-                  const showIndicator = ynabToolKit.options.pacing === '3';
+                  const showIndicator = ynabToolKit.options.pacing === '2';
+                  const showDays = ynabToolKit.options.pacing === '3';
 
                   var deemphasized = masterCategory.get('isDebtPaymentCategory') || $.inArray(masterCategoryDisplayName + '_' + subCategoryDisplayName, deemphasizedCategories) >= 0;
                   var display = Math.round((budgeted * timeSpent() - activity) * 1000);

--- a/source/common/res/features/pacing/settings.json
+++ b/source/common/res/features/pacing/settings.json
@@ -8,8 +8,8 @@
       "options": [
                     { "name": "Disabled", "value": "0" },
                     { "name": "Show Full Amount", "value": "1" },
-                    { "name": "Show Days Ahead/Behind Schedule", "value": "2" },
-                    { "name": "Show Simple Indicator", "value": "3" }                    
+                    { "name": "Show Simple Indicator", "value": "2" },
+                    { "name": "Show Days Ahead/Behind Schedule", "value": "3" }
                  ],
       "actions": {
                     "1": [
@@ -17,6 +17,10 @@
                       "injectScript", "main.js"
                     ],
                     "2": [
+                      "injectCSS", "main.css",
+                      "injectScript", "main.js"
+                    ],
+                    "3": [
                       "injectCSS", "main.css",
                       "injectScript", "main.js"
                     ]

--- a/source/common/res/features/pacing/settings.json
+++ b/source/common/res/features/pacing/settings.json
@@ -8,7 +8,8 @@
       "options": [
                     { "name": "Disabled", "value": "0" },
                     { "name": "Show Full Amount", "value": "1" },
-                    { "name": "Show Simple Indicator", "value": "2" }                    
+                    { "name": "Show Days Ahead/Behind Schedule", "value": "2" },
+                    { "name": "Show Simple Indicator", "value": "3" }                    
                  ],
       "actions": {
                     "1": [


### PR DESCRIPTION
Github Issue (if applicable): #865 

Trello Link (if applicable): N/A

Forum Link (if applicable): N/A

#### Explanation of Bugfix/Feature/Enhancement:

It's sometimes difficult to determine how far behind schedule you are when viewing your pacing in terms of currency. Adding an option to display the pacing column in terms of number of days ahead or behind makes it much clearer to see how well you're doing . For instance, "-4 days" means that if I do not spend another penny in that category for 4 days, I'll be back on track.


#### Recommended Release Notes:

New option added to pacing for displaying in days ahead/behind schedule
