### PR TITLE
Resize the budget grid when the collapse button is pushed.

### DIFF
--- a/source/common/res/features/collapse-side-menu/main.js
+++ b/source/common/res/features/collapse-side-menu/main.js
@@ -188,10 +188,9 @@
           if ($('.budget-content').is(':visible')) {
             if (ynabToolKit.options.resizeInspector) {
               let bcWidth = ynabToolKit.resizeInspector.getContentSize(true);
-              $('.budget-content').animate({ width: bcWidth }, 400, 'swing', function () {
+              $('.budget-content, .budget-table-container').animate({ width: bcWidth }, 400, 'swing', function () {
                 $('.ynabtk-navlink-collapse').removeClass('collapsed').addClass('expanded');
               });
-              $('.budget-table-container').animate({ width: bcWidth });
             } else {
               // if resize-inspector feature not on
               $('.budget-content').animate({ width: originalSizes.contentWidth }, 400, 'swing', function () {
@@ -228,8 +227,7 @@
           if ($('.budget-content').is(':visible')) {
             if (ynabToolKit.options.resizeInspector) {
               let bcWidth = ynabToolKit.resizeInspector.getContentSizeCollapsed();
-              $('.budget-content').animate({ width: bcWidth });
-              $('.budget-table-container').animate({ width: bcWidth });
+              $('.budget-content, .budget-table-container').animate({ width: bcWidth });
             } else {
               $('.budget-content').animate({ width: '73%' });
               $('.budget-inspector').animate({ width: '27%' });

--- a/source/common/res/features/collapse-side-menu/main.js
+++ b/source/common/res/features/collapse-side-menu/main.js
@@ -187,9 +187,11 @@
           $('.budget-header').animate({ left: originalSizes.headerLeft });
           if ($('.budget-content').is(':visible')) {
             if (ynabToolKit.options.resizeInspector) {
-              $('.budget-content').animate({ width: ynabToolKit.resizeInspector.getContentSize(true) }, 400, 'swing', function () {
+              let bcWidth = ynabToolKit.resizeInspector.getContentSize(true);
+              $('.budget-content').animate({ width: bcWidth }, 400, 'swing', function () {
                 $('.ynabtk-navlink-collapse').removeClass('collapsed').addClass('expanded');
               });
+              $('.budget-table-container').animate({ width: bcWidth });
             } else {
               // if resize-inspector feature not on
               $('.budget-content').animate({ width: originalSizes.contentWidth }, 400, 'swing', function () {
@@ -225,7 +227,9 @@
           $('.budget-header').animate({ left: '40px' });
           if ($('.budget-content').is(':visible')) {
             if (ynabToolKit.options.resizeInspector) {
-              $('.budget-content').animate({ width: ynabToolKit.resizeInspector.getContentSizeCollapsed() });
+              let bcWidth = ynabToolKit.resizeInspector.getContentSizeCollapsed();
+              $('.budget-content').animate({ width: bcWidth });
+              $('.budget-table-container').animate({ width: bcWidth });
             } else {
               $('.budget-content').animate({ width: '73%' });
               $('.budget-inspector').animate({ width: '27%' });

--- a/source/common/res/features/resize-inspector/main.js
+++ b/source/common/res/features/resize-inspector/main.js
@@ -29,8 +29,8 @@
                   ynabToolKit.shared.setToolkitStorageKey('budget-resize-inspector', asideWidth);
                   ynabToolKit.resizeInspector.asideWidth = asideWidth;
 
-                  let wdth = $('.budget-content').css('width');
-                  $('.budget-table-container').css({ width: wdth, top: '9.5rem' });
+                  let bcWidth = $('.budget-content').css('width');
+                  $('.budget-table-container').css({ width: bcWidth, top: '9.5rem' });
                 }
               });
 
@@ -45,8 +45,8 @@
                   }
                 });
 
-                let wdth = $('.budget-content').css('width');
-                $('.budget-table-container').css({ width: wdth, top: '9.5rem' });
+                let bcWidth = $('.budget-content').css('width');
+                $('.budget-table-container').css({ width: bcWidth, top: '9.5rem' });
               }
             }
           } else {

--- a/source/common/res/features/resize-inspector/main.js
+++ b/source/common/res/features/resize-inspector/main.js
@@ -45,8 +45,8 @@
                   }
                 });
 
-                let bcWidth = $('.budget-content').css('width');
-                $('.budget-table-container').css({ width: bcWidth, top: '9.5rem' });
+                const width = $('.budget-content').css('width');
+                $('.budget-table-container').css({ width, top: '9.5rem' });
               }
             }
           } else {


### PR DESCRIPTION
Orginal code change didn't account for the collapse button feature being
active and the user actually using the button. doh!

Github Issue (if applicable): #897 part 2

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:



#### Recommended Release Notes:
The budget grid will now be resized correctly when the collapse button is clicked.