### PR TITLE
Add removeFeatureSetting to ToolkitStorage and use it in options

### DIFF
--- a/src/core/browser/options/options.js
+++ b/src/core/browser/options/options.js
@@ -306,8 +306,18 @@ jq(() => {
   }
 
   function resetSettings() {
-    return deleteAllToolkitSettings().then(function () {
-      window.location.reload();
+    // ensure there aren't any pre-web-extensions feature settings stored
+    localStorage.clear();
+
+    return storage.getStoredFeatureSettings().then((settings) => {
+      localStorage.clear();
+      const promises = settings.map((settingKey) => {
+        return storage.removeFeatureSetting(settingKey);
+      });
+
+      Promise.all(promises).then(() => {
+        window.location.reload();
+      });
     });
   }
 

--- a/src/core/common/storage/index.js
+++ b/src/core/common/storage/index.js
@@ -40,6 +40,10 @@ export class ToolkitStorage {
     return this.setStorageItem(featureSettingKey(settingName), value, options);
   }
 
+  removeFeatureSetting(settingName, options = {}) {
+    return this.removeStorageItem(featureSettingKey(settingName), options);
+  }
+
   getStorageItem(itemKey, options = {}) {
     return this._get(itemKey, options).then((value) => {
       if (typeof value === 'undefined' && typeof options.default !== 'undefined') {


### PR DESCRIPTION
Github Issue (if applicable): #1179

#### Explanation of Bugfix/Feature/Enhancement:
There was no way to delete feature settings. Now there is.

#### Recommended Release Notes:
Fixed the "Reset Settings" button.