### PR TITLE
Alias "toolkit" to the sauce directory.

### DIFF
--- a/sauce/README.md
+++ b/sauce/README.md
@@ -35,7 +35,7 @@ follow these stpes:
 3. Create an index.js file which has the following:
   <!-- spacing is intentionally weird here because of markdown -->
   ```javascript
-  import { Feature } from 'core/feature';
+  import { Feature } from 'toolkit/core/feature';
 
   export class MyCoolFeature extends Feature {
      shouldInvoke() {
@@ -109,14 +109,14 @@ at this point, the page is ready for manipulation and YNAB is loaded.
 **optional function, not required to be declared**
 
 injectCSS is called only once when the feature is instantiated, and its job is to
-return any global CSS styles you'd like to have placed in a `<style>` tag in the 
+return any global CSS styles you'd like to have placed in a `<style>` tag in the
 `<head>` of the page.
 
 For example, a CSS based feature to hide the referral program banner would look like this:
 
 **index.js**
 ```javascript
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class HideReferralBanner extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/core/feature.js
+++ b/sauce/core/feature.js
@@ -1,4 +1,4 @@
-import { ObserveListener, RouteChangeListener } from 'core/listeners';
+import { ObserveListener, RouteChangeListener } from 'toolkit/core/listeners';
 
 export class Feature {
   constructor() {

--- a/sauce/core/listeners/routeChangeListener.js
+++ b/sauce/core/listeners/routeChangeListener.js
@@ -1,4 +1,4 @@
-import { controllerLookup } from 'helpers/toolkit';
+import { controllerLookup } from 'toolkit/helpers/toolkit';
 
 let instance = null;
 

--- a/sauce/features/accounts/additional-columns/check-numbers.js
+++ b/sauce/features/accounts/additional-columns/check-numbers.js
@@ -1,4 +1,4 @@
-import * as toolkitHelper from 'helpers/toolkit';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 export class CheckNumbers {
   insertHeader() {

--- a/sauce/features/accounts/additional-columns/index.js
+++ b/sauce/features/accounts/additional-columns/index.js
@@ -1,8 +1,8 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 import { AdditionalColumnStub } from './additional-column-stub';
 import { RunningBalance } from './running-balance';
 import { CheckNumbers } from './check-numbers';
-import * as toolkitHelper from 'helpers/toolkit';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 export class AdditionalColumns extends Feature {
   constructor() {

--- a/sauce/features/accounts/additional-columns/running-balance.js
+++ b/sauce/features/accounts/additional-columns/running-balance.js
@@ -1,4 +1,4 @@
-import * as toolkitHelper from 'helpers/toolkit';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 export class RunningBalance {
   willInvoke() {

--- a/sauce/features/accounts/adjustable-column-widths/index.js
+++ b/sauce/features/accounts/adjustable-column-widths/index.js
@@ -1,10 +1,10 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 import {
   getCurrentRouteName,
   getToolkitStorageKey,
   removeToolkitStorageKey,
   setToolkitStorageKey
-} from 'helpers/toolkit';
+} from 'toolkit/helpers/toolkit';
 
 const RESIZABLES = [
   'ynab-grid-cell-date',

--- a/sauce/features/accounts/change-enter-behavior/index.js
+++ b/sauce/features/accounts/change-enter-behavior/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import * as toolkitHelper from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 export class ChangeEnterBehavior extends Feature {
   shouldInvoke() {

--- a/sauce/features/accounts/clear-selection/index.js
+++ b/sauce/features/accounts/clear-selection/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class ClearSelection extends Feature {
   uncheckTransactions = () => {

--- a/sauce/features/accounts/custom-flag-names/index.js
+++ b/sauce/features/accounts/custom-flag-names/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import * as toolkitHelper from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 let flags;
 let redFlagLabel;

--- a/sauce/features/accounts/emphasized-outflows/index.js
+++ b/sauce/features/accounts/emphasized-outflows/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class AccountsEmphasizedOutflows extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/accounts/row-height/index.js
+++ b/sauce/features/accounts/row-height/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import { getEmberView } from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import { getEmberView } from 'toolkit/helpers/toolkit';
 
 const compactHeight = 27;
 const slimHeight = 22;

--- a/sauce/features/accounts/show-category-balance/index.js
+++ b/sauce/features/accounts/show-category-balance/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import * as toolkitHelper from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 export class ShowCategoryBalance extends Feature {
   shouldInvoke() {

--- a/sauce/features/accounts/split-keyboard-shortcut/index.js
+++ b/sauce/features/accounts/split-keyboard-shortcut/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import { getCurrentRouteName } from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import { getCurrentRouteName } from 'toolkit/helpers/toolkit';
 
 const BUDGET_CATEGORIES_DROPDOWN_NODE = 'ynab-u modal-popup modal-account-dropdown modal-account-categories ember-view modal-overlay active';
 

--- a/sauce/features/accounts/striped-rows/index.js
+++ b/sauce/features/accounts/striped-rows/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class AccountsStripedRows extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/budget/activity-transaction-link/index.js
+++ b/sauce/features/budget/activity-transaction-link/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class ActivityTransactionLink extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/budget/budget-balance-to-zero/index.js
+++ b/sauce/features/budget/budget-balance-to-zero/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import * as toolkitHelper from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 export class BudgetBalanceToZero extends Feature {
   attachedObserver = false

--- a/sauce/features/budget/category-activity-copy/index.js
+++ b/sauce/features/budget/category-activity-copy/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import * as toolkitHelper from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 export class CategoryActivityCopy extends Feature {
   shouldInvoke() {

--- a/sauce/features/budget/display-goal-amount/index.js
+++ b/sauce/features/budget/display-goal-amount/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import * as toolkitHelper from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 export class DisplayTargetGoalAmount extends Feature {
   shouldInvoke() {

--- a/sauce/features/budget/goal-warning-color/index.js
+++ b/sauce/features/budget/goal-warning-color/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class GoalWarningColor extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/budget/remove-positive-highlight/index.js
+++ b/sauce/features/budget/remove-positive-highlight/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class RemovePositiveHighlight extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/budget/rows-height/index.js
+++ b/sauce/features/budget/rows-height/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class RowsHeight extends Feature {
   injectCSS() {

--- a/sauce/features/budget/stealing-from-future/index.js
+++ b/sauce/features/budget/stealing-from-future/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import * as toolkitHelper from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 // TODO: move income-from-last-month to the new framework and just export this
 // variable from that feature

--- a/sauce/features/budget/target-balance-warning/index.js
+++ b/sauce/features/budget/target-balance-warning/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import * as toolkitHelper from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
 
 export class TargetBalanceWarning extends Feature {
   constructor() {

--- a/sauce/features/general/accounts-display-density/index.js
+++ b/sauce/features/general/accounts-display-density/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class AccountsDisplayDensity extends Feature {
   injectCSS() {

--- a/sauce/features/general/better-scrollbars/index.js
+++ b/sauce/features/general/better-scrollbars/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class BetterScrollbars extends Feature {
   injectCSS() {

--- a/sauce/features/general/budget-quick-switch/index.js
+++ b/sauce/features/general/budget-quick-switch/index.js
@@ -1,5 +1,5 @@
-import { Feature } from 'core/feature';
-import { controllerLookup, getRouter } from 'helpers/toolkit';
+import { Feature } from 'toolkit/core/feature';
+import { controllerLookup, getRouter } from 'toolkit/helpers/toolkit';
 
 export class BudgetQuickSwitch extends Feature {
   populateBudgetList() {

--- a/sauce/features/general/colour-blind-mode/index.js
+++ b/sauce/features/general/colour-blind-mode/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class ColourBlindMode extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/general/edit-account-button/index.js
+++ b/sauce/features/general/edit-account-button/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class EditAccountButton extends Feature {
   injectCSS() {

--- a/sauce/features/general/hide-age-of-money/index.js
+++ b/sauce/features/general/hide-age-of-money/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class HideAgeOfMoney extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/general/hide-referral-banner/index.js
+++ b/sauce/features/general/hide-referral-banner/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class HideReferralBanner extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/general/import-notification/index.js
+++ b/sauce/features/general/import-notification/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class ImportNotification extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/general/printing-improvements/index.js
+++ b/sauce/features/general/printing-improvements/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class PrintingImprovements extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/features/general/privacy-mode/index.js
+++ b/sauce/features/general/privacy-mode/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class PrivacyMode extends Feature {
 

--- a/sauce/features/general/square-negative-mode/index.js
+++ b/sauce/features/general/square-negative-mode/index.js
@@ -1,4 +1,4 @@
-import { Feature } from 'core/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class SquareNegativeMode extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/sauce/main.js
+++ b/sauce/main.js
@@ -1,4 +1,4 @@
-import features from 'features';
+import features from 'toolkit/features';
 
 const featureInstances = features.map(Feature => new Feature());
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,10 @@ module.exports = {
   },
 
   resolve: {
-    modules: [path.resolve(__dirname, 'sauce'), 'node_modules']
+    alias: {
+      toolkit: path.resolve(__dirname, 'sauce')
+    },
+    modules: ['node_modules']
   },
 
   module: {


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Enhancement:
When I first built the framework, I made `sauce` a "module" as far as webpack is concerned which is actually really confusing. Now I've aliased `toolkit` to the `sauce` directory which makes it more obvious you're importing from that directory.

`import { Feature } from 'toolkit/core/feature'`
`import * as toolkitHelper from 'toolkit/helpers/toolkit'` 

#### Recommended Release Notes:
none