### PR TITLE
Remove override of top attribute for budget-table

### DIFF
--- a/src/extension/features/budget/rows-height/compact.css
+++ b/src/extension/features/budget/rows-height/compact.css
@@ -2,10 +2,6 @@
   height: 1.6em !important;
 }
 
-.budget-table {
-  top: 1.4em !important;
-}
-
 .budget-content ul, .budget-table-row.is-dragging {
   height: 2em;
 }


### PR DESCRIPTION
class for the compact view layout.

Github Issue (if applicable): #1205 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:


#### Recommended Release Notes:
Uncategorized transactions will no longer be hidden or partially hidden with budget row height of Compact.