### PR TITLE
Add tests to the toolkit entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-# OSX is a troll
+# workspace files
 .DS_Store
 .project
 
-# don't want to push node_modules :O
+# build/generated files
 node_modules/
+coverage/
 
 # extension deploy stuff
 certificates/

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-loader": "^6.2.10",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "chokidar": "^1.6.0",
     "chrome-webstore-upload": "0.2.1",
@@ -67,7 +68,6 @@
     ]
   },
   "jest": {
-    "collectCoverage": true,
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/"

--- a/src/extension/features/budget/days-of-buffering/helpers.js
+++ b/src/extension/features/budget/days-of-buffering/helpers.js
@@ -16,7 +16,7 @@ const isValidDate = (transactionTime, currentTime, historyLookupMonths) => {
 };
 
 
-export function outflowTransactionsFilter(historyLookupMonths) {
+export function outflowTransactionFilter(historyLookupMonths) {
   const dateNow = Date.now();
 
   return (transaction) => (

--- a/src/extension/index.js
+++ b/src/extension/index.js
@@ -1,0 +1,3 @@
+import { YNABToolkit } from './ynab-toolkit';
+const ynabToolkit = new YNABToolkit();
+ynabToolkit.initializeToolkit();

--- a/src/extension/utils/feature.js
+++ b/src/extension/utils/feature.js
@@ -1,0 +1,6 @@
+export function isFeatureEnabled(feature) {
+  return (
+    (typeof feature.settings.enabled === 'boolean' && feature.settings.enabled) ||
+    (typeof feature.settings.enabled === 'string' && feature.settings.enabled !== '0') // assumes '0' means disabled
+  );
+}

--- a/src/extension/utils/ynab.js
+++ b/src/extension/utils/ynab.js
@@ -31,3 +31,13 @@ export function getAllBudgetMonthsViewModel() {
 export function getAllBudgetMonthsViewModelResult() {
   return getAllBudgetMonthsViewModel()._result;
 }
+
+export function isYNABReady() {
+  return (
+    typeof Em !== 'undefined' &&
+    typeof Ember !== 'undefined' &&
+    typeof $ !== 'undefined' &&
+    $('.ember-view.layout').length &&
+    typeof ynabToolKit !== 'undefined'
+  );
+}

--- a/src/extension/ynab-toolkit.test.js
+++ b/src/extension/ynab-toolkit.test.js
@@ -1,0 +1,72 @@
+import { YNABToolkit, TOOLKIT_LOADED_MESSAGE, TOOLKIT_BOOTSTRAP_MESSAGE } from './ynab-toolkit';
+import { allToolkitSettings } from 'toolkit/core/settings';
+
+const setup = (setupOptions = {}) => {
+  const options = {
+    initialize: true,
+    ...setupOptions
+  };
+
+  let messageCallback;
+  const addEventListenerSpy = jest.spyOn(window, 'addEventListener').mockImplementation((event, callback) => {
+    messageCallback = callback;
+  });
+
+  const postMessageSpy = jest.spyOn(window, 'postMessage');
+  const callMessageListener = (...args) => {
+    messageCallback.apply(null, args);
+  };
+
+  const ynabToolkit = new YNABToolkit();
+  if (options.initialize) {
+    ynabToolkit.initializeToolkit();
+  }
+
+  const toolkitBootStrap = { options: {} };
+  allToolkitSettings.forEach((setting) => {
+    toolkitBootStrap.options[setting.name] = true;
+  });
+
+  return {
+    addEventListenerSpy,
+    callMessageListener,
+    postMessageSpy,
+    toolkitBootStrap,
+    ynabToolkit
+  };
+};
+
+describe('YNABToolkit', () => {
+  describe('.initializeToolkit()', () => {
+    it('should attach a message listener to the window', () => {
+      const { addEventListenerSpy, ynabToolkit } = setup({ initialize: false });
+      ynabToolkit.initializeToolkit();
+      expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+    });
+
+    it('should postMessage the toolkit loaded message', () => {
+      const { postMessageSpy, ynabToolkit } = setup({ initialize: false });
+      ynabToolkit.initializeToolkit();
+      expect(postMessageSpy).toHaveBeenCalledWith(TOOLKIT_LOADED_MESSAGE, '*');
+    });
+  });
+
+  describe('once the TOOLKIT_BOOTSTRAP_MESSAGE is received', () => {
+    it('should create the ynabToolKit global object', () => {
+      const { callMessageListener, toolkitBootStrap } = setup();
+      callMessageListener({
+        source: window,
+        data: {
+          type: TOOLKIT_BOOTSTRAP_MESSAGE,
+          ynabToolKit: toolkitBootStrap
+        }
+      });
+
+      expect(global.ynabToolKit).toEqual(toolkitBootStrap);
+    });
+
+    describe('once YNAB is ready', () => {
+      // TODO
+    });
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
     'options/options': path.resolve(`${CODE_SOURCE_DIR}/core/browser/options/options.js`),
     'popup/popup': path.resolve(`${CODE_SOURCE_DIR}/core/browser/popup/index.js`),
     'content-scripts/init': path.resolve(`${CODE_SOURCE_DIR}/core/browser/content-scripts/init.js`),
-    'web-accessibles/ynab-toolkit': path.resolve(`${CODE_SOURCE_DIR}/extension/ynab-toolkit.js`)
+    'web-accessibles/ynab-toolkit': path.resolve(`${CODE_SOURCE_DIR}/extension/index.js`)
   },
 
   devtool: 'source-map',


### PR DESCRIPTION
This will at least call new on every feature so we can ensure with some
level of certainty that the toolkit will at least load into the browser.

I still want to add some more generic tests that will call all the lifecycle functions of a feature if they exist but this should get us something to start with.