### PR TITLE
Fixed an issue where features on the budget page wouldn't appear immediately after navigating to the budget page

### DIFF
--- a/src/extension/legacy/features/act-on-change/main.js
+++ b/src/extension/legacy/features/act-on-change/main.js
@@ -71,6 +71,27 @@ Set.prototype.regex = function (regex) {
         });
       });
 
+      applicationController.addObserver('budgetVersionId', function () {
+        let currentRoute = applicationController.get('currentRouteName');
+        Ember.run.scheduleOnce('afterRender', function () {
+          ynabToolKit.shared.feedChanges({ routeChanged: currentRoute });
+        });
+      });
+
+      applicationController.addObserver('selectedAccountId', function () {
+        let currentRoute = applicationController.get('currentRouteName');
+        Ember.run.scheduleOnce('afterRender', function () {
+          ynabToolKit.shared.feedChanges({ routeChanged: currentRoute });
+        });
+      });
+
+      applicationController.addObserver('monthString', function () {
+        let currentRoute = applicationController.get('currentRouteName');
+        Ember.run.scheduleOnce('afterRender', function () {
+          ynabToolKit.shared.feedChanges({ routeChanged: currentRoute });
+        });
+      });
+
       ynabToolKit.onCurrentRouteChangedInit = true;
     };
 

--- a/src/extension/legacy/features/budget-category-info/main.js
+++ b/src/extension/legacy/features/budget-category-info/main.js
@@ -183,14 +183,10 @@
           }
         },
 
-        addBudgetVersionIdObserver() {
-          let applicationController = ynabToolKit.shared.containerLookup('controller:application');
-          applicationController.addObserver('budgetVersionId', function () {
-            Ember.run.scheduleOnce('afterRender', this, resetBudgetViewBudgetCategoryInfo);
-          });
-
-          function resetBudgetViewBudgetCategoryInfo() {
+        onRouteChanged() {
+          if (ynabToolKit.shared.getCurrentRoute().includes('budget')) {
             loadCategories = true;
+            ynabToolKit.budgetCategoryInfo.invoke();
           }
         }
       };
@@ -198,7 +194,6 @@
 
     // Run once and activate setTimeOut()
     ynabToolKit.budgetCategoryInfo.invoke();
-    ynabToolKit.budgetCategoryInfo.addBudgetVersionIdObserver();
   } else {
     setTimeout(poll, 250);
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.
-->

Github Issue (if applicable): #1189

#### Explanation of Bugfix/Feature/Modification:
The `budget-category-info` feature was only listening for `budgetVersionId` changes which doesn't handle the month changing. I added the same listeners to the legacy framework for `onRouteChanged` as are in the new framework and used then used that hook in the feature.
