### PR TITLE
Fix Days Of Buffering metric

### DIFF
--- a/source/common/res/features/days-of-buffering/main.js
+++ b/source/common/res/features/days-of-buffering/main.js
@@ -7,13 +7,26 @@
         // Get outflow transactions.
         var entityManager = ynab.YNABSharedLib.defaultInstance.entityManager;
         var transactions = entityManager.getAllTransactions();
+
+        let isPayeeOk = function (payee) {
+          if (payee === null) {
+            return true;
+          }
+
+          return payee.internalName !== 'StartingBalancePayee';
+        };
+
         var outflowTransactions = transactions.filter(function (el) {
+          let masterCategoryId = el.get('masterCategoryId');
+          let subCategoryId = el.get('subCategoryId');
+          let isTransfer = masterCategoryId === null || subCategoryId === null;
+
           return !el.isTombstone &&
             el.transferAccountId === null &&
             el.amount < 0 &&
-            el.payeeId !== null &&
-            el.getPayee().internalName !== 'StartingBalancePayee' &&
-            el.getAccount().onBudget;
+            isPayeeOk(el.getPayee()) &&
+            el.getAccount().onBudget &&
+            !isTransfer;
         });
 
         // Filter outflow transactions by Date for history lookup option.


### PR DESCRIPTION
Github Issue: #931

#### Explanation of Bugfix/Feature/Enhancement:

Detection of transfer transaction is improved. Now, if you don't specify payee - Days of Buffering will be calculated correctly.

#### Other

I have noticed that `isTransfer` logic is using in many places:

<img width="782" alt="screen shot 2017-09-29 at 19 05 08" src="https://user-images.githubusercontent.com/7958527/31024889-27dd3b88-a549-11e7-9023-3d83b46abe21.png">

Is it possible to avoid duplication?
