### PR TITLE
Target balance warning fix

### DIFF
--- a/sauce/features/budget/target-balance-warning/index.js
+++ b/sauce/features/budget/target-balance-warning/index.js
@@ -7,7 +7,9 @@ export class TargetBalanceWarning extends Feature {
   }
 
   shouldInvoke() {
-    return toolkitHelper.getCurrentRouteName().indexOf('budget') !== -1;
+    if (this.settings.enabled === true && toolkitHelper.getCurrentRouteName().indexOf('budget') !== -1) {
+      return true;
+    }
   }
 
   invoke() {


### PR DESCRIPTION
Github Issue (if applicable): --
Trello Link (if applicable): --
Forum Link (if applicable): https://forum.youneedabudget.com/discussion/55129/confusing-highlighting-on-budget-screen-after-new-ynab-toolkit

**Explanation of Bugfix/Feature/Enhancement:**
Corrected shouldInvoke() to ensure the feature is only active if it is enabled in settings.

**Recommended Release Notes:**
Bugfixes.


#hacktoberfest