### PR TITLE
Days of Buffering feature was throwing an error during the initial load of the

### DIFF
--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -24,7 +24,13 @@ export class DaysOfBuffering extends Feature {
     }
 
     const transactions = getEntityManager().getAllTransactions().filter(this.transactionFilter);
-    const report = generateReport(transactions, this.accountBalance());
+    let report = { ableToGenerate: true };
+
+    try {
+      report = generateReport(transactions, this.accountBalance());
+    } catch (e) {
+      report = { ableToGenerate: false };
+    }
 
     this.render(report);
   }


### PR DESCRIPTION
toolkit. Changed the code to check that the report object was
successfully created before continuing to process the feature.

Github Issue (if applicable): #1055

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:


#### Recommended Release Notes:
