### PR TITLE
Bug with Days of Buffering with no Age of Money

### DIFF
--- a/sauce/features/budget/days-of-buffering/generateReport.js
+++ b/sauce/features/budget/days-of-buffering/generateReport.js
@@ -4,7 +4,7 @@ export default function reportGenerator(transactions, totalBudget) {
   const lastTransactionDate = Math.max(...transactionDates);
   const totalDays = (lastTransactionDate - firstTransactionDate) / 3600 / 24 / 1000;
   const totalOutflow = transactions.map(t => -t.amount).reduce(
-    (outflow, amount) => outflow + amount
+    (outflow, amount) => outflow + amount, 0
   );
   const avgDailyOutflow = totalOutflow / totalDays;
   const avgDailyTransactions = transactions.length / totalDays;

--- a/sauce/features/budget/days-of-buffering/index.js
+++ b/sauce/features/budget/days-of-buffering/index.js
@@ -1,3 +1,5 @@
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
+
 import { Feature } from 'toolkit/core/feature';
 import { getEntityManager } from 'toolkit/helpers/toolkit';
 
@@ -17,7 +19,7 @@ export class DaysOfBuffering extends Feature {
   }
 
   invoke() {
-    if (!shouldRender(this.lastRenderTime)) return;
+    if (!this.shouldInvoke() || !shouldRender(this.lastRenderTime)) return;
 
     const transactions = this.entityManager.getAllTransactions().filter(this.transactionFilter);
     const report = generateReport(transactions, this.accountBalance);
@@ -26,7 +28,7 @@ export class DaysOfBuffering extends Feature {
   }
 
   shouldInvoke() {
-    return true;
+    return toolkitHelper.getCurrentRouteName().indexOf('budget') > -1;
   }
 
   render(report) {

--- a/sauce/features/budget/days-of-buffering/index.js
+++ b/sauce/features/budget/days-of-buffering/index.js
@@ -17,7 +17,7 @@ export class DaysOfBuffering extends Feature {
   }
 
   invoke() {
-    if (!shouldRender(this.lastRenderTime)) return;
+    if (!shouldRender(this.lastRenderTime) || !this.shouldInvoke()) return;
 
     const transactions = this.entityManager.getAllTransactions().filter(this.transactionFilter);
     const report = generateReport(transactions, this.accountBalance);
@@ -26,7 +26,7 @@ export class DaysOfBuffering extends Feature {
   }
 
   shouldInvoke() {
-    return true;
+    return !(document.getElementsByClassName('budget-header-days')[0].classList.contains('budget-header-no-days'));
   }
 
   render(report) {

--- a/sauce/features/budget/days-of-buffering/index.js
+++ b/sauce/features/budget/days-of-buffering/index.js
@@ -26,7 +26,7 @@ export class DaysOfBuffering extends Feature {
   }
 
   shouldInvoke() {
-    return !(document.getElementsByClassName('budget-header-days')[0].classList.contains('budget-header-no-days'));
+    return true;
   }
 
   render(report) {

--- a/sauce/features/budget/days-of-buffering/index.js
+++ b/sauce/features/budget/days-of-buffering/index.js
@@ -17,7 +17,7 @@ export class DaysOfBuffering extends Feature {
   }
 
   invoke() {
-    if (!shouldRender(this.lastRenderTime) || !this.shouldInvoke()) return;
+    if (!shouldRender(this.lastRenderTime)) return;
 
     const transactions = this.entityManager.getAllTransactions().filter(this.transactionFilter);
     const report = generateReport(transactions, this.accountBalance);

--- a/sauce/features/budget/days-of-buffering/render.js
+++ b/sauce/features/budget/days-of-buffering/render.js
@@ -5,12 +5,9 @@ const format = (...args) => (ynab.YNABSharedLib.currencyFormatter.format(...args
 const getDobEl = () => document.getElementsByClassName('days-of-buffering')[0];
 
 const createDobEl = () => {
-  const elementForDoB = document.getElementsByClassName('budget-header-days')[0]
-                                .cloneNode(true);
-
-  elementForDoB.className = elementForDoB.className + ' days-of-buffering';
-  elementForDoB.children[1].textContent = i10n('budget.ageOfMoneyDays.DoB', 'Days of Buffering');
-  elementForDoB.children[1].title = "Don't like AoM? Try this out instead!";
+  const elementForDoB = $('<div>', { class: 'budget-header-item budget-header-days days-of-buffering' }).
+    append($('<div>', { class: 'budget-header-days-age' })).
+    append($('<div>', { class: 'budget-header-days-label' }).text(i10n('budget.ageOfMoneyDays.DoB', 'Days of Buffering')).prop('title', 'Don\'t like AoM? Try this out instead!'))[0];
 
   document.getElementsByClassName('budget-header-flexbox')[0]
           .appendChild(elementForDoB);


### PR DESCRIPTION
Github Issue (if applicable): #1027 & #1026 and possibly #1024

#### Explanation of Bugfix/Feature/Enhancement:

The Days of Buffering Feature currently duplicates the node of the Age of Money feature and then updates the values. This obviously fails where AoM hasn't been created (fresh start #1026 & no transactions in a few months #1027).

I've created the Days of Buffering manually as opposed to cloning the AoM node.

Also added an initial value to the render for when there are zero transactions (#1026) as currently it will just fail.

First PR here, let me know if there are any issues!
