### PR TITLE
Feature: Display "Total Monthly Goals" in Budget Inspector

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -55,7 +55,8 @@ export class DisplayTotalMonthlyGoals extends Feature {
 
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
-    if (changedNodes.has('budget-table-cell-budgeted')) {
+    if (changedNodes.has('budget-table-row is-sub-category is-checked') ||
+        changedNodes.has('budget-table-row is-sub-category')) {
       this.invoke();
     }
   }

--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -9,7 +9,11 @@ export class DisplayTotalMonthlyGoals extends Feature {
   }
 
   invoke() {
-    let monthlyGoalsTotal = 0;
+    const monthlyGoals = {
+      total: 0,
+      checkedTotal: 0,
+      checkedCount: 0
+    };
 
     $('.budget-table-row.is-sub-category').each((index, element) => {
       const emberId = element.id;
@@ -23,33 +27,51 @@ export class DisplayTotalMonthlyGoals extends Feature {
       const monthlyFunding = subCategory.get('monthlyFunding');
       const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
 
+      let monthlyCategoryGoal = 0;
+
       switch (goalType) {
         case 'MF': {
-          monthlyGoalsTotal += monthlyFunding;
+          monthlyCategoryGoal = monthlyFunding;
           break;
         }
         case 'TBD': {
-          monthlyGoalsTotal += targetBalanceDate;
+          monthlyCategoryGoal = targetBalanceDate;
           break;
         }
       }
+
+      monthlyGoals.total += monthlyCategoryGoal;
+      if ($(element).is('.is-checked')) {
+        monthlyGoals.checkedTotal += monthlyCategoryGoal;
+        monthlyGoals.checkedCount++;
+      }
     });
 
-    const currencyClass = (monthlyGoalsTotal === 0) ? 'zero' : 'positive';
+    const showAmount = monthlyGoals.checkedCount !== 1;
+    const amount = monthlyGoals.checkedCount > 0
+      ? monthlyGoals.checkedTotal
+      : monthlyGoals.total;
+
+    $('.total-monthly-goals-inspector').remove();
+
+    if (!showAmount) {
+      return;
+    }
+
+    const currencyClass = (amount === 0) ? 'zero' : 'positive';
 
     const monthlyGoalsInspectorElement = $(`
       <div class="total-monthly-goals-inspector">
         <h3>TOTAL MONTHLY GOALS</h3>
         <h1 title>
           <span class="user-data currency ${currencyClass}">
-            ${formatCurrency(monthlyGoalsTotal)}
+            ${formatCurrency(amount)}
           </span>
         </h1>
         <hr />
       </div>
     `);
 
-    $('.total-monthly-goals-inspector').remove();
     monthlyGoalsInspectorElement.insertBefore($('.inspector-quick-budget'));
   }
 

--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -1,0 +1,67 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { getEmberView } from 'toolkit/extension/utils/ember';
+import { formatCurrency } from 'toolkit/extension/utils/currency';
+import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+
+export class DisplayTotalMonthlyGoals extends Feature {
+  shouldInvoke() {
+    return getCurrentRouteName().indexOf('budget') !== -1 && this.settings.enabled !== '0';
+  }
+
+  invoke() {
+    let monthlyGoalsTotal = 0;
+
+    $('.budget-table-row.is-sub-category').each((index, element) => {
+      const emberId = element.id;
+      const viewData = getEmberView(emberId).data;
+      const {
+        subCategory,
+        monthlySubCategoryBudgetCalculation
+      } = viewData;
+
+      const goalType = subCategory.get('goalType');
+      const monthlyFunding = subCategory.get('monthlyFunding');
+      const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
+
+      switch (goalType) {
+        case 'MF': {
+          monthlyGoalsTotal += monthlyFunding;
+          break;
+        }
+        case 'TBD': {
+          monthlyGoalsTotal += targetBalanceDate;
+          break;
+        }
+      }
+    });
+
+    const currencyClass = (monthlyGoalsTotal === 0) ? 'zero' : 'positive';
+
+    const monthlyGoalsInspectorElement = $(`
+      <div class="total-monthly-goals-inspector">
+        <h3>TOTAL MONTHLY GOALS</h3>
+        <h1 title>
+          <span class="user-data currency ${currencyClass}">
+            ${formatCurrency(monthlyGoalsTotal)}
+          </span>
+        </h1>
+        <hr />
+      </div>
+    `);
+
+    monthlyGoalsInspectorElement.insertBefore($('.inspector-quick-budget'));
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+    if (changedNodes.has('budget-table-cell-budgeted')) {
+      $('.total-monthly-goals-inspector').remove();
+      this.invoke();
+    }
+  }
+
+  onRouteChanged() {
+    if (!this.shouldInvoke()) return;
+    this.invoke();
+  }
+}

--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -5,20 +5,16 @@ import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
 
 export class DisplayTotalMonthlyGoals extends Feature {
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') !== -1 && this.settings.enabled !== '0';
+    return getCurrentRouteName().indexOf('budget') !== -1;
   }
 
   extractCategoryGoalInformation(element) {
     const emberId = element.id;
     const viewData = getEmberView(emberId).data;
-    const {
-      subCategory,
-      monthlySubCategoryBudgetCalculation
-    } = viewData;
 
-    const goalType = subCategory.get('goalType');
-    const monthlyFunding = subCategory.get('monthlyFunding');
-    const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
+    const goalType = viewData.get('subCategory.goalType');
+    const monthlyFunding = viewData.get('subCategory.monthlyFunding');
+    const targetBalanceDate = viewData.get('monthlySubCategoryBudgetCalculation.goalTarget');
 
     let monthlyGoalAmount = 0;
 
@@ -35,7 +31,7 @@ export class DisplayTotalMonthlyGoals extends Feature {
 
     return {
       monthlyGoalAmount,
-      isChecked: $(element).is('.is-checked')
+      isChecked: viewData.get('isChecked')
     };
   }
 

--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -49,13 +49,13 @@ export class DisplayTotalMonthlyGoals extends Feature {
       </div>
     `);
 
+    $('.total-monthly-goals-inspector').remove();
     monthlyGoalsInspectorElement.insertBefore($('.inspector-quick-budget'));
   }
 
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
     if (changedNodes.has('budget-table-cell-budgeted')) {
-      $('.total-monthly-goals-inspector').remove();
       this.invoke();
     }
   }

--- a/src/extension/features/budget/display-total-monthly-goals/settings.js
+++ b/src/extension/features/budget/display-total-monthly-goals/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'DisplayTotalMonthlyGoals',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Display Total Monthly Goals',
+  description: 'Adds a \'Total Monthly Goals\' to the budget inspector, which displays the total amount of monthly funding goals.'
+};


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:

Shows "Total Monthly Goals" in the Budget Inspector.

"Total Monthly Goals" is here defined as the sum of all monthly + target budget by date goal amounts for the month; put another way, it is the number that shows for the "Underfunded" quick budget, if you have not budgeted money towards any goals in that month.

Background: I mostly made this for myself. I use goals heavily ... almost every category has a goal. I also have a spreadsheet where I keep track of the number of months I have covered in my budget. The "Total Monthly Goals" number is really helpful for populating that spreadsheet. It would be nice to see this merged so that I don't have to use a custom built version of the extension 😃