### PR TITLE
Fixes / Improvements for #117

### DIFF
--- a/sauce/features/general/square-negative-mode/index.css
+++ b/sauce/features/general/square-negative-mode/index.css
@@ -19,7 +19,8 @@
 /* Budget Numbers, pacing */
 li.budget-table-cell-available > div.budget-table-cell-available-div > span.negative,
 li.toolkit-row-availablenegative > budget-table-cell-available-div > span.cautious,
-li.budget-table-cell-pacing span.negative {
+li.budget-table-cell-pacing span.negative,
+li.budget-table-cell-pacing span.cautious {
     border-radius: 0em !important;
     -webkit-border-radius: 0em !important;
 }

--- a/source/common/res/features/highlight-negatives-negative/main.css
+++ b/source/common/res/features/highlight-negatives-negative/main.css
@@ -6,6 +6,18 @@
 	background: #b43326 !important;
 }
 
+/* pacing column */
+li.budget-table-cell-pacing span.cautious {
+    background: #d33c2d !important;
+}
+li.budget-table-cell-pacing .budget-table-cell-pacing-display.cautious:hover {
+	background: #b43326 !important;
+}
+li.budget-table-cell-pacing span.deemphasized.cautious,
+li.budget-table-cell-pacing span.deemphasized.cautious:hover {
+    background: none !important;
+}
+
 /* inspector */
 .budget-inspector-category-overview .toolkit-row-availablenegative dt.cautious {
 	color: #d33c2d;


### PR DESCRIPTION
Github Issue (if applicable): #117 
Trello Link (if applicable):
Forum Link (if applicable):

**Explanation of Bugfix/Feature/Enhancement:**
Fixes/improvements to make the “Square Negatives” and “Highlight Negatives Negative” work more consistently within the Pacing column. Values in the Pacing column will be square or highlighted in red appropriately if these features are on.

**Recommended Release Notes:**
Bugfixes