### PR TITLE
Fix retro calculator feature

### DIFF
--- a/sauce/features/budget/enable-retro-calculator/index.js
+++ b/sauce/features/budget/enable-retro-calculator/index.js
@@ -2,7 +2,7 @@ import { Feature } from 'toolkit/core/feature';
 import { getCurrentRouteName } from 'toolkit/helpers/toolkit';
 
 export class EnableRetroCalculator extends Feature {
-  onRouteChanged(route) {
+  onRouteChanged() {
     // Remove our handler no matter what, because if they move between
     // months, we'll end up attaching multiple, which would be bad.
     // Let's always remove and then reattach if needed.
@@ -12,7 +12,7 @@ export class EnableRetroCalculator extends Feature {
 
     $(document).off('keypress', selector, this.handleKeypress);
 
-    if (route === 'budget.select') {
+    if (this.shouldInvoke()) {
       $(document).on('keypress', selector, this.handleKeypress);
     }
   }
@@ -21,11 +21,13 @@ export class EnableRetroCalculator extends Feature {
     // If we're loading up on the budget page, then we should trigger
     // our listener on startup. Let's pretend we switched routes
     // so that the normal handling happens.
-    return getCurrentRouteName() === 'budget.select';
+    return getCurrentRouteName().indexOf('budget') !== -1;
   }
 
   invoke() {
-    this.onRouteChanged(getCurrentRouteName());
+    if (this.shouldInvoke()) {
+      this.onRouteChanged();
+    }
   }
 
   handleKeypress(e) {


### PR DESCRIPTION
Github Issue (if applicable): #1092

#### Explanation of Bugfix/Feature/Enhancement:
The feature was only worrying about the `budget.select` route which
is specific to budget pages with a month specified. But it's possible to
get to the `budget.index` route by navigation from open budget -> your budget.
This result then gets cached apparently in local storage and used which is
weird but...there ya have it.

Now we just check for the word `budget` in the route name which means it
will run on the "Open A Budget" page but that should be okay since the
keypress listener is added to the document which will be there on that page :D


#### Recommended Release Notes:
Fixed an issue where the retro calculator feature would not always work.