### PR TITLE
press enter in move money popup to click OK

### DIFF
--- a/sauce/features/budget/enter-to-move/index.js
+++ b/sauce/features/budget/enter-to-move/index.js
@@ -1,0 +1,49 @@
+import { Feature } from 'toolkit/core/feature';
+import * as toolkitHelper from 'toolkit/helpers/toolkit';
+
+const MOVE_POPUP =
+  'ynab-u modal-popup modal-budget modal-budget-move-money ember-view modal-overlay active';
+const CATEGORY_DROPDOWN = 'dropdown-container categories-dropdown-container';
+const BUTTON_PRIMARY = 'button button-primary ';
+
+export class EnterToMove extends Feature {
+  modalIsOpen = false;
+
+  constructor() {
+    super();
+    this.onKeyDownHandler = this.onKeyDown.bind(this);
+  }
+
+  shouldInvoke() {
+    return toolkitHelper.getCurrentRouteName().indexOf('budget') !== -1;
+  }
+
+  invoke() {}
+
+  onKeyDown(e) {
+    const keycode = e.keycode || e.which;
+    if (keycode === 13) {
+      const OK = $(
+        '.modal-budget-move-money .modal-actions button:first-child'
+      );
+      OK.click();
+      document.removeEventListener('keydown', this.onKeyDownHandler, false);
+    }
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (changedNodes.has(MOVE_POPUP)) {
+      this.modalIsOpen = true;
+    }
+
+    if (
+      this.modalIsOpen &&
+      changedNodes.has(CATEGORY_DROPDOWN) &&
+      changedNodes.has(BUTTON_PRIMARY)
+    ) {
+      document.addEventListener('keydown', this.onKeyDownHandler, false);
+    }
+  }
+}

--- a/sauce/features/budget/enter-to-move/index.js
+++ b/sauce/features/budget/enter-to-move/index.js
@@ -5,14 +5,11 @@ const MOVE_POPUP =
   'ynab-u modal-popup modal-budget modal-budget-move-money ember-view modal-overlay active';
 const CATEGORY_DROPDOWN = 'dropdown-container categories-dropdown-container';
 const BUTTON_PRIMARY = 'button button-primary ';
+const BUTTON_CANCEL = 'button button-cancel';
+const MODAL_CONTENT = 'modal-content';
 
 export class EnterToMove extends Feature {
   modalIsOpen = false;
-
-  constructor() {
-    super();
-    this.onKeyDownHandler = this.onKeyDown.bind(this);
-  }
 
   shouldInvoke() {
     return toolkitHelper.getCurrentRouteName().indexOf('budget') !== -1;
@@ -20,16 +17,15 @@ export class EnterToMove extends Feature {
 
   invoke() {}
 
-  onKeyDown(e) {
+  onKeyDown = e => {
     const keycode = e.keycode || e.which;
     if (keycode === 13) {
       const OK = $(
         '.modal-budget-move-money .modal-actions button:first-child'
       );
       OK.click();
-      document.removeEventListener('keydown', this.onKeyDownHandler, false);
     }
-  }
+  };
 
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
@@ -43,7 +39,19 @@ export class EnterToMove extends Feature {
       changedNodes.has(CATEGORY_DROPDOWN) &&
       changedNodes.has(BUTTON_PRIMARY)
     ) {
-      document.addEventListener('keydown', this.onKeyDownHandler, false);
+      // Ready to click button
+      document.addEventListener('keydown', this.onKeyDown, false);
+    }
+
+    if (
+      this.modalIsOpen &&
+      changedNodes.has(BUTTON_PRIMARY) &&
+      changedNodes.has(BUTTON_CANCEL) &&
+      changedNodes.has(MODAL_CONTENT)
+    ) {
+      // Modal has closed
+      this.modalIsOpen = false;
+      document.removeEventListener('keydown', this.onKeyDown, false);
     }
   }
 }

--- a/sauce/features/budget/enter-to-move/settings.js
+++ b/sauce/features/budget/enter-to-move/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'EnterToMove',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Add "Enter" Shortcut to the Move Popup',
+  description:
+    'Pressing Enter in the Move Popup acts like clicking the OK button, instead of losing focus or doing nothing.'
+};


### PR DESCRIPTION
Github Issue (if applicable): #1044

#### Explanation of Bugfix/Feature/Enhancement:

When I'm moving money between categories, I automatically push Enter after putting the amount and category to move. However, this either takes focus away from the modal and closes it, or does nothing.

Now, you can press Enter after selecting a category and have the same behavior as clicking OK!

This uses an event listener on `document` to listen for the Enter key. The listener is added when the modal is opened and removed once Enter is pressed.
