### PR TITLE
Wrap lifecycle calls with a try-catch

### DIFF
--- a/src/core/common/errors/__snapshots__/with-toolkit-error.test.js.snap
+++ b/src/core/common/errors/__snapshots__/with-toolkit-error.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withToolkitError should error if the first argument is not a function 1`] = `"The first argument to withToolkitError must be a Function"`;

--- a/src/core/common/errors/with-toolkit-error.js
+++ b/src/core/common/errors/with-toolkit-error.js
@@ -1,0 +1,33 @@
+export function withToolkitError(wrappedFunction, feature) {
+  if (typeof wrappedFunction !== 'function') {
+    throw new Error('The first argument to withToolkitError must be a Function');
+  }
+
+  let featureName = feature;
+  if (typeof feature === 'object') {
+    featureName = feature.constructor.name;
+  }
+
+  const featureSetting = ynabToolKit.options[featureName];
+  if (typeof featureSetting === 'undefined') {
+    console.warn("Second argument to withToolkitError should either be Feature Class or Feature Name as found in the feature's settings.js file");
+  }
+
+  return function () {
+    try {
+      return wrappedFunction();
+    } catch (exception) {
+      logToolkitError(exception, featureName, wrappedFunction.name, featureSetting);
+    }
+  };
+}
+
+export function logToolkitError(exception, featureName, location, featureSetting) {
+  let message = `Toolkit Error:
+    - Feature: ${featureName}
+    - Location: ${location || 'anonymous'}
+    - User Setting: ${featureSetting}
+    - Message: ${exception.message ? exception.message : 'none'}`;
+
+  console.error(message, exception.stack ? exception.stack : '');
+}

--- a/src/extension/features/accounts/change-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-enter-behavior/index.js
@@ -13,7 +13,7 @@ export class ChangeEnterBehavior extends Feature {
     const $outflowInput = $('.ynab-grid-cell-outflow input', $addRow);
     const $inflowInput = $('.ynab-grid-cell-inflow input', $addRow);
 
-    if (!$memoInput[10].getAttribute('data-toolkit-save-behavior')) {
+    if (!$memoInput[0].getAttribute('data-toolkit-save-behavior')) {
       $memoInput[0].setAttribute('data-toolkit-save-behavior', true);
       $memoInput.keydown(this.applyNewEnterBehavior);
     }

--- a/src/extension/features/accounts/change-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-enter-behavior/index.js
@@ -13,7 +13,7 @@ export class ChangeEnterBehavior extends Feature {
     const $outflowInput = $('.ynab-grid-cell-outflow input', $addRow);
     const $inflowInput = $('.ynab-grid-cell-inflow input', $addRow);
 
-    if (!$memoInput[0].getAttribute('data-toolkit-save-behavior')) {
+    if (!$memoInput[10].getAttribute('data-toolkit-save-behavior')) {
       $memoInput[0].setAttribute('data-toolkit-save-behavior', true);
       $memoInput.keydown(this.applyNewEnterBehavior);
     }

--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -1,3 +1,5 @@
+import { withToolkitError } from 'toolkit/core/common/errors/with-toolkit-error';
+
 let instance = null;
 
 export class ObserveListener {
@@ -51,7 +53,9 @@ export class ObserveListener {
 
   emitChanges() {
     this.features.forEach((feature) => {
-      Ember.run.later(feature.observe.bind(feature, this.changedNodes), 0);
+      const observe = feature.observe.bind(feature, this.changedNodes);
+      const wrapped = withToolkitError(observe, feature);
+      Ember.run.later(wrapped, 0);
     });
   }
 }

--- a/src/extension/listeners/routeChangeListener.js
+++ b/src/extension/listeners/routeChangeListener.js
@@ -1,4 +1,5 @@
 import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { withToolkitError } from 'toolkit/core/common/errors/with-toolkit-error';
 
 let instance = null;
 
@@ -30,14 +31,18 @@ export class RouteChangeListener {
       emitSameBudgetRouteChange: function () {
         let currentRoute = applicationController.get('currentRouteName');
         routeChangeListener.features.forEach((feature) => {
-          setTimeout(feature.onRouteChanged.bind(feature, currentRoute), 0);
+          const observe = feature.onRouteChanged.bind(feature, currentRoute);
+          const wrapped = withToolkitError(observe, feature);
+          Ember.run.later(wrapped, 0);
         });
       },
 
       emitBudgetRouteChange: function () {
         let currentRoute = applicationController.get('currentRouteName');
         routeChangeListener.features.forEach((feature) => {
-          setTimeout(feature.onBudgetChanged.bind(feature, currentRoute), 0);
+          const observe = feature.onBudgetChanged.bind(feature, currentRoute);
+          const wrapped = withToolkitError(observe, feature);
+          Ember.run.later(wrapped, 0);
         });
       }
     });

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,8 +1,19 @@
 import { Chrome } from 'toolkit/test/mocks/web-extensions/chrome';
 import { Ember } from 'toolkit/test/mocks/ember';
+import { allToolkitSettings } from 'toolkit/core/settings/settings';
 import $ from 'jquery';
 
 process.on('unhandledRejection', console.log.bind(console));
+
+function resetConsoleSpies() {
+  global.console = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn()
+  };
+}
 
 function resetWebExtensionsAPI() {
   let webExtensionsAPI = new Chrome();
@@ -12,11 +23,15 @@ function resetWebExtensionsAPI() {
 
 export function readyYNAB(options = {}) {
   const ember = new Ember();
+  const toolkitOptions = allToolkitSettings.reduce((settings, current) => {
+    settings[current.name] = false;
+    return settings;
+  }, {});
 
   global.Ember = ember;
   global.Em = ember;
   global.$ = $;
-  global.ynabToolKit = options.ynabToolKit || {};
+  global.ynabToolKit = options.ynabToolKit || { options: toolkitOptions };
 }
 
 export function unreadyYNAB() {
@@ -27,11 +42,13 @@ export function unreadyYNAB() {
 }
 
 beforeEach(() => {
+  resetConsoleSpies();
   resetWebExtensionsAPI();
   readyYNAB();
 
   localStorage.clear();
 });
 
+resetConsoleSpies();
 resetWebExtensionsAPI();
 readyYNAB();


### PR DESCRIPTION
Created a withToolkitError wrapper function which you can use to wrap
a call to some function with a try-catch which will verbosely log an error
to the console. In the future we can use this wrapper to also increment a
counter on top of the icon in the browser informing the user an error has
occured and perhaps provide a way for them to automatically report the error
to us.