### PR TITLE
Remove starting balances from reports

### DIFF
--- a/src/extension/legacy/features/toolkit-reports/incomeVsExpense/main.js
+++ b/src/extension/legacy/features/toolkit-reports/incomeVsExpense/main.js
@@ -129,14 +129,16 @@
         },
 
         filterTransaction(transaction) {
-          let categoriesViewModel = ynab.YNABSharedLib.getBudgetViewModel_CategoriesViewModel()._result;
-          let masterCategoryId = transaction.get('masterCategoryId');
-          let subCategoryId = transaction.get('subCategoryId');
-          let isTransfer = masterCategoryId === null || subCategoryId === null;
-          let ynabCategory = categoriesViewModel.getMasterCategoryById(masterCategoryId);
-          let isInternalDebtCategory = isTransfer ? false : ynabCategory.isDebtPaymentMasterCategory();
+          const categoriesViewModel = ynab.YNABSharedLib.getBudgetViewModel_CategoriesViewModel()._result;
+          const masterCategoryId = transaction.get('masterCategoryId');
+          const subCategoryId = transaction.get('subCategoryId');
+          const isTransfer = masterCategoryId === null || subCategoryId === null;
+          const ynabCategory = categoriesViewModel.getMasterCategoryById(masterCategoryId);
+          const isInternalDebtCategory = isTransfer ? false : ynabCategory.isDebtPaymentMasterCategory();
+          const payee = transaction.getPayee();
+          const isStartingBalance = payee && payee.getInternalName() === ynab.constants.InternalPayees.StartingBalance;
 
-          return !transaction.get('isSplit') && !isTransfer && !isInternalDebtCategory;
+          return !transaction.get('isSplit') && !isTransfer && !isInternalDebtCategory && !isStartingBalance;
         },
 
         calculate(transactions) {
@@ -289,7 +291,13 @@
             $('.ynabtk-tfoot .ynabtk-tr', $outflowTable).append($('<th>', { class: 'col-data', text: outflowFormatted }));
 
             // net-income table
-            $('.ynabtk-header-row', $netIncomeTable).append($('<th>', { class: 'col-data', text: netIncomeFormatted }));
+            let currencyClass = '';
+            if (netIncome > 0) {
+              currencyClass = 'ynabtk-currency-positive';
+            } else if (netIncome < 0) {
+              currencyClass = 'ynabtk-currency-negative';
+            }
+            $('.ynabtk-header-row', $netIncomeTable).append($('<th>', { class: `col-data ${currencyClass}`, text: netIncomeFormatted }));
           });
 
           // add the toggle row for the payees first

--- a/src/extension/legacy/features/toolkit-reports/main.css
+++ b/src/extension/legacy/features/toolkit-reports/main.css
@@ -143,6 +143,14 @@
   flex-grow: 1;
 }
 
+.ynabtk-currency-positive {
+  color: #16a336;
+}
+
+.ynabtk-currency-negative {
+  color: #d33c2d;
+}
+
 /* noUiSlider classes */
 .noUi-connect {
   background: #34aebe;

--- a/src/extension/legacy/features/toolkit-reports/main.js
+++ b/src/extension/legacy/features/toolkit-reports/main.js
@@ -523,7 +523,8 @@ const YNAB_NATIVE_CONTENT_SELECTOR = 'div.scroll-wrap';
           // because the Toolkit reports <li> gets removed when the <li> for the native
           // YNAB links are updated. The CollapseSideMenu Toolkit feature relies on the
           // <li> so it needs to be added back if it's gone missing.
-          if (changedNodes.has('sidebar-contents') ||
+          if (changedNodes.has('nav-main') ||
+              changedNodes.has('sidebar-contents') ||
               changedNodes.has('navlink-budget active') ||
               changedNodes.has('navlink-reports active') ||
               changedNodes.has('navlink-accounts active')) {

--- a/src/extension/legacy/features/toolkit-reports/spendingByCategory/main.js
+++ b/src/extension/legacy/features/toolkit-reports/spendingByCategory/main.js
@@ -132,20 +132,21 @@
         filterTransaction(transaction) {
           // can't use a promise here and the _result *should* if there's anything to worry about,
           // it's this line but im still not worried about it.
-          let categoriesViewModel = ynab.YNABSharedLib.getBudgetViewModel_CategoriesViewModel()._result;
-          let masterCategoryId = transaction.get('masterCategoryId');
-          let subCategoryId = transaction.get('subCategoryId');
-          let isTransfer = masterCategoryId === null || subCategoryId === null;
-          let ynabCategory = categoriesViewModel.getMasterCategoryById(masterCategoryId);
-          let isInternalDebtCategory = isTransfer ? false : ynabCategory.isDebtPaymentMasterCategory();
-          let isInternalMasterCategory = isTransfer ? false : ynabCategory.isInternalMasterCategory();
-          let isPositiveStartingBalance = transaction.get('inflow') && isInternalMasterCategory;
+          const categoriesViewModel = ynab.YNABSharedLib.getBudgetViewModel_CategoriesViewModel()._result;
+          const masterCategoryId = transaction.get('masterCategoryId');
+          const subCategoryId = transaction.get('subCategoryId');
+          const isTransfer = masterCategoryId === null || subCategoryId === null;
+          const ynabCategory = categoriesViewModel.getMasterCategoryById(masterCategoryId);
+          const isInternalDebtCategory = isTransfer ? false : ynabCategory.isDebtPaymentMasterCategory();
+          const payee = transaction.getPayee();
+          const isStartingBalance = payee && payee.getInternalName() === ynab.constants.InternalPayees.StartingBalance;
 
           return !transaction.get('isSplit') &&
                  transaction.getAmount() &&
                  !isTransfer &&
                  !isInternalDebtCategory &&
-                 (!isPositiveStartingBalance || !transaction.get('inflow'));
+                 !isStartingBalance &&
+                 (!isStartingBalance || !transaction.get('inflow'));
         },
 
         calculate(transactions) {

--- a/src/extension/legacy/features/toolkit-reports/spendingByPayee/main.js
+++ b/src/extension/legacy/features/toolkit-reports/spendingByPayee/main.js
@@ -20,20 +20,20 @@
         filterTransaction(transaction) {
           // can't use a promise here and the _result *should* if there's anything to worry about,
           // it's this line but im still not worried about it.
-          let categoriesViewModel = ynab.YNABSharedLib.getBudgetViewModel_CategoriesViewModel()._result;
-          let masterCategoryId = transaction.get('masterCategoryId');
-          let subCategoryId = transaction.get('subCategoryId');
-          let isTransfer = masterCategoryId === null || subCategoryId === null;
-          let ynabCategory = categoriesViewModel.getMasterCategoryById(masterCategoryId);
-          let isInternalDebtCategory = isTransfer ? false : ynabCategory.isDebtPaymentMasterCategory();
-          let isInternalMasterCategory = isTransfer ? false : ynabCategory.isInternalMasterCategory();
-          let isPositiveStartingBalance = transaction.get('inflow') && isInternalMasterCategory;
+          const categoriesViewModel = ynab.YNABSharedLib.getBudgetViewModel_CategoriesViewModel()._result;
+          const masterCategoryId = transaction.get('masterCategoryId');
+          const subCategoryId = transaction.get('subCategoryId');
+          const isTransfer = masterCategoryId === null || subCategoryId === null;
+          const ynabCategory = categoriesViewModel.getMasterCategoryById(masterCategoryId);
+          const isInternalDebtCategory = isTransfer ? false : ynabCategory.isDebtPaymentMasterCategory();
+          const payee = transaction.getPayee();
+          const isStartingBalance = payee && payee.getInternalName() === ynab.constants.InternalPayees.StartingBalance;
 
           return transaction.getAmount() &&
                  !transaction.get('isSplit') &&
                  !isTransfer &&
                  !isInternalDebtCategory &&
-                 (!isPositiveStartingBalance || !transaction.get('inflow'));
+                (!isStartingBalance || !transaction.get('inflow'));
         },
 
         calculate(transactions) {


### PR DESCRIPTION
Also fixed #1161

#### Explanation of Bugfix/Feature/Enhancement:
Starting balances skew pretty much everything in reports so I've removed them.

#### Recommended Release Notes:
We've removed "Starting Balance" from Toolkit Reports since they aren't really an inflow or an outflow...they're just a baseline. If you would like to count your Starting Balance as an inflow or outflow in your reports, it's recommended that you change them to "Income: To Be Budgeted".