### PR TITLE
Improve spacing for credit card emoji feature

### DIFF
--- a/src/extension/features/budget/credit-card-emoji/credit.css
+++ b/src/extension/features/budget/credit-card-emoji/credit.css
@@ -1,3 +1,4 @@
 [title="Credit Card Payments"] .user-entered-text::before {
-  content: "💳 ";
+  content: "💳";
+  padding-right: .25em;
 }


### PR DESCRIPTION
This improves the look of the recently added "Credit Card Emoji" feature. Previously I had used a space after the emoji, but the spacing was messed up:

![image](https://user-images.githubusercontent.com/6256032/37548602-1fe40b00-2947-11e8-9e21-c9034d6d5310.png)

I've removed the spacing and added `.25em` of right padding to the emoji. This results in the title being lined up:

![image](https://user-images.githubusercontent.com/6256032/37548626-43cafa24-2947-11e8-9f05-efd34ca6a16c.png)
