### PR TITLE
Bug Fix: Restore "Goal Indicator Warning Color" feature

### DIFF
--- a/src/extension/features/budget/goal-warning-color/index.js
+++ b/src/extension/features/budget/goal-warning-color/index.js
@@ -1,5 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 
+import '../../../legacy/features/budget-category-info/main';
+
 export class GoalWarningColor extends Feature {
   injectCSS() { return require('./index.css'); }
 }


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:

The blue "Goal Indicator Warning" has not been working for a while.  I pulled in the "legacy" code that was setting the styles that it needs ... not sure if that is the right way to address this.