### PR TITLE
Feature needed to call shouldInvoke()

### DIFF
--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -13,6 +13,8 @@ export class EasyTransactionApproval extends Feature {
   }
 
   observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
     // watch for the user potentially changing the budget
     if (this.initBudgetVersion) {
       this.addBudgetVersionIdObserver();


### PR DESCRIPTION
in the observe() function to ensure it was only running on the
account(s) view.

Github Issue (if applicable): #XXX

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:



#### Recommended Release Notes:
