### PR TITLE
Update extension icon tooltip for Beta and Development builds

### DIFF
--- a/src/manifest.beta.json
+++ b/src/manifest.beta.json
@@ -1,3 +1,6 @@
 {
-  "name": "Toolkit for YNAB (Beta)"
+  "name": "Toolkit for YNAB (Beta)",
+  "browser_action": {
+    "default_title": "Toolkit for YNAB (Beta)"
+  }
 }

--- a/src/manifest.development.json
+++ b/src/manifest.development.json
@@ -1,3 +1,6 @@
 {
-  "name": "Toolkit for YNAB (Development)"
+  "name": "Toolkit for YNAB (Development)",
+  "browser_action": {
+    "default_title": "Toolkit for YNAB (Development)"
+  }
 }


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:

Small tweak to manifest overrides to update the tooltip on the extension icon for Beta and Development builds.