### PR TITLE
Filter transfer and starting balance transactions

### DIFF
--- a/source/common/res/features/days-of-buffering/main.js
+++ b/source/common/res/features/days-of-buffering/main.js
@@ -11,6 +11,8 @@
           return !el.isTombstone &&
           el.transferAccountId === null &&
           el.amount < 0 &&
+          el.payeeId !== null &&
+          el.getPayee().internalName !== 'StartingBalancePayee' &&
         el.getAccount().onBudget; });
 
         // Filter outflow transactions by Date for history lookup option.


### PR DESCRIPTION
Adds additional transaction filters to remove all 'Transfer' and 'Starting Balance' transactions, as these negatively impact the accuracy of the metric.

Github Issue: #246 (not the EXACT issue, but could be related)

#### Explanation of Bugfix/Feature/Enhancement:
The metric was not filtering out all 'Transfer' and 'Starting Balance' transactions. This was artificially increasing the total outflow amount. Increasing the total outflow increases the average daily outflow, which then decreases the days of buffering. I found that not all transfers have a transferAccountId, so they were not all being filtered. Checking for a null payee ID was the solution here. With regard to 'Starting Balance' transactions, checking for a payee internal name of 'StartingBalancePayee' appears to be fairly robust. I did not want to check the name field, as that may vary based on language preferences.


#### Recommended Release Notes:
Improved the accuracy of the Days of Buffering metric by removing 'Transfer' and 'Starting Balance' transactions from the calculation