### PR TITLE
Bug: Display of goal indicator header

### DIFF
--- a/src/extension/features/budget/display-goal-amount/index.js
+++ b/src/extension/features/budget/display-goal-amount/index.js
@@ -12,7 +12,7 @@ export class DisplayTargetGoalAmount extends Feature {
     $('.budget-table-header .budget-table-cell-name').css('position', 'relative');
     $('.budget-table-row.is-sub-category li.budget-table-cell-name').css('position', 'relative');
 
-    $('.budget-table-header .budget-table-cell-name').append($('<div>', { class: 'budget-table-cell-goal' }).css({ position: 'absolute', right: 0, top: '6px' }).append('GOAL'));
+    $('.budget-table-header .budget-table-cell-name').append($('<div>', { class: 'budget-table-cell-goal' }).css({ position: 'absolute', right: 0, top: 0, 'line-height': '2.56rem' }).append('GOAL'));
 
     $('.budget-table-row.is-sub-category li.budget-table-cell-name').append($('<div>', { class: 'budget-table-cell-goal currency' }).css({
       background: '-webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 10%,rgba(255,255,255,1) 100%)', position: 'absolute', 'font-size': '80%', 'padding-left': '.75em', 'padding-right': '1px', 'line-height': '2.55em'


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:

The column header for the "Goal" column (for me anyway) displays weird:

![screen shot 2018-03-20 at 4 11 30 pm](https://user-images.githubusercontent.com/7999269/37680139-62e6615e-2c59-11e8-9d49-17639e0e8c38.png)

I think this is the result of a minor redesign that YNAB did awhile ago.  The updated 2.56rem value is from YNAB's `.categories-new-style .budget-table-header` style ... I could not find a way to make this work without hard-coding _something_.