### PR TITLE
Bug: Goal amounts don't update when they are changed in Inspector

### DIFF
--- a/src/extension/features/budget/display-goal-amount/index.js
+++ b/src/extension/features/budget/display-goal-amount/index.js
@@ -56,7 +56,8 @@ export class DisplayTargetGoalAmount extends Feature {
 
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
-    if (changedNodes.has('budget-table-cell-budgeted')) {
+    if (changedNodes.has('budget-table-cell-budgeted') ||
+        changedNodes.has('goal-message')) {
       $('.budget-table-cell-goal').remove();
       this.invoke();
     }


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:

Currently, the goal amount columns (for the "Display Target Goal Amount" feature) do not update when a category's goal is modified; they will only update once you budget money or navigate to a different month.  This PR is intended to address that behavior.