### PR TITLE
fix rectify available button state tracking

### DIFF
--- a/source/common/res/features/check-credit-balances/main.js
+++ b/source/common/res/features/check-credit-balances/main.js
@@ -144,9 +144,6 @@
           var inspectorName = $('.inspector-category-name.user-data').text().trim();
 
           if (name && name === inspectorName) {
-            if (difference === '-0') {
-              return true;
-            }
             var fDifference = ynabToolKit.shared.formatCurrency(difference);
             var positive = '';
             if (ynab.unformat(difference) >= 0) {
@@ -179,6 +176,12 @@
               .append(' ' + positive)
               .append($('<strong>', { class: 'user-data', title: fDifference })
                 .append(ynabToolKit.shared.appendFormattedCurrencyHtml($('<span>', { class: 'user-data currency zero' }), difference)));
+
+            if (difference !== 0) {
+              button.removeAttr('disabled');
+            } else {
+              button.attr('disabled', true);
+            }
 
             return true;
           }


### PR DESCRIPTION
Github Issue: #928

#### Explanation of Bugfix/Feature/Enhancement:

Use correct class name when looking to see if the button already exists.
Update contents and data of button when changing to a different account.
Remove the button when no longer on a valid account. Add more change
events to handle these situations.

#### Recommended Release Notes:

Fix Paid in Full Credit Card Assist feature