### PR TITLE
Remove income from spending reports.

### DIFF
--- a/src/extension/legacy/features/toolkit-reports/spendingByCategory/main.js
+++ b/src/extension/legacy/features/toolkit-reports/spendingByCategory/main.js
@@ -141,12 +141,15 @@
           const payee = transaction.getPayee();
           const isStartingBalance = payee && payee.getInternalName() === ynab.constants.InternalPayees.StartingBalance;
 
-          return !transaction.get('isSplit') &&
-                 transaction.getAmount() &&
-                 !isTransfer &&
-                 !isInternalDebtCategory &&
-                 !isStartingBalance &&
-                 (!isStartingBalance || !transaction.get('inflow'));
+          return (
+            transaction.getAmount() &&
+            !transaction.get('isSplit') &&
+            !isTransfer &&
+            !isInternalDebtCategory &&
+            !isStartingBalance &&
+            !isStartingBalance &&
+            !transaction.get('inflow')
+          );
         },
 
         calculate(transactions) {

--- a/src/extension/legacy/features/toolkit-reports/spendingByPayee/main.js
+++ b/src/extension/legacy/features/toolkit-reports/spendingByPayee/main.js
@@ -29,11 +29,14 @@
           const payee = transaction.getPayee();
           const isStartingBalance = payee && payee.getInternalName() === ynab.constants.InternalPayees.StartingBalance;
 
-          return transaction.getAmount() &&
-                 !transaction.get('isSplit') &&
-                 !isTransfer &&
-                 !isInternalDebtCategory &&
-                (!isStartingBalance || !transaction.get('inflow'));
+          return (
+            transaction.getAmount() &&
+            !transaction.get('isSplit') &&
+            !isTransfer &&
+            !isInternalDebtCategory &&
+            !isStartingBalance &&
+            !transaction.get('inflow')
+          );
         },
 
         calculate(transactions) {


### PR DESCRIPTION
Github Issue (if applicable): #1212

#### Explanation of Bugfix/Feature/Enhancement:
When logic was updated to disclude starting balances, an errant check was added which caused inflows to be included with spending reports. 
