### PR TITLE
Clean up the auto-distribute feature

### DIFF
--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -72,8 +72,9 @@ export class AutoDistributeSplits extends Feature {
 
   alertCannotDistribute() {
     // eslint-disable-next-line no-alert
-    alert('Must fill in at least the total and one sub-transaction ' +
-        'in order to auto-distribute');
+    alert('Please fill in the transaction total and at least one ' +
+        'sub-transaction in order to auto-distribute the ' +
+        'remaining amount between sub-transactions');
   }
 
   getRemainingValue(total, subValues) {
@@ -98,8 +99,6 @@ export class AutoDistributeSplits extends Feature {
       $(cell).trigger('change');
     });
 
-    getEmberView(
-      $('.ynab-grid-body-row.is-editing')[0].id
-    ).calculateSplitRemaining();
+    getEmberView($('.ynab-grid-body-row.is-editing')[0].id).calculateSplitRemaining();
   }
 }

--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -98,6 +98,8 @@ export class AutoDistributeSplits extends Feature {
       $(cell).trigger('change');
     });
 
-    getEmberView($('.ynab-grid-add-rows')[0].id).calculateSplitRemaining();
+    getEmberView(
+      $('.ynab-grid-body-row.is-editing')[0].id
+    ).calculateSplitRemaining();
   }
 }

--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -22,10 +22,15 @@ export class AutoDistributeSplits extends Feature {
   }
 
   observe(changedNodes) {
-    if (changedNodes.has('button button-primary modal-account-categories-split-transaction')
-        || changedNodes.has('ynab-grid-body-row ynab-grid-body-split is-editing')) {
+    if (this.buttonShouldBePresent(changedNodes)) {
       this.ensureButtonPresent();
     }
+  }
+
+  buttonShouldBePresent(changedNodes) {
+    return (changedNodes.has('button button-primary modal-account-categories-split-transaction')
+         || changedNodes.has('ynab-grid-body-row ynab-grid-body-split is-editing'))
+      && document.getElementsByClassName('ynab-grid-split-add-sub-transaction').length > 0;
   }
 
   ensureButtonPresent() {

--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -2,8 +2,6 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 
 const DISTRIBUTE_BUTTON_ID = 'auto-distribute-splits-button';
-const SPLIT_BUTTON_CLASS =
-  'button button-primary modal-account-categories-split-transaction';
 
 function actualNumber(n) {
   return typeof n === 'number' && !Number.isNaN(n);
@@ -24,17 +22,24 @@ export class AutoDistributeSplits extends Feature {
   }
 
   observe(changedNodes) {
-    if (changedNodes.has(SPLIT_BUTTON_CLASS) && !this.buttonPresent()) {
-      this.addButton();
+    if (!changedNodes.has('ynab-grid-actions-buttons')) {
+      if (
+        $('.ynab-grid-cell-subCategoryName input').val() ===
+        'Split (Multiple Categories)...'
+      ) {
+        this.ensureButtonPresent();
+      }
+    }
+  }
+
+  ensureButtonPresent() {
+    if (!this.buttonPresent()) {
+      $('.ynab-grid-actions-buttons .button-cancel').after(this.button);
     }
   }
 
   buttonPresent() {
-    return !!document.getElementById(DISTRIBUTE_BUTTON_ID);
-  }
-
-  addButton() {
-    $('.ynab-grid-actions-buttons .button-cancel').after(this.button);
+    return $('.ynab-grid-actions-buttons .' + DISTRIBUTE_BUTTON_ID).length > 0;
   }
 
   distribute() {

--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -22,13 +22,9 @@ export class AutoDistributeSplits extends Feature {
   }
 
   observe(changedNodes) {
-    if (!changedNodes.has('ynab-grid-actions-buttons')) {
-      if (
-        $('.ynab-grid-cell-subCategoryName input').val() ===
-        'Split (Multiple Categories)...'
-      ) {
-        this.ensureButtonPresent();
-      }
+    if (changedNodes.has('button button-primary modal-account-categories-split-transaction')
+        || changedNodes.has('ynab-grid-body-row ynab-grid-body-split is-editing')) {
+      this.ensureButtonPresent();
     }
   }
 


### PR DESCRIPTION
This fixes a few issues brought up in the original pull request (https://github.com/toolkit-for-ynab/toolkit-for-ynab/pull/1061):

- The button now gets added based on the text of the category field, meaning:
    - It shows up both for new transactions and when editing
    - It doesn't show up on non-split transactions
- The error message when unable to auto-distribute is friendlier

Also, the controller with the `calculateSplitRemaining` method got moved/merged with another controller, so I changed it to the new one.