### PR TITLE
Revert back to hiding the help button with CSS

### DIFF
--- a/src/extension/features/general/hide-help/index.css
+++ b/src/extension/features/general/hide-help/index.css
@@ -1,0 +1,7 @@
+body.toolkit-hide-help #hs-beacon {
+  display: none !important;
+}
+
+body.toolkit-hide-help #beacon-container {
+  display: none !important;
+}

--- a/src/extension/features/general/hide-help/index.js
+++ b/src/extension/features/general/hide-help/index.js
@@ -1,8 +1,10 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
-import { getEmberView, controllerLookup } from 'toolkit/extension/utils/toolkit';
+import { i10n, getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 export class HideHelp extends Feature {
+  injectCSS() { return require('./index.css'); }
+
   shouldInvoke() { return true; }
 
   observe(changedNodes) {
@@ -16,26 +18,17 @@ export class HideHelp extends Feature {
     this.setHiddenState(initialState);
   }
 
-  getBeacon() {
-    return getEmberView($('.self-service').attr('id'));
-  }
-
-  isBeaconHidden() {
-    return this.getBeacon().getBeaconContainer().css('display') === 'none';
-  }
-
-  setHiddenState(state) {
+  setHiddenState = (state) => {
     setToolkitStorageKey('hide-help', state);
-    const beacon = this.getBeacon();
     if (state) {
-      beacon.hideContainer();
+      $('body').addClass('toolkit-hide-help');
     } else {
-      beacon.showContainer();
+      $('body').removeClass('toolkit-hide-help');
     }
   }
 
   updatePopupButton() {
-    const isBeaconHidden = this.isBeaconHidden();
+    const isHidden = getToolkitStorageKey('hide-help', true);
     const $modal = $('.modal-user-prefs .modal');
     const $modalList = $('.modal-user-prefs .modal-list');
 
@@ -44,7 +37,7 @@ export class HideHelp extends Feature {
     // it's possible the beacon doesn't actually match the state we think it should so don't
     // set the label based on what we have in local storage so we should always use the source
     // of truth when toggling. We'll use local storage to get the initial state.
-    const label = isBeaconHidden ? 'Hide' : 'Show';
+    const label = isHidden ? i10n('app.show', 'Show') : i10n('app.hide', 'Hide');
 
     $(`<li class="ynab-toolkit-hide-help">
       <button>
@@ -53,8 +46,8 @@ export class HideHelp extends Feature {
       </button>
      </li>
     `).click(() => {
-      this.setHideState(!isBeaconHidden);
-      controllerLookup('controller:accounts').send('closeModal');
+      this.setHiddenState(!isHidden);
+      controllerLookup('accounts').send('closeModal');
     }).appendTo($modalList);
 
     $modal.css({ height: '+=12px' });


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

#### Explanation of Bugfix/Feature/Modification:
The previous PR was bug ridden. We need to go back to using CSS because the help button is indeterministic about showing up and doesn't trigger `observe`.
