### PR TITLE
Removing unsafe-eval from our CSP

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -35,7 +35,7 @@
     "page": "options/index.html"
   },
   "manifest_version": 2,
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self'; object-src 'self'",
   "browser_action": {
     "default_icon": "assets/images/icons/button.png",
     "default_title": "Toolkit for YNAB",


### PR DESCRIPTION
It got knocked back in Firefox review.

#### Explanation of Bugfix/Feature/Enhancement:

This seems to work for me. Is there something I'm missing?

#### Recommended Release Notes:
N/A