### PR TITLE
Add Credit Card Emoji 💳 to the "Credit Card Payments" category group

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ on the roadmap. If you can't find what you want to build on the roadmap, feel fr
 a note up on the github issues board to let the team know you're working on something new.
 When your code is ready, submit a pull request. You can also contact @blarg on [the YNAB forums](http://forum.youneedabudget.com).
 
-For documentation on how to build a feature, [see the documentation](https://github.com/toolkit-for-ynab/toolkit-for-ynab/blob/master/source/common/res/features/HOW_TO_BUILD_FEATURES.md).
+For documentation on how to build a feature, [see the documentation](https://github.com/toolkit-for-ynab/toolkit-for-ynab/blob/master/docs/building-features.md).
 
 ### Building the Code
 This extension uses three main things in its build process:

--- a/src/README.md
+++ b/src/README.md
@@ -35,7 +35,7 @@ follow these steps:
 3. Create an `index.js` file which has the following:
   <!-- spacing is intentionally weird here because of markdown -->
   ```javascript
-  import { Feature } from 'toolkit/extension/features/feature';
+  import { Feature } from 'toolkit/core/feature';
 
   export class MyCoolFeature extends Feature {
     shouldInvoke() {
@@ -61,12 +61,9 @@ follow these steps:
 
   ```
 
-5. Run `yarn build` to build the extension into the `dist` directory.
+5. Run `./build` to build the extension for all the browswers.
 6. *chrome:* go to `chrome://extensions` and turn on "Developer mode". Then "Load
-unpacked extension". Select `dist/` and it will load into Chrome.
-   *firefox:* go to `about:addons`, select Extensions on the left, click the cog
-button, then "Install Add-on from File". Select `/dist/manifest.json` and it will
-load into Firefox.
+unpacked extension". Select `/output/chrome/` and it will load into chrome.
 7. Reload YNAB!
 
 In order to help you develop cool features, we've created a few API functions
@@ -82,8 +79,9 @@ that you get for free when extending `Feature`.
 Your feature's constructor is invoked as soon as the Toolkit is injected onto
 the page. You should not attempt a DOM manipulation or access to Ember/YNAB
 as it is not guaranteed or likely to be ready when your constructor is invoked.
-The job of the base `Feature` constructor is to do any initialisation that your
-feature requires. Most features do not need a constructor at all.
+The job of the base `Feature` constructor is to simply fetch the user settings
+of your feature. If `enabled` is set to false for your Feature's settings,
+then invoke will not be called.
 
 #### `willInvoke(): <void|Promise>`
 **optional function, not required to be declared**
@@ -138,7 +136,7 @@ For example, a CSS based feature to hide the referral program banner would look 
 
 **index.js**
 ```javascript
-import { Feature } from 'toolkit/extension/features/feature';
+import { Feature } from 'toolkit/core/feature';
 
 export class HideReferralBanner extends Feature {
   injectCSS() { return require('./index.css'); }

--- a/src/extension/features/budget/credit-card-emoji/credit.css
+++ b/src/extension/features/budget/credit-card-emoji/credit.css
@@ -1,0 +1,3 @@
+[title="Credit Card Payments"] .user-entered-text::before, .modal-budget-edit-category-label::before {
+  content: "💳 ";
+}

--- a/src/extension/features/budget/credit-card-emoji/credit.css
+++ b/src/extension/features/budget/credit-card-emoji/credit.css
@@ -1,3 +1,3 @@
-[title="Credit Card Payments"] .user-entered-text::before, .modal-budget-edit-category-label::before {
+[title="Credit Card Payments"] .user-entered-text::before {
   content: "💳 ";
 }

--- a/src/extension/features/budget/credit-card-emoji/index.js
+++ b/src/extension/features/budget/credit-card-emoji/index.js
@@ -1,0 +1,7 @@
+import { Feature } from 'toolkit/extension/features/feature';
+
+export class CreditCardEmoji extends Feature {
+  injectCSS() {
+    return require('./credit.css');
+  }
+}

--- a/src/extension/features/budget/credit-card-emoji/settings.js
+++ b/src/extension/features/budget/credit-card-emoji/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'CreditCardEmoji',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Credit Card Emoji',
+  description: 'Adds a credit card emoji 💳 to the "Credit Card Payments" category.'
+};


### PR DESCRIPTION
This is a second pull request for this feature. The first PR was #1013. This PR was rejected because YNAB changed the credit card payment category to be stickied at the top and added a few other UI tweaks, which I didn't have at the time. It seems YNAB has rolled this UI change back, and this PR feature is possible once again!

---

Users are unable to edit the name of the "Credit Card Payments" category group in YNAB. I have enjoyed adding emojis to all of my category names and this was the only category group missing an emoji. I built this little feature that adds the emoji for your through the toolkit!

A couple notes:
1. It took me less than an hour to build the app and get my feature working. The core team has built an awesome framework, great job!
2. This only works on the name of the category group in the budget list, and not in the modal that pops up when you click it (as if you were going to edit it). I played with using `.modal-budget-edit-category-label.user-data` to also make the change in the modal, but that also affected each credit card (since those titles are not editable as a budget).
 e.g.:
![image](https://user-images.githubusercontent.com/6256032/32033848-b31adcc4-b9d4-11e7-9179-5b01b264998c.png)



#### Recommended Release Notes:
- Added toggle for showing a credit card emoji on the "Credit Card Payments" category group.
