### PR TITLE
Bugfix for Issue #897

### DIFF
--- a/source/common/main.js
+++ b/source/common/main.js
@@ -107,5 +107,10 @@ Promise.all(optionsPromises).then(function () {
   /* Load the ynabToolkit bundle */
   injectScript('res/features/ynabToolkit.js');
 
+  /* Putting this code here temporarily. Once the resize-inspector feature
+     is refactored to be saucy, the call should be moved to the
+     resize-insptector willInvoke() function. */
+  injectJSString('window.resizeInspectorAsset = "' + kango.io.getResourceUrl('assets/vsizegrip.png') + '";');
+
   ensureDefaultsAreSet().then(applySettingsToDom);
 });

--- a/source/common/res/features/resize-inspector/main.css
+++ b/source/common/res/features/resize-inspector/main.css
@@ -1,8 +1,19 @@
+:root {
+  --tlkt-btc-width: 0px; /* budget-table-container */
+}
+
 .budget-table {
   position: static !important;
   overflow: scroll;
-  height: calc(100% - 24.5px); /* The header is now 24.5px high, which pushes the bottom row below
+  height: 100%;
+  /*height: calc(100% - 24.5px);*/ /* The header is now 24.5px high, which pushes the bottom row below
                                   the bottom of the resizable parent unless we pull it back out. */
+}
+
+.budget-table-containerx {
+  top: 9.5rem;
+  /* width: calc(100% - 290px); */
+  width: calc(100% - var(--tlkt-btc-width));
 }
 
 .budget-content {
@@ -10,7 +21,7 @@
   padding-top: 8em;
   position: static !important;
   flex: 0 0 auto;
-  width: 67%;
+  bottom: 0;
   overflow: hidden;
 }
 
@@ -37,6 +48,7 @@
   min-width: 13px;
   background: #e5f5f9 no-repeat center center;
   cursor: col-resize;
+  z-index: 999;
 }
 
 .inspector-resize-handle:hover {

--- a/source/common/res/features/resize-inspector/main.js
+++ b/source/common/res/features/resize-inspector/main.js
@@ -14,9 +14,9 @@
             ynabToolKit.resizeInspector.asideWidth = asideWidth;
           }
 
-          if ($('.ember-view.content .budget-inspector').length > 0) {
+          if ($('.ember-view .budget-inspector').length > 0) {
             if ($('.resize-inspector').length === 0) {
-              $('.ember-view.content .scroll-wrap').addClass('resize-inspector');
+              $('.ember-view .scroll-wrap').addClass('resize-inspector');
               $('aside').before('<div class="inspector-resize-handle">&nbsp;</div>');
               $('.inspector-resize-handle').css('background-image', 'url(' + window.resizeInspectorAsset + ')');
               $('section').resizable({
@@ -28,6 +28,9 @@
 
                   ynabToolKit.shared.setToolkitStorageKey('budget-resize-inspector', asideWidth);
                   ynabToolKit.resizeInspector.asideWidth = asideWidth;
+
+                  let wdth = $('.budget-content').css('width');
+                  $('.budget-table-container').css({ width: wdth, top: '9.5rem' });
                 }
               });
 
@@ -41,6 +44,9 @@
                     $('section').css('width', ynabToolKit.resizeInspector.getContentSize(false));
                   }
                 });
+
+                let wdth = $('.budget-content').css('width');
+                $('.budget-table-container').css({ width: wdth, top: '9.5rem' });
               }
             }
           } else {


### PR DESCRIPTION
Github Issue (if applicable): #897

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Recent changes to the DOM structure and class names resulted in this feature no longer working. I also had to add a call to injectJSString in source/common/main.js to get the URL of the image file that goes on the resize handle element. This is odd because I cannot determine which commit the code was removed on. I suspect it's been gone a while but didn't cause an issue until YNAB changed something and made it an issue. The code added main.js needs to be moved to the willInvoke() function when the feature is refactored to be saucy but I don't have time to do that right now. 

#### Recommended Release Notes:
Resize Inspector should be working again.