### PR TITLE
Settings CSS Fix

### DIFF
--- a/source/common/options.css
+++ b/source/common/options.css
@@ -217,7 +217,10 @@ i {
   color: #292929;
   /* adjustments for markdown adding <p> */
   font-size: 16px;
-  margin-top: -15px;
+}
+
+.help-block p:first-child {
+  padding-top: 0;
 }
 
 #settingsSaved {


### PR DESCRIPTION
Github Issue (if applicable): #723 
Trello Link (if applicable):
Forum Link (if applicable):

**Explanation of Bugfix/Feature/Enhancement:**
Fix for #723, which corrects an error where the help text overlapped the select elements and made them more difficult to click.

**Recommended Release Notes:**
Bugfixes.