### PR TITLE
Override accounts-toolbar CSS with friendly flexbox css

### DIFF
--- a/src/extension/features/accounts/toggle-transaction-filters/index.css
+++ b/src/extension/features/accounts/toggle-transaction-filters/index.css
@@ -1,7 +1,3 @@
-/* layout */
-#toolkit-toggleReconciled {
-	margin-right: 20px;
-}
 #toolkit-toggleReconciled.button-icononly {
 	margin-right: 1px;
 }

--- a/src/extension/ynab-toolkit.css
+++ b/src/extension/ynab-toolkit.css
@@ -1,0 +1,30 @@
+.accounts-toolbar {
+  display: flex;
+  justify-content: space-between;
+  padding-top: 0;
+}
+
+.accounts-toolbar .accounts-toolbar-left {
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.accounts-toolbar .accounts-toolbar-right {
+  height: auto;
+  display: flex;
+  align-items: center;
+  flex-direction: row-reverse;
+  flex-shrink: 0;
+}
+
+.accounts-toolbar .accounts-toolbar-right > .button {
+  position: static;
+}
+
+.accounts-toolbar .transaction-search {
+  height: inherit;
+}
+
+.accounts-toolbar .transaction-search .transaction-search-input {
+  position: static;
+}

--- a/src/extension/ynab-toolkit.css
+++ b/src/extension/ynab-toolkit.css
@@ -4,17 +4,17 @@
   padding-top: 0;
 }
 
-.accounts-toolbar .accounts-toolbar-left {
+.accounts-toolbar .accounts-toolbar-left,
+.accounts-toolbar .accounts-toolbar-right,
+.accounts-toolbar.buttons-can-overflow .accounts-toolbar-left {
   align-items: center;
   flex-shrink: 0;
+  height: auto;
 }
 
 .accounts-toolbar .accounts-toolbar-right {
-  height: auto;
   display: flex;
-  align-items: center;
   flex-direction: row-reverse;
-  flex-shrink: 0;
 }
 
 .accounts-toolbar .accounts-toolbar-right > .button {
@@ -22,7 +22,7 @@
 }
 
 .accounts-toolbar .transaction-search {
-  height: inherit;
+  height: auto;
 }
 
 .accounts-toolbar .transaction-search .transaction-search-input {

--- a/src/extension/ynab-toolkit.js
+++ b/src/extension/ynab-toolkit.js
@@ -56,7 +56,7 @@ export class YNABToolkit {
       }
 
       return css;
-    }, '');
+    }, require('./ynab-toolkit.css'));
 
     $('head').append($('<style>', { id: 'toolkit-injected-styles', type: 'text/css' })
       .text(globalCSS));


### PR DESCRIPTION
Github Issue (if applicable): #1149 
Forum Link (if applicable): https://forum.youneedabudget.com/discussion/55480/ynab-24th-january-update-screwed-toggle-scheduled-and-reconciled-transaction-buttons#latest

#### Explanation of Bugfix/Feature/Enhancement:
A CSS change caused feature which put buttons in the accounts-toolbar to look weird, I've completely overridden some css related to the accounts-toolbar to use flexbox instead of float which will allow us to (hopefully) safely add more things to the toolbar.

#### Recommended Release Notes:
Fixed an issue with the styling of features which take advantage of the accounts toolbar (where transaction search is)