### PR TITLE
Feature: View Zero as Empty 

### DIFF
--- a/src/extension/features/reports/view-zero-as-empty/index.js
+++ b/src/extension/features/reports/view-zero-as-empty/index.js
@@ -1,0 +1,17 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+
+export class ViewZeroAsEmpty extends Feature {
+  shouldInvoke() {
+    return getCurrentRouteName().indexOf('reports.income-expense') !== -1;
+  }
+
+  invoke() {
+    $('.user-data.zero').empty();
+  }
+
+  onRouteChanged() {
+    if (!this.shouldInvoke()) return;
+    this.invoke();
+  }
+}

--- a/src/extension/features/reports/view-zero-as-empty/index.js
+++ b/src/extension/features/reports/view-zero-as-empty/index.js
@@ -7,7 +7,7 @@ export class ViewZeroAsEmpty extends Feature {
   }
 
   invoke() {
-    $('.user-data.zero').empty();
+    $('.income-expense-level2 .user-data.zero').empty();
   }
 
   onRouteChanged() {

--- a/src/extension/features/reports/view-zero-as-empty/settings.js
+++ b/src/extension/features/reports/view-zero-as-empty/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'ViewZeroAsEmpty',
+  type: 'checkbox',
+  default: false,
+  section: 'reports',
+  title: 'View Zero as Empty',
+  description: 'If a cell is zero, replace it with an empty cell so it is easier to focus on non-zero cells.'
+};

--- a/src/extension/features/reports/view-zero-as-empty/settings.js
+++ b/src/extension/features/reports/view-zero-as-empty/settings.js
@@ -4,5 +4,5 @@ module.exports = {
   default: false,
   section: 'reports',
   title: 'View Zero as Empty',
-  description: 'If a cell is zero, replace it with an empty cell so it is easier to focus on non-zero cells. \'Total\' cells are not modified.'
+  description: 'If a cell is zero, replace it with an empty cell so it is easier to focus on non-zero cells. "Total" rows are not modified.'
 };

--- a/src/extension/features/reports/view-zero-as-empty/settings.js
+++ b/src/extension/features/reports/view-zero-as-empty/settings.js
@@ -4,5 +4,5 @@ module.exports = {
   default: false,
   section: 'reports',
   title: 'View Zero as Empty',
-  description: 'If a cell is zero, replace it with an empty cell so it is easier to focus on non-zero cells.'
+  description: 'If a cell is zero, replace it with an empty cell so it is easier to focus on non-zero cells. \'Total\' cells are not modified.'
 };


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
Adds an option to view zero cells in the Income v Expenses report as empty instead of with a grey zero. This makes those cells less distracting and makes it easier to focus on the non-zero cells. "Total" rows are not affected.