### PR TITLE
Fix 824 - calculator being inadvertently dismissed 

### DIFF
--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -265,7 +265,7 @@
           // Handle mouse clicks outside the drop-down modal. Namespace the
           // click event so we can remove our specific instance.
           $(document).on('click.toolkitPopupCalc', (e) => {
-            if (e.target.id !== '' && e.target.id !== 'toolkitPopupCalc') {
+            if (e.target.id !== '' && e.target.id.slice(0, 16) !== 'toolkitPopupCalc') {
               dismissCalculator();
             }
           });

--- a/source/common/res/features/popup-calculator/main.js
+++ b/source/common/res/features/popup-calculator/main.js
@@ -265,7 +265,7 @@
           // Handle mouse clicks outside the drop-down modal. Namespace the
           // click event so we can remove our specific instance.
           $(document).on('click.toolkitPopupCalc', (e) => {
-            if (e.target.id !== 'toolkitPopupCalc') {
+            if (e.target.id !== '' && e.target.id !== 'toolkitPopupCalc') {
               dismissCalculator();
             }
           });


### PR DESCRIPTION
Github Issue (if applicable): #824 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Be more selective about the circumstances under which the calculator should be dismissed when the user clicks somewhere on the page besides the calculator.


#### Recommended Release Notes:
Fix issues caused by recent YNAB updates.