### PR TITLE
Add text regarding the location of the button

### DIFF
--- a/sauce/features/accounts/toggle-splits/settings.js
+++ b/sauce/features/accounts/toggle-splits/settings.js
@@ -3,6 +3,6 @@ module.exports = {
   type: 'checkbox',
   default: false,
   section: 'accounts',
-  title: 'Add a Toggle Splits Button',
-  description: 'Clicking the toggle splits button shows or hides the sub-transactions within a split.'
+  title: 'Add a Toggle Splits Button to the Account(s) toolbar',
+  description: 'Clicking the Toggle Splits button shows or hides all sub-transactions within all split transactions. *__Note__: you must toggle splits open before editing a split transaction!*'
 };


### PR DESCRIPTION
and that splits must be toggled open before editing a split txn.

Github Issue (if applicable): #XXX

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:



#### Recommended Release Notes:
