### PR TITLE
Fixed an issue where YNAB would crash when selecting a date range with no transactions on the Net Worth report

### DIFF
--- a/src/extension/legacy/features/toolkit-reports/netWorth/main.js
+++ b/src/extension/legacy/features/toolkit-reports/netWorth/main.js
@@ -13,6 +13,10 @@
       function setHeaderValues(pointIndex) {
         let series = ynabToolKit.netWorthReport.chart.series;
         series.forEach((seriesData, index) => {
+          if (!seriesData.data[pointIndex]) {
+            return;
+          }
+
           let formattedCurrency = ynabToolKit.shared.formatCurrency(seriesData.data[pointIndex].y);
           if (index === 0) {
             seriesData.data[pointIndex].setState('hover');
@@ -33,6 +37,10 @@
 
       function onMouseOut(pointIndex) {
         ynabToolKit.netWorthReport.chart.series.forEach((seriesData) => {
+          if (!seriesData.data[pointIndex]) {
+            return;
+          }
+
           seriesData.data[pointIndex].setState('');
         });
       }


### PR DESCRIPTION
<!--
Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.
-->

Github Issue (if applicable): #1008

#### Explanation of Bugfix/Feature/Modification:
We attempting to attach hover listeners to data points to update the legend on Net Worth reports but if there are no data points, this would crash YNAB. Now we just early exit if there is no data.
