### PR TITLE
Make it slightly less easy to accidentally delete the end of the code block

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,9 @@ Other Extensions:
 <summary>Settings Export</summary>
 
 ```
+
 [paste settings here]
+
 ```
 </details>
 


### PR DESCRIPTION
Just a tiny change since a couple of issues have come in without these characters which messes up the formatting significantly.