### PR TITLE
Automatically JSON.parse local storage values when using toolkit helpers

### DIFF
--- a/src/extension/features/accounts/adjustable-column-widths/index.js
+++ b/src/extension/features/accounts/adjustable-column-widths/index.js
@@ -107,7 +107,7 @@ export class AdjustableColumnWidths extends Feature {
     }
 
     RESIZABLES.forEach((resizableClass) => {
-      const width = getToolkitStorageKey(`column-width-${resizableClass}`, 'number');
+      const width = getToolkitStorageKey(`column-width-${resizableClass}`);
       if (width) {
         $(`.${resizableClass}`).width(width);
       }

--- a/src/extension/features/accounts/custom-flag-names/index.js
+++ b/src/extension/features/accounts/custom-flag-names/index.js
@@ -17,7 +17,7 @@ export class CustomFlagNames extends Feature {
       this.storeDefaultFlags();
     }
     if (typeof flags === 'undefined') {
-      flags = JSON.parse(getToolkitStorageKey('flags'));
+      flags = getToolkitStorageKey('flags');
       this.updateFlagLabels();
     }
   }
@@ -105,7 +105,7 @@ export class CustomFlagNames extends Feature {
       let key = flag.attr('id');
 
       flags[key].label = flag.val();
-      setToolkitStorageKey('flags', JSON.stringify(flags));
+      setToolkitStorageKey('flags', flags);
 
       this.updateFlagLabels();
       this.invoke();
@@ -148,6 +148,7 @@ export class CustomFlagNames extends Feature {
         color: '#9384b7'
       }
     };
-    setToolkitStorageKey('flags', JSON.stringify(flagsJSON));
+
+    setToolkitStorageKey('flags', flagsJSON);
   }
 }

--- a/src/extension/features/budget/resize-inspector/index.js
+++ b/src/extension/features/budget/resize-inspector/index.js
@@ -16,7 +16,7 @@ export class ResizeInspector extends Feature {
   }
 
   invoke() {
-    let width = getToolkitStorageKey('inspector-width', 'number');
+    let width = getToolkitStorageKey('inspector-width');
     if (typeof width === 'undefined' || width === null) {
       width = 0;
     }
@@ -93,7 +93,7 @@ export class ResizeInspector extends Feature {
       }
     });
 
-    let width = getToolkitStorageKey('inspector-width', 'number');
+    let width = getToolkitStorageKey('inspector-width');
     let btn = $modal.find('button[data-inspector-size="' + width + '"]');
     btn.prop('disabled', true);
     btn.addClass(BUTTONDISABLED);

--- a/src/extension/features/general/collapse-side-menu/index.js
+++ b/src/extension/features/general/collapse-side-menu/index.js
@@ -13,7 +13,7 @@ export class CollapseSideMenu extends Feature {
 
   observe(changedNodes) {
     if (changedNodes.has('nav-main')) {
-      if (getToolkitStorageKey('isCollapsed', 'boolean')) {
+      if (getToolkitStorageKey('isCollapsed')) {
         this.getHideElements().hide();
       }
 
@@ -22,7 +22,7 @@ export class CollapseSideMenu extends Feature {
   }
 
   onRouteChanged() {
-    if (getToolkitStorageKey('isCollapsed', 'boolean')) {
+    if (getToolkitStorageKey('isCollapsed')) {
       this.getHideElements().hide();
     }
 
@@ -41,7 +41,7 @@ export class CollapseSideMenu extends Feature {
     }).append($('<span>', {
       class: 'ember-view ynabtk-collapse-icon flaticon stroke left-circle-4'
     })).append(i10n('toolkit.collapse', 'Collapse'))).click(() => {
-      const isCollapsed = getToolkitStorageKey('isCollapsed', 'boolean');
+      const isCollapsed = getToolkitStorageKey('isCollapsed');
       setToolkitStorageKey('isCollapsed', !isCollapsed);
       this.applyState();
     });
@@ -50,7 +50,7 @@ export class CollapseSideMenu extends Feature {
   }
 
   applyState() {
-    const isCollapsed = getToolkitStorageKey('isCollapsed', 'boolean');
+    const isCollapsed = getToolkitStorageKey('isCollapsed');
 
     if (isCollapsed) {
       Promise.all([

--- a/src/extension/features/general/hide-help/index.js
+++ b/src/extension/features/general/hide-help/index.js
@@ -15,11 +15,7 @@ export class HideHelp extends Feature {
   }
 
   invoke() {
-    let hide = getToolkitStorageKey('hide-help');
-
-    if (hide === null) {
-      setToolkitStorageKey('hide-help', true);
-    }
+    const hide = getToolkitStorageKey('hide-help', true);
 
     if (hide) {
       $('body').addClass('toolkit-hide-help');
@@ -44,10 +40,11 @@ export class HideHelp extends Feature {
       </button>
      </li>
     `).click(() => {
-      let hide = !getToolkitStorageKey('hide-help');
-      setToolkitStorageKey('hide-help', hide);
+      const hide = getToolkitStorageKey('hide-help', true);
+      setToolkitStorageKey('hide-help', !hide);
+
       $('body').toggleClass('toolkit-hide-help');
-      let accountController = ynabToolKit.shared.containerLookup('controller:accounts');
+      const accountController = ynabToolKit.shared.containerLookup('controller:accounts');
       accountController.send('closeModal');
     }).appendTo($modalList);
 

--- a/src/extension/features/general/hide-help/index.js
+++ b/src/extension/features/general/hide-help/index.js
@@ -18,11 +18,10 @@ export class HideHelp extends Feature {
     let hide = getToolkitStorageKey('hide-help');
 
     if (hide === null) {
-      setToolkitStorageKey('hide-help', 'true');
-      hide = 'true';
+      setToolkitStorageKey('hide-help', true);
     }
 
-    if (hide === 'true') {
+    if (hide) {
       $('body').addClass('toolkit-hide-help');
     }
 
@@ -45,7 +44,7 @@ export class HideHelp extends Feature {
       </button>
      </li>
     `).click(() => {
-      let hide = !getToolkitStorageKey('hide-help', 'boolean');
+      let hide = !getToolkitStorageKey('hide-help');
       setToolkitStorageKey('hide-help', hide);
       $('body').toggleClass('toolkit-hide-help');
       let accountController = ynabToolKit.shared.containerLookup('controller:accounts');

--- a/src/extension/features/general/privacy-mode/index.js
+++ b/src/extension/features/general/privacy-mode/index.js
@@ -6,7 +6,7 @@ export class PrivacyMode extends Feature {
   }
 
   invoke() {
-    let toggle = ynabToolKit.shared.getToolkitStorageKey('privacy-mode', 'boolean');
+    let toggle = ynabToolKit.shared.getToolkitStorageKey('privacy-mode');
     if (typeof toggle === 'undefined') {
       ynabToolKit.shared.setToolkitStorageKey('privacy-mode', false);
     }
@@ -40,13 +40,13 @@ export class PrivacyMode extends Feature {
   togglePrivacyMode() {
     $('button#toolkit-togglePrivacy').toggleClass('active');
 
-    let toggle = ynabToolKit.shared.getToolkitStorageKey('privacy-mode', 'boolean');
+    let toggle = ynabToolKit.shared.getToolkitStorageKey('privacy-mode');
     ynabToolKit.shared.setToolkitStorageKey('privacy-mode', !toggle);
     this.updatePrivacyMode();
   }
 
   updatePrivacyMode() {
-    let toggle = ynabToolKit.shared.getToolkitStorageKey('privacy-mode', 'boolean');
+    let toggle = ynabToolKit.shared.getToolkitStorageKey('privacy-mode');
 
     if (toggle) {
       $('body').addClass('toolkit-privacyMode');

--- a/src/extension/legacy/features/shared/main.js
+++ b/src/extension/legacy/features/shared/main.js
@@ -384,13 +384,13 @@ ynabToolKit.shared = (function () {
       }
     },
 
-    getToolkitStorageKey(key, type) {
-      let value = localStorage.getItem(storageKeyPrefix + key);
+    getToolkitStorageKey(key) {
+      const value = localStorage.getItem(storageKeyPrefix + key);
 
-      switch (type) {
-        case 'boolean': return value === 'true';
-        case 'number': return Number(value);
-        default: return value;
+      try {
+        return JSON.parse(value);
+      } catch (e) {
+        return value;
       }
     },
 

--- a/src/extension/utils/toolkit.js
+++ b/src/extension/utils/toolkit.js
@@ -1,12 +1,16 @@
 const STORAGE_KEY_PREFIX = 'ynab-toolkit-';
 
 export function getToolkitStorageKey(key, defaultValue) {
-  const value = localStorage.getItem(STORAGE_KEY_PREFIX + key);
+  let serializedValue = localStorage.getItem(STORAGE_KEY_PREFIX + key);
+
+  if (serializedValue === null || serializedValue === 'undefined') {
+    return defaultValue;
+  }
 
   try {
-    return JSON.parse(value) || defaultValue;
+    return JSON.parse(serializedValue);
   } catch (e) {
-    return value || defaultValue;
+    return defaultValue;
   }
 }
 

--- a/src/extension/utils/toolkit.js
+++ b/src/extension/utils/toolkit.js
@@ -1,17 +1,17 @@
 const STORAGE_KEY_PREFIX = 'ynab-toolkit-';
 
-export function getToolkitStorageKey(key, type) {
-  let value = localStorage.getItem(STORAGE_KEY_PREFIX + key);
+export function getToolkitStorageKey(key, defaultValue) {
+  const value = localStorage.getItem(STORAGE_KEY_PREFIX + key);
 
-  switch (type) {
-    case 'boolean': return value === 'true';
-    case 'number': return Number(value);
-    default: return value;
+  try {
+    return JSON.parse(value) || defaultValue;
+  } catch (e) {
+    return value || defaultValue;
   }
 }
 
 export function setToolkitStorageKey(key, value) {
-  return localStorage.setItem(STORAGE_KEY_PREFIX + key, value);
+  return localStorage.setItem(STORAGE_KEY_PREFIX + key, JSON.stringify(value));
 }
 
 export function removeToolkitStorageKey(key) {


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
The original method of passing in a type to convert the value into was
not very scalable and not nearly as reliably as just JSON.parsing the value.
