### PR TITLE
Fixed an issue where running balance would not load if navigating to a budget/account from the "Select a Budget" page.

### DIFF
--- a/src/extension/features/accounts/transaction-grid-features/feature.js
+++ b/src/extension/features/accounts/transaction-grid-features/feature.js
@@ -18,6 +18,10 @@ export class TransactionGridFeature {
   // is on a page that should receive the new column.
   shouldInvoke() {}
 
+  // Run any setup your transaction grid feature needs to operate. You want
+  // to make this function idempotant because it is likely to be called many times.
+  invoke() {}
+
   // Called during the lifecycle event `didUpdate` in Ember for an Ember Component.
   didUpdate() {}
 

--- a/src/extension/features/accounts/transaction-grid-features/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/index.js
@@ -4,6 +4,7 @@ import { RunningBalance } from './running-balance';
 import { CheckNumbers } from './check-numbers';
 import { ReconciledTextColor } from './reconciled-text-color';
 import { controllerLookup, componentLookup } from 'toolkit/extension/utils/ember';
+import { logToolkitError } from 'toolkit/core/common/errors/with-toolkit-error';
 
 export class TransactionGridFeatures extends Feature {
   features = [
@@ -118,6 +119,7 @@ export class TransactionGridFeatures extends Feature {
     this.features.forEach((feature) => {
       if (feature.shouldInvoke()) {
         feature.insertHeader();
+        feature.invoke();
       }
     });
 

--- a/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
@@ -1,7 +1,10 @@
 import { TransactionGridFeature } from '../feature';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { getCurrentRouteName, getEntityManager } from 'toolkit/extension/utils/ynab';
 
 export class RunningBalance extends TransactionGridFeature {
+  hasInitialized = false;
+
   injectCSS() {
     let css = require('./index.css');
 
@@ -17,8 +20,14 @@ export class RunningBalance extends TransactionGridFeature {
   }
 
   shouldInvoke() {
-    const applicationController = controllerLookup('application');
-    return applicationController.get('selectedAccountId') !== null;
+    return (
+      getCurrentRouteName().includes('account') &&
+      controllerLookup('application').get('selectedAccountId') !== null
+    );
+  }
+
+  invoke() {
+    this.initializeRunningBalances();
   }
 
   cleanup() {
@@ -101,8 +110,15 @@ export class RunningBalance extends TransactionGridFeature {
   }
 
   initializeRunningBalances() {
+    const { accountsCollection } = getEntityManager();
+    if (accountsCollection.length === 0 || this.hasInitialized) {
+      return;
+    }
+
+    this.hasInitialized = true;
+
     const promises = [];
-    ynab.YNABSharedLib.defaultInstance.entityManager.accountsCollection.forEach((account) => {
+    accountsCollection.forEach((account) => {
       const viewModel = ynab.YNABSharedLib.defaultInstance.getBudgetViewModel_AccountTransactionsViewModel(account.entityId);
       promises.push(viewModel.then(() => calculateRunningBalance(account.entityId)));
     });


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1282

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
Before, we were only initializing running balance in willInvoke this
caused a bug where the code would run before you've selected a budget
(on the users/budgets page). Now, we will always attempt to initialize
the running balance on accounts whenever the feature is invoked which
happens on route changes. We've included a guard preventing this function
from processing once it's already initialized.
