### PR TITLE
Fixed an issue where the progress bars were displayed outside the current month.

### DIFF
--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName, getEntityManager } from 'toolkit/extension/utils/ynab';
+import { getCurrentRouteName, getEntityManager, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
 import { migrateLegacyPacingStorage, pacingForCategory } from 'toolkit/extension/utils/pacing';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 
@@ -20,7 +20,7 @@ export class BudgetProgressBars extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') > -1;
+    return getCurrentRouteName().indexOf('budget') > -1 && isCurrentMonthSelected();
   }
 
   // Takes N colors and N-1 sorted points from (0, 1) to make color1|color2|color3 bg style.
@@ -193,6 +193,10 @@ export class BudgetProgressBars extends Feature {
   }
 
   observe(changedNodes) {
+    if (!this.shouldInvoke()) {
+      return;
+    }
+
     /**
      * Check for this node seperately from the other checks to ensure the flag to load
      * categories gets set just in case there is another changed node that drives invoke().
@@ -228,4 +232,3 @@ export class BudgetProgressBars extends Feature {
     }
   }
 }
-


### PR DESCRIPTION

<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1189 (mentioned in this issue though directly about this PR)

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
Displaying the progress bars makes no sense outside the current month so they will no longer be displayed. This also includes the Pacing line and the Goals shading (progress indicator).
