### PR TITLE
Add Credit Card Emoji 💳 to the "Credit Card Payments" category group

### DIFF
--- a/sauce/features/budget/credit-card-emoji/credit.css
+++ b/sauce/features/budget/credit-card-emoji/credit.css
@@ -1,0 +1,3 @@
+[title="Credit Card Payments"] .user-entered-text::before {
+    content: "💳 ";
+}

--- a/sauce/features/budget/credit-card-emoji/index.js
+++ b/sauce/features/budget/credit-card-emoji/index.js
@@ -1,0 +1,7 @@
+import { Feature } from 'toolkit/core/feature';
+
+export class CreditCardEmoji extends Feature {
+  injectCSS() {
+    return require('./credit.css');
+  }
+}

--- a/sauce/features/budget/credit-card-emoji/settings.js
+++ b/sauce/features/budget/credit-card-emoji/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'CreditCardEmoji',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Credit Card Emoji',
+  description: 'Add a credit card emoji 💳 to the "Credit Card Payments" category.'
+};


### PR DESCRIPTION
Users are unable to edit the name of the "Credit Card Payments" category group in YNAB. I have enjoyed adding emojis to all of my category names and this was the only category group missing an emoji. I built this little feature that adds the emoji for your through the toolkit!

A couple notes:
1. It took me less than an hour to build the app and get my feature working. The core team has built an awesome framework, great job!
2. This only works on the name of the category group in the budget list, and not in the modal that pops up when you click it (as if you were going to edit it). I played with using `.modal-budget-edit-category-label.user-data` to also make the change in the modal, but that also affected each credit card (since those titles are not editable as a budget).
 e.g.:
![image](https://user-images.githubusercontent.com/6256032/32033848-b31adcc4-b9d4-11e7-9179-5b01b264998c.png)



#### Recommended Release Notes:
- Added toggle for showing a credit card emoji on the "Credit Card Payments" category group.
