### PR TITLE
Implement auto-adjusting of split transactions

### DIFF
--- a/sauce/features/accounts/auto-distribute-splits/index.js
+++ b/sauce/features/accounts/auto-distribute-splits/index.js
@@ -93,7 +93,7 @@ export class AutoDistributeSplits extends Feature {
     subCells.forEach((cell, i) => {
       $(cell).val(
         actualNumber(newSubValues[i])
-          ? String(Math.round(newSubValues[i] * 100) / 100)
+          ? (Math.round(newSubValues[i] * 100) / 100).toFixed(2)
           : ''
       );
       $(cell).trigger('change');

--- a/sauce/features/accounts/auto-distribute-splits/index.js
+++ b/sauce/features/accounts/auto-distribute-splits/index.js
@@ -1,0 +1,104 @@
+import { Feature } from 'toolkit/core/feature';
+import { getEmberView } from 'toolkit/helpers/toolkit';
+
+const DISTRIBUTE_BUTTON_ID = 'auto-distribute-splits-button';
+const SPLIT_BUTTON_CLASS =
+  'button button-primary modal-account-categories-split-transaction';
+
+function actualNumber(n) {
+  return typeof n === 'number' && !isNaN(n);
+}
+
+export class AutoDistributeSplits extends Feature {
+  constructor() {
+    super();
+    this.button = document.createElement('button');
+    this.button.id = DISTRIBUTE_BUTTON_ID;
+    this.button.classList.add('button');
+    this.button.classList.add('button-primary');
+    this.button.innerHTML = 'Auto-Distribute';
+    this.button.onclick = () => {
+      this.distribute();
+      this.button.blur();
+    };
+  }
+
+  observe(changedNodes) {
+    if (changedNodes.has(SPLIT_BUTTON_CLASS) && !this.buttonPresent()) {
+      this.addButton();
+    }
+  }
+
+  buttonPresent() {
+    return !!document.getElementById(DISTRIBUTE_BUTTON_ID);
+  }
+
+  addButton() {
+    $('.ynab-grid-actions .ynab-grid-cell-subCategoryName').append(this.button);
+  }
+
+  distribute() {
+    const [[, ...subCells], [total, ...subValues]] = this.getCellsAndValues();
+    if (!this.canDistribute(total, subValues)) {
+      this.alertCannotDistribute();
+      return;
+    }
+
+    const remaining = this.getRemainingValue(total, subValues);
+    if (remaining < 0 && !this.confirmSubtraction()) {
+      return;
+    }
+
+    this.adjustValues(
+      subCells,
+      subValues.map(this.proportionalValue(total, remaining))
+    );
+  }
+
+  getCellsAndValues() {
+    const cells = $('.is-editing .ynab-grid-cell-outflow input').toArray();
+    const values = cells.map(node => parseFloat(node.value.trim()));
+    return [cells, values];
+  }
+
+  canDistribute(total, subValues) {
+    return actualNumber(total) && subValues.any(actualNumber);
+  }
+
+  alertCannotDistribute() {
+    // eslint-disable-next-line no-alert
+    alert(
+      'Must fill in at least the total and one sub-transaction ' +
+        'in order to auto-distribute'
+    );
+  }
+
+  getRemainingValue(total, subValues) {
+    return total - subValues.filter(actualNumber).reduce((a, b) => a + b);
+  }
+
+  confirmSubtraction() {
+    // eslint-disable-next-line no-alert
+    return confirm(
+      'Sub-transactions add up to more than the total, ' +
+        'are you sure you want to subtract from them?'
+    );
+  }
+
+  proportionalValue(total, remaining) {
+    return value => value + value / (total - remaining) * remaining;
+  }
+
+  adjustValues(subCells, newSubValues) {
+    subCells.forEach((cell, i) => {
+      $(cell).val(
+        actualNumber(newSubValues[i])
+          ? String(Math.round(newSubValues[i] * 100) / 100)
+          : ''
+      );
+      $(cell).trigger('change');
+    });
+
+    getEmberView($('.ynab-grid-add-rows')[0].id).calculateSplitRemaining();
+  }
+}

--- a/sauce/features/accounts/auto-distribute-splits/index.js
+++ b/sauce/features/accounts/auto-distribute-splits/index.js
@@ -34,7 +34,7 @@ export class AutoDistributeSplits extends Feature {
   }
 
   addButton() {
-    $('.ynab-grid-actions .ynab-grid-cell-subCategoryName').append(this.button);
+    $('.ynab-grid-actions-buttons .button-cancel').after(this.button);
   }
 
   distribute() {

--- a/sauce/features/accounts/auto-distribute-splits/settings.js
+++ b/sauce/features/accounts/auto-distribute-splits/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'AutoDistributeSplits',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Add Auto-Distribute Button To Split Transactions',
+  description: 'Allows you to distribute the remaining amount in a split transaction proportionally to sub-transactions'
+};


### PR DESCRIPTION
Trello Link (if applicable): https://trello.com/c/MX65S7CO/153-auto-adjust-remainder-of-transaction-splits

#### Explanation of Bugfix/Feature/Enhancement:

This implements the feature from YNAB 4 where upon attempting to save a split transaction, if the amounts do not add up to the totals, the software asked if you wanted to auto-distribute the remaining amount proportionally amongst the splits. This was very convenient for splitting up a receipt while being conscious of sales tax.

Instead of a prompt, I made it an explicit button added whenever a split transaction is started. This seemed lighter-weight to me and more discoverable.

I switched over from YNAB 4 recently and this was the biggest missing feature for me. I hacked it together in a Tampermonkey script first because it was quicker than getting set up for development with Toolkit, but I thought after using it for a while thought it would be useful to others.

#### Example

Given the following split transaction:

![image](https://user-images.githubusercontent.com/1709318/33497573-5fad1f36-d69c-11e7-8c07-d1a7322017dc.png)

Pressing the "Auto-Distribute" button would result in this:

![image](https://user-images.githubusercontent.com/1709318/33497593-7367a000-d69c-11e7-981d-8a9b0a164700.png)
