### PR TITLE
Use outflowTransactionsFilter not outflowTransactionFilter

### DIFF
--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -1,7 +1,7 @@
 import { getEntityManager } from 'toolkit/extension/utils/ynab';
 import { Feature } from 'toolkit/extension/features/feature';
 import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
-import { generateReport, outflowTransactionFilter } from './helpers';
+import { generateReport, outflowTransactionsFilter } from './helpers';
 import { render, shouldRender } from './render';
 
 export class DaysOfBuffering extends Feature {
@@ -20,7 +20,7 @@ export class DaysOfBuffering extends Feature {
     if (!this.shouldInvoke() || !shouldRender(this.lastRenderTime)) return;
 
     if (this.transactionFilter === null) {
-      this.transactionFilter = outflowTransactionFilter(this.historyLookup);
+      this.transactionFilter = outflowTransactionsFilter(this.historyLookup);
     }
 
     const transactions = getEntityManager().getAllTransactions().filter(this.transactionFilter);


### PR DESCRIPTION
Github Issue (if applicable): #XXX

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:

There was a function called OutflowTransaction**s**Filter in days-of-buffering/helpers.js but it was imported and called as OutflowTransactionFilter in index.php within the same directory. This caused JS issues in the browser console when testing in Firefox nightly. This changes the calling code to call the function by it's correct name - though I haven't verified that the plural for transactions is indeed the logical name for the function.

#### Recommended Release Notes:
