### PR TITLE
Budget Balance to Zero Fix

### DIFF
--- a/sauce/features/budget/budget-balance-to-zero/index.js
+++ b/sauce/features/budget/budget-balance-to-zero/index.js
@@ -65,6 +65,10 @@ export class BudgetBalanceToZero extends Feature {
       }
     }
 
+    if (this.budgetView.categoriesViewModel === null) {
+      return;
+    }
+
     const categories = [];
     const masterCats = this.budgetView.categoriesViewModel.masterCategoriesCollection._internalDataArray;
     const masterCategories = masterCats.filter(category => category.internalName === null);


### PR DESCRIPTION
Github Issue (if applicable): --
Trello Link (if applicable): --
Forum Link (if applicable): --

**Explanation of Bugfix/Feature/Enhancement:**
Fixed an odd error where this.budgetView.categoriesViewModel could possibly be null immediately after a Fresh Start, resulting in YNAB crashing and forcing the user to refresh. This prevents the crash and ensures that the feature continues to work as expected.

Discovered the error when trying to replicate issues with the Days of Buffering feature and doing a Fresh Start.

**Recommended Release Notes:**
Bug fixes.