### PR TITLE
Use the YNAB component to hide the help button

### DIFF
--- a/src/extension/features/general/hide-help/index.css
+++ b/src/extension/features/general/hide-help/index.css
@@ -1,3 +1,0 @@
-.toolkit-hide-help #hs-beacon {
-	display: none;
-}

--- a/src/extension/features/general/hide-help/index.js
+++ b/src/extension/features/general/hide-help/index.js
@@ -1,51 +1,62 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+import { getEmberView, controllerLookup } from 'toolkit/extension/utils/toolkit';
 
 export class HideHelp extends Feature {
   injectCSS() { return require('./index.css'); }
 
-  shouldInvoke() {
-    return true;
-  }
+  shouldInvoke() { return true; }
 
   observe(changedNodes) {
     if (changedNodes.has('ynab-u modal-popup modal-user-prefs ember-view modal-overlay active')) {
-      this.invoke();
+      this.updatePopupButton();
     }
   }
 
   invoke() {
-    const hide = getToolkitStorageKey('hide-help', true);
+    const initialState = getToolkitStorageKey('hide-help', true);
+    this.setHiddenState(initialState);
+  }
 
-    if (hide) {
-      $('body').addClass('toolkit-hide-help');
+  getBeacon() {
+    return getEmberView($('.self-service').attr('id'));
+  }
+
+  isBeaconHidden() {
+    return this.getBeacon().getBeaconContainer().css('display') === 'none';
+  }
+
+  setHiddenState(state) {
+    setToolkitStorageKey('hide-help', state);
+    const beacon = this.getBeacon();
+    if (state) {
+      beacon.hideContainer();
+    } else {
+      beacon.showContainer();
     }
-
-    this.updatePopupButton();
   }
 
   updatePopupButton() {
-    let $modal = $('.modal-user-prefs .modal');
-    let $modalList = $('.modal-user-prefs .modal-list');
+    const isBeaconHidden = this.isBeaconHidden();
+    const $modal = $('.modal-user-prefs .modal');
+    const $modalList = $('.modal-user-prefs .modal-list');
 
     if ($('.ynab-toolkit-hide-help', $modalList).length) return;
 
-    let $label = 'Show';
-    if ($('#hs-beacon').is(':visible')) { $label = 'Hide'; }
+    // it's possible the beacon doesn't actually match the state we think it should so don't
+    // set the label based on what we have in local storage so we should always use the source
+    // of truth when toggling. We'll use local storage to get the initial state.
+    const label = isBeaconHidden ? 'Hide' : 'Show';
 
     $(`<li class="ynab-toolkit-hide-help">
       <button>
         <i class="flaticon stroke help-2"></i>
-        ` + $label + ` Help Button
+        ` + label + ` Help Button
       </button>
      </li>
     `).click(() => {
-      const hide = getToolkitStorageKey('hide-help', true);
-      setToolkitStorageKey('hide-help', !hide);
-
-      $('body').toggleClass('toolkit-hide-help');
-      const accountController = ynabToolKit.shared.containerLookup('controller:accounts');
-      accountController.send('closeModal');
+      this.setHideState(!isBeaconHidden);
+      controllerLookup('controller:accounts').send('closeModal');
     }).appendTo($modalList);
 
     $modal.css({ height: '+=12px' });

--- a/src/extension/features/general/hide-help/index.js
+++ b/src/extension/features/general/hide-help/index.js
@@ -3,8 +3,6 @@ import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/ut
 import { getEmberView, controllerLookup } from 'toolkit/extension/utils/toolkit';
 
 export class HideHelp extends Feature {
-  injectCSS() { return require('./index.css'); }
-
   shouldInvoke() { return true; }
 
   observe(changedNodes) {


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1264 

#### Explanation of Bugfix/Feature/Modification:
The `#hs-beacon` now has a hard coded `display: block` on the element. We could use `!important` but I opted to just swap to use JS for this feature since it should be more fail-proof. Also we'll now always generate the hide/show help button based off the state of the HS-beacon. Before, we'd show the text based of the state of the world but we would only do what local storage said we should.
