### PR TITLE
Removed calls to no longer available logging function

### DIFF
--- a/source/common/res/features/pacing/main.js
+++ b/source/common/res/features/pacing/main.js
@@ -184,12 +184,10 @@
 
                 if ($.inArray(name, latestDemphasizedCategories) >= 0) {
                   latestDemphasizedCategories.splice($.inArray(name, latestDemphasizedCategories), 1);
-                  ynab.utilities.ConsoleUtilities.logWithColor(ynab.constants.LogLevels.Debug, 'Re-emphasizing category ' + name + ', new hide list ' + JSON.stringify(latestDemphasizedCategories));
                   setDeemphasizedCategories(latestDemphasizedCategories);
                   $(this).removeClass('deemphasized');
                 } else {
                   latestDemphasizedCategories.push(name);
-                  ynab.utilities.ConsoleUtilities.logWithColor(ynab.constants.LogLevels.Debug, 'De-emphasizing category ' + name + ', new hide list ' + JSON.stringify(latestDemphasizedCategories));
                   setDeemphasizedCategories(latestDemphasizedCategories);
                   $(this).addClass('deemphasized');
                 }


### PR DESCRIPTION
Github Issue (if applicable): #1034 

Trello Link (if applicable):
 
Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:

Hi.

This is my first PR, so any feedback is welcomed.
Today I discovered your extension and was trying out pacing feature. It looked great, but when I tried to deemphasize category - nothing happened.

Those are logs from Chrome:
[app.youneedabudget.com-1509830371531.log](https://github.com/toolkit-for-ynab/toolkit-for-ynab/files/1443584/app.youneedabudget.com-1509830371531.log)

As it turned out the function ynab.utilities.ConsoleUtilities.logWithColor is no longer accessible.
My commit removes those calls, allowing pacing feature to work.

I don't have any experience with JS, so that might be not a proper solution. In that case I can open an issue.

#### Recommended Release Notes:
