### PR TITLE
Fix firefox options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ save-commands.json
 
 # we use yarn -- ignore package-lock in case someone npm installed
 package-lock.json
+yarn-error.log
 
 # build directory
 dist/

--- a/src/core/browser/options/options.js
+++ b/src/core/browser/options/options.js
@@ -326,12 +326,8 @@ jq(() => {
   }
 
   function updateToolkitLogo(isToolkitDisabled) {
-    const logos = {
-      false: 'assets/images/logos/toolkitforynab-logo-200.png',
-      true: 'assets/images/logos/toolkitforynab-logo-200-disabled.png'
-    };
-
-    jq('#logo').attr('src', getBrowser().runtime.getURL(logos[isToolkitDisabled]));
+    const logo = `assets/images/logos/toolkitforynab-logo-200${isToolkitDisabled ? '-disabled' : ''}.png`;
+    jq('#logo').attr('src', getBrowser().runtime.getURL(logo));
   }
 
   function toggleToolkit() {


### PR DESCRIPTION
When fetching all user settings, we weren't chaining the promises
correctly. We were just simply passing the `getFeatureSetting` call
into the `.then()` of our `setFeatureSetting` when we need to pass
a function which returns a Promise for the proper chain to occur.