### PR TITLE
Website Version Update

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -228,7 +228,7 @@ ul {
 
 	@media (min-width: $mq-xsmall) {
 	    display: inline-block;
-	    min-width: 225px;
+	    min-width: 185px;
 		padding: 15px 40px;
 		font-size: 16px;
 		line-height: 26px;

--- a/index.html
+++ b/index.html
@@ -15,5 +15,5 @@ layout: default
     <li>Interested in contributing? Submit a pull request on <a href="https://github.com/toolkit-for-ynab/toolkit-for-ynab" target="_blank">GitHub</a>.</li>
 </ul>
 
-<a href="https://chrome.google.com/webstore/detail/toolkit-for-ynab/lmhdkkhepllpnondndgpgclfjnlofgjl?hl=en" target="_blank" class="btn">Install 1.2.0 <i>for</i> Chrome</a>
-<a href="https://addons.mozilla.org/firefox/addon/toolkit-for-ynab/" target="_blank" class="btn">Install 1.2.0 <i>for</i> Firefox</a>
+<a href="https://chrome.google.com/webstore/detail/toolkit-for-ynab/lmhdkkhepllpnondndgpgclfjnlofgjl?hl=en" target="_blank" class="btn">Toolkit <i>for</i> Chrome</a>
+<a href="https://addons.mozilla.org/firefox/addon/toolkit-for-ynab/" target="_blank" class="btn">Toolkit <i>for</i> Firefox</a>


### PR DESCRIPTION
Github Issue (if applicable): --
Trello Link (if applicable): --
Forum Link (if applicable): --

#### Explanation of Bugfix/Feature/Enhancement:
Updates to the splash page to remove specific Toolkit version numbers, to make maintenance a little easier/quicker when new versions get released. 

Maybe there’s a way to automate getting to latest version numbers for the full website, rather than needing to update them manually each time? Something to look into eventually.

#hacktoberfest