### PR TITLE
Fixed an issue where the Auto-Distribute button wasn't being displayed

### DIFF
--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getEmberView } from 'toolkit/extension/utils/ember';
+import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
 
 const DISTRIBUTE_BUTTON_ID = 'toolkit-auto-distribute-splits-button';
 
@@ -21,12 +21,23 @@ export class AutoDistributeSplits extends Feature {
     };
   }
 
-  observe(changedNodes) {
-    if (this.buttonShouldBePresent(changedNodes)) {
+  shouldInvoke() {
+    return getCurrentRouteName().includes('account');
+  }
+
+  invoke() {
+    if (this.buttonShouldBePresent()) {
       this.ensureButtonPresent();
     } else {
       this.ensureButtonNotPresent();
     }
+  }
+
+  // don't really care which nodes have been changed since the feature doesn't trigger off of changed nodes but the presence of nodes.
+  observe() {
+    if (!this.shouldInvoke) return;
+
+    this.invoke();
   }
 
   buttonShouldBePresent() {
@@ -105,7 +116,5 @@ export class AutoDistributeSplits extends Feature {
         : '');
       $(cell).trigger('change');
     });
-
-    getEmberView($('.ynab-grid-body-row.is-editing')[0].id).calculateSplitRemaining();
   }
 }


### PR DESCRIPTION
when it should be.

<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1180

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
The shouldInvoke() and invoke() functions were not defined and an internal function we were calling is no longer available. Added the functions and looks like the internal function is no longer needed.  
