### PR TITLE
Pop-up calculator positioning fix

### DIFF
--- a/source/common/res/features/popup-calculator/budget/main.js
+++ b/source/common/res/features/popup-calculator/budget/main.js
@@ -125,7 +125,7 @@
                   .append($('<div>', { id: 'toolkit-popup-calc-' + id, class: 'toolkit-popup-calc-postition' })));
             });
 
-            switch (ynabToolKit.options.budgetRowsHeight) {
+            switch (ynabToolKit.options.RowsHeight) {
               case '0':
                 ynabToolKit.budgetPopupCalculator.buttonBottom = -242;
                 ynabToolKit.budgetPopupCalculator.buttonRight = 14;
@@ -150,6 +150,12 @@
           if (changedNodes.has('budget-content  resizable') ||
               changedNodes.has('budget-table-header') ||
               changedNodes.has('inspector-quick-budget')) {
+            ynabToolKit.budgetPopupCalculator.invoke();
+          }
+        },
+
+        onRouteChanged(currentRoute) {
+          if (currentRoute.indexOf('budget') !== -1) {
             ynabToolKit.budgetPopupCalculator.invoke();
           }
         }


### PR DESCRIPTION
and respond to route change.

Github Issue (if applicable): #XXX

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:
Popup calculator wasn't positioned correctly after the Budget Row Height feature went saucy because the name of the settings value changed. Also the route change wasn't being handled probably because of a change in the list of changed nodes so I added onRouteChanged().


#### Recommended Release Notes:
