### PR TITLE
Fix for 'enabled' check.

### DIFF
--- a/sauce/main.js
+++ b/sauce/main.js
@@ -18,7 +18,11 @@ const featureInstances = features.map(Feature => new Feature());
 
     ynabToolKit.invokeFeature = (featureName) => {
       featureInstances.forEach((feature) => {
-        if (feature.constructor.name === featureName && feature.shouldInvoke()) {
+        if (
+          feature.constructor.name === featureName &&
+          isFeatureEnabled(feature) &&
+          feature.shouldInvoke()
+        ) {
           feature.invoke();
         }
       });
@@ -32,8 +36,9 @@ const featureInstances = features.map(Feature => new Feature());
 
     // Hook up listeners and then invoke any features that are ready to go.
     featureInstances.forEach((feature) => {
-      if ((typeof feature.settings.enabled === 'boolean' && feature.settings.enabled) ||
-          feature.settings.enabled !== '0') { // assumes '0' means disabled
+      if (isFeatureEnabled(feature)) { // assumes '0' means disabled
+      // if ((typeof feature.settings.enabled === 'boolean' && feature.settings.enabled) ||
+      //     feature.settings.enabled !== '0') { // assumes '0' means disabled
         feature.applyListeners();
 
         const willInvokeRetValue = feature.willInvoke();
@@ -53,5 +58,12 @@ const featureInstances = features.map(Feature => new Feature());
     });
   } else {
     setTimeout(poll, 250);
+  }
+  // Check if the passed feature is enabled.
+  function isFeatureEnabled(feature) {
+    return (
+      (typeof feature.settings.enabled === 'boolean' && feature.settings.enabled) ||
+      (typeof feature.settings.enabled === 'string' && feature.settings.enabled !== '0') // assumes '0' means disabled
+    );
   }
 }());

--- a/sauce/main.js
+++ b/sauce/main.js
@@ -2,6 +2,14 @@ import features from 'features';
 
 const featureInstances = features.map(Feature => new Feature());
 
+// Check if the passed feature is enabled.
+function isFeatureEnabled(feature) {
+  return (
+    (typeof feature.settings.enabled === 'boolean' && feature.settings.enabled) ||
+    (typeof feature.settings.enabled === 'string' && feature.settings.enabled !== '0') // assumes '0' means disabled
+  );
+}
+
 // This poll() function will only need to run until we find that the DOM is ready
 (function poll() {
   if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' &&
@@ -11,7 +19,7 @@ const featureInstances = features.map(Feature => new Feature());
     let globalCSS = '';
 
     featureInstances.forEach(feature => {
-      if (feature.settings.enabled && feature.injectCSS()) {
+      if (isFeatureEnabled(feature) && feature.injectCSS()) {
         globalCSS += `/* == Injected CSS from feature: ${feature.constructor.name} == */\n\n${feature.injectCSS()}\n`;
       }
     });
@@ -36,9 +44,7 @@ const featureInstances = features.map(Feature => new Feature());
 
     // Hook up listeners and then invoke any features that are ready to go.
     featureInstances.forEach((feature) => {
-      if (isFeatureEnabled(feature)) { // assumes '0' means disabled
-      // if ((typeof feature.settings.enabled === 'boolean' && feature.settings.enabled) ||
-      //     feature.settings.enabled !== '0') { // assumes '0' means disabled
+      if (isFeatureEnabled(feature)) {
         feature.applyListeners();
 
         const willInvokeRetValue = feature.willInvoke();
@@ -58,12 +64,5 @@ const featureInstances = features.map(Feature => new Feature());
     });
   } else {
     setTimeout(poll, 250);
-  }
-  // Check if the passed feature is enabled.
-  function isFeatureEnabled(feature) {
-    return (
-      (typeof feature.settings.enabled === 'boolean' && feature.settings.enabled) ||
-      (typeof feature.settings.enabled === 'string' && feature.settings.enabled !== '0') // assumes '0' means disabled
-    );
   }
 }());

--- a/sauce/main.js
+++ b/sauce/main.js
@@ -2,6 +2,16 @@ import features from 'features';
 
 const featureInstances = features.map(Feature => new Feature());
 
+function isYNABReady() {
+  return (
+    typeof Em !== 'undefined' &&
+    typeof Ember !== 'undefined' &&
+    typeof $ !== 'undefined' &&
+    $('.ember-view.layout').length &&
+    typeof ynabToolKit !== 'undefined'
+  );
+}
+
 // Check if the passed feature is enabled.
 function isFeatureEnabled(feature) {
   return (
@@ -12,9 +22,7 @@ function isFeatureEnabled(feature) {
 
 // This poll() function will only need to run until we find that the DOM is ready
 (function poll() {
-  if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' &&
-    typeof $ !== 'undefined' && $('.ember-view.layout').length &&
-    typeof ynabToolKit !== 'undefined') {
+  if (isYNABReady()) {
     // Gather any desired global CSS from features
     let globalCSS = '';
 
@@ -25,15 +33,10 @@ function isFeatureEnabled(feature) {
     });
 
     ynabToolKit.invokeFeature = (featureName) => {
-      featureInstances.forEach((feature) => {
-        if (
-          feature.constructor.name === featureName &&
-          isFeatureEnabled(feature) &&
-          feature.shouldInvoke()
-        ) {
-          feature.invoke();
-        }
-      });
+      const feature = featureInstances.find((f) => f.constructor.name === featureName);
+      if (isFeatureEnabled(feature) && feature.shouldInvoke()) {
+        feature.invoke();
+      }
     };
 
     // Inject it into the head so it's left alone


### PR DESCRIPTION
The type of the settings.enabled needs to be checked on both sides of
the || because if it isn't, the check always returns true for a boolean
based feature.

Github Issue (if applicable): #XXX

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
A non boolean field will always return  true if the check is x !== '0' because '0' is a string not a boolean.


#### Recommended Release Notes:
Features that were not enabled will no longer be loaded as though they were enabled.