### PR TITLE
remove the entire overlay when user clicks continue

### DIFF
--- a/source/common/res/features/shared/main.js
+++ b/source/common/res/features/shared/main.js
@@ -349,7 +349,7 @@ ynabToolKit.shared = (function () {
                       </div>`);
 
       $modal.find('.toolkit-modal-action-close').on('click', () => {
-        return $('.layout .toolkit-modal').remove();
+        return $('.layout .toolkit-modal-overlay').remove();
       });
 
       if (!$('.modal-error').length) {


### PR DESCRIPTION
We weren't removing the entire overlay when the user clicked "continue" on the modal.