### PR TITLE
Budget Category Info Fix

### DIFF
--- a/source/common/res/features/budget-category-info/main.js
+++ b/source/common/res/features/budget-category-info/main.js
@@ -161,7 +161,6 @@
           // but until then we'll just have to keep adding stuff to this check that should trigger
           // budget-category related features to update
           if (changedNodes.has('navlink-budget active') ||
-            changedNodes.has('budget-table-header') ||
             changedNodes.has('budget-inspector') ||
             changedNodes.has('budget-table-cell-available-div user-data') ||
             changedNodes.has('budget-inspector-goals') ||

--- a/source/common/res/features/budget-category-info/main.js
+++ b/source/common/res/features/budget-category-info/main.js
@@ -123,7 +123,7 @@
               }
 
               // add available balance
-              var available = $(this).find('.budget-table-cell-available .currency').text();
+              var available = $(this).find('.budget-table-cell-available:first .currency').text();
               if (ynab.unformat(available) < 0) {
                 classes.push('availablenegative');
               } else if (ynab.unformat(available) > 0) {
@@ -161,6 +161,7 @@
           // but until then we'll just have to keep adding stuff to this check that should trigger
           // budget-category related features to update
           if (changedNodes.has('navlink-budget active') ||
+            changedNodes.has('budget-table-header') ||
             changedNodes.has('budget-inspector') ||
             changedNodes.has('budget-table-cell-available-div user-data') ||
             changedNodes.has('budget-inspector-goals') ||


### PR DESCRIPTION
Github Issue (if applicable): #626, #944
Trello Link (if applicable):
Forum Link (if applicable):

****Explanation of Bugfix/Feature/Enhancement:****
Corrected a bug where the Pacing feature caused an error with the Budget Category Info loop, potentially resulting the labels in the Available and Pacing columns changing colors when the category was selected.

Ultimately, this feature will need to get rewritten when it's moved over to /sauce/, but this will help things in the mean time.

**Recommended Release Notes:**
Bugfixes.