### PR TITLE
Feature budget-category-info fix

### DIFF
--- a/source/common/res/features/budget-category-info/main.js
+++ b/source/common/res/features/budget-category-info/main.js
@@ -160,7 +160,8 @@
           // when this is moved to the webpack codebase, hopefully we can just listen to onRouteChanged
           // but until then we'll just have to keep adding stuff to this check that should trigger
           // budget-category related features to update
-          if (changedNodes.has('navlink-budget active') ||
+          if ((changedNodes.has('nav-main') && ynabToolKit.shared.getCurrentRoute().includes('budget')) ||
+            changedNodes.has('budget-table-row is-sub-category') ||
             changedNodes.has('budget-inspector') ||
             changedNodes.has('budget-table-cell-available-div user-data') ||
             changedNodes.has('budget-inspector-goals') ||


### PR DESCRIPTION
Added two instances not handled when deciding when rows need to be updated

Github Issue (if applicable): #997 #944 #846 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:

This fixes two scenarios where the budget-category-info feature should update rows but does not.

Scenario # 1: Navigating from somewhere else to the budget screen.
Scenario # 2: Selecting a different sub-category that has the same inspector goal type

#### Recommended Release Notes:

Bugfixes
