### PR TITLE
Fix a bug with `onBudgetChanged` and `willInvoke` error catching

### DIFF
--- a/src/extension/listeners/routeChangeListener.js
+++ b/src/extension/listeners/routeChangeListener.js
@@ -21,7 +21,13 @@ export class RouteChangeListener {
         'monthString', // this will handle changing which month of a budget you're looking at
         (controller, changedProperty) => {
           if (changedProperty === 'budgetVersionId') {
-            Ember.run.scheduleOnce('afterRender', controller, 'emitBudgetRouteChange');
+            (function poll() {
+              if (controller.get('budgetVersionId') === controller.get('budgetViewModel.budgetVersionId')) {
+                Ember.run.scheduleOnce('afterRender', controller, 'emitBudgetRouteChange');
+              } else {
+                Ember.run.next(poll, 250);
+              }
+            }());
           } else {
             Ember.run.scheduleOnce('afterRender', controller, 'emitSameBudgetRouteChange');
           }

--- a/src/extension/ynab-toolkit.js
+++ b/src/extension/ynab-toolkit.js
@@ -2,7 +2,7 @@ import 'babel-polyfill';
 import { features } from 'toolkit/extension/features';
 import { isYNABReady } from 'toolkit/extension/utils/ynab';
 import { isFeatureEnabled } from 'toolkit/extension/utils/feature';
-import { logFeatureError, withToolkitError } from 'toolkit/core/common/errors/with-toolkit-error';
+import { logToolkitError, withToolkitError } from 'toolkit/core/common/errors/with-toolkit-error';
 
 export const TOOLKIT_LOADED_MESSAGE = 'ynab-toolkit-loaded';
 export const TOOLKIT_BOOTSTRAP_MESSAGE = 'ynab-toolkit-bootstrap';
@@ -72,7 +72,7 @@ export class YNABToolkit {
         } catch (exception) {
           const featureName = feature.constructor.name;
           const featureSetting = ynabToolKit.options[featureName];
-          logFeatureError(exception, featureName, 'willInvoke', featureSetting);
+          logToolkitError(exception, featureName, 'willInvoke', featureSetting);
         }
 
         const wrappedShouldInvoke = withToolkitError(feature.shouldInvoke.bind(feature), feature);


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

#### Explanation of Bugfix/Feature/Modification:
We attach an observer to the applicationController's budgetVersionId
to detect when the user has switched budgets but this value changes
before YNAB loads data causing our feature code to potentially operate
on stale data. Now, we stil listen to the field because it's the best
source of truth we have but once it changes, we begin polling for the
budgetViewModel's budgetVersionId to match -- this should always happen
because the budget is the first view users see once swapping budgets.

