### PR TITLE
Bugfix for Issue #979

### DIFF
--- a/sauce/features/accounts/adjustable-column-widths/index.js
+++ b/sauce/features/accounts/adjustable-column-widths/index.js
@@ -26,7 +26,7 @@ export class AdjustableColumnWidths extends Feature {
   currentX = null;
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1;
+    return getCurrentRouteName().indexOf('account') !== -1 && this.settings.enabled;
   }
 
   onMouseMove(event) {


### PR DESCRIPTION
Added check in shouldInvoke() for the feature being enabled. Without the
check the feature is always enabled even though the user hasn't enabled
it.

Github Issue (if applicable): #979 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
I could find nowhere that the settings.enabled flag was being checked for this feature. That resulted in it always be enabled or at least the Reset Column Widths button was visible. The CSS for the feature wasn't loaded because there is a check of settings.enabled before loading the CSS. Without the CSS loaded the user can;t resize the columns even though the feature is loaded. 


#### Recommended Release Notes:
The Reset Column Widths button will no longer be shown if the feature is not enabled.