### PR TITLE
Fix selector for auto-distribute feature

### DIFF
--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -24,13 +24,13 @@ export class AutoDistributeSplits extends Feature {
   observe(changedNodes) {
     if (this.buttonShouldBePresent(changedNodes)) {
       this.ensureButtonPresent();
+    } else {
+      this.ensureButtonNotPresent();
     }
   }
 
-  buttonShouldBePresent(changedNodes) {
-    return (changedNodes.has('button button-primary modal-account-categories-split-transaction')
-         || changedNodes.has('ynab-grid-body-row ynab-grid-body-split is-editing'))
-      && document.getElementsByClassName('ynab-grid-split-add-sub-transaction').length > 0;
+  buttonShouldBePresent() {
+    return $('.ynab-grid-split-add-sub-transaction').length > 0;
   }
 
   ensureButtonPresent() {
@@ -39,8 +39,14 @@ export class AutoDistributeSplits extends Feature {
     }
   }
 
+  ensureButtonNotPresent() {
+    if (this.buttonPresent()) {
+      $('#' + DISTRIBUTE_BUTTON_ID).remove();
+    }
+  }
+
   buttonPresent() {
-    return $('.ynab-grid-actions-buttons .' + DISTRIBUTE_BUTTON_ID).length > 0;
+    return $('#' + DISTRIBUTE_BUTTON_ID).length > 0;
   }
 
   distribute() {

--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -1,7 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 
-const DISTRIBUTE_BUTTON_ID = 'auto-distribute-splits-button';
+const DISTRIBUTE_BUTTON_ID = 'toolkit-auto-distribute-splits-button';
 
 function actualNumber(n) {
   return typeof n === 'number' && !Number.isNaN(n);


### PR DESCRIPTION
Github Issue (if applicable): N/A

Trello Link (if applicable): N/A

Forum Link (if applicable): N/A

#### Explanation of Bugfix/Feature/Enhancement:

They moved some things around again. This is more general, though it does execute a DOM query (looking for an id) for each `observe` call. Since I wanted to remove the button when it shouldn't be there (such as when changing the category from split back to some non-split category), and to prevent future changes by the YNAB team from being likely to break this feature, I decided the (relatively cheap) cost of an id lookup after each observe was worth it. If this is more expensive than I think, please let me know.

Tested:

- Opening an existing split transaction (appears)
- Opening an existing non-split transaction (does not appear)
- Categorizing a new transaction as a split (appears) and then back to a non-split category (disappears)

#### Recommended Release Notes:
