### PR TITLE
Fixed: Goal Indicator Warning Color wasn't working unless Add Goals Indication was enabled (woops!)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,8 @@
         "ynabToolKit": true,
         "YNABFEATURES": true,
         "browser": true,
-        "Components": true
+        "Components": true,
+        "__ynabapp__": true
     },
     "rules": {
         "consistent-return": "off",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build:check": "yarn && yarn gen && yarn lint",
     "build:beta": "yarn build:check && yarn webpack:beta && yarn build:legacy && yarn manifest:beta && yarn compress",
     "build:dev": "yarn build:development",
-    "build:development": "yarn build:check && yarn webpack:development && yarn build:legacy && yarn manifest:development && yarn compress",
+    "build:development": "yarn build:check && yarn webpack:development && yarn build:legacy && yarn manifest:development",
     "build:prod": "yarn build:production",
     "build:production": "yarn build:check && yarn webpack:production && yarn build:legacy && yarn compress",
     "build:legacy": "babel src/extension/legacy --compact false --quiet --out-dir dist/extension/web-accessibles/legacy",

--- a/src/extension/features/budget/goal-warning-color/index.css
+++ b/src/extension/features/budget/goal-warning-color/index.css
@@ -1,27 +1,29 @@
 /* row */
-.budget-table-row.toolkit-row-goal.toolkit-row-availablepositive:not(.toolkit-row-upcoming) .budget-table-cell-available .cautious,
-.budget-table-row.toolkit-row-goal.toolkit-row-availablezero:not(.toolkit-row-upcoming) .budget-table-cell-available .cautious {
+.budget-table-row .budget-table-cell-available .toolkit-goal-underfunded .currency {
 	background-color: #009cc2;
 }
-.budget-table-row.toolkit-row-goal.toolkit-row-availablepositive:not(.toolkit-row-upcoming) .budget-table-cell-available .cautious:hover,
-.budget-table-row.toolkit-row-goal.toolkit-row-availablezero:not(.toolkit-row-upcoming) .budget-table-cell-available .cautious:hover {
+.budget-table-row .budget-table-cell-available .toolkit-goal-underfunded .currency:hover {
 	background-color: #1f8ca7;
 }
 
 /* inspector */
-.budget-inspector-category-overview .toolkit-row-goal.toolkit-row-availablepositive:not(.toolkit-row-upcoming) dt.cautious,
-.budget-inspector-category-overview .toolkit-row-goal.toolkit-row-availablezero:not(.toolkit-row-upcoming) dt.cautious {
+.budget-inspector-category-overview.toolkit-goal-underfunded .inspector-overview-available dt {
 	color: #009cc2;
 }
-.budget-inspector-category-overview .toolkit-row-goal.toolkit-row-availablepositive:not(.toolkit-row-upcoming) dd .cautious,
-.budget-inspector-category-overview .toolkit-row-goal.toolkit-row-availablezero:not(.toolkit-row-upcoming) dd .cautious {
+.budget-inspector-category-overview.toolkit-goal-underfunded .inspector-overview-available dd .currency {
 	background: #009cc2;
+}
+.budget-inspector-category-overview.toolkit-goal-underfunded .inspector-message {
+  background-color: #d0ecf5;
+}
+.budget-inspector-category-overview.toolkit-goal-underfunded .inspector-message .inspector-message-arrow {
+  border-bottom-color: #d0ecf5;
 }
 
 /* goal */
-.goal-warning .inner-circle {
-	stroke: #43aecb;	
+.toolkit-goal-underfunded .goal-progress-chart .inner-circle {
+	stroke: #43aecb;
 }
-.goal-warning .outer-circle {
+.toolkit-goal-underfunded .goal-progress-chart .outer-circle {
 	fill: #1f8ca7;
 }

--- a/src/extension/features/budget/goal-warning-color/index.js
+++ b/src/extension/features/budget/goal-warning-color/index.js
@@ -1,5 +1,111 @@
 import { Feature } from 'toolkit/extension/features/feature';
+import { currentRouteIsBudgetPage } from 'toolkit/extension/utils/ynab';
+import { getEmberView, lookupForReopen } from 'toolkit/extension/utils/ember';
+
+const UNDERFUNDED_CLASSNAME = 'toolkit-goal-underfunded';
 
 export class GoalWarningColor extends Feature {
   injectCSS() { return require('./index.css'); }
+
+  shouldInvoke() { return currentRouteIsBudgetPage(); }
+
+  invoke() {
+    const BudgetTableRowComponent = lookupForReopen('component:budget/table/budget-table-available');
+    const CategoryOverviewComponent = lookupForReopen('component:budget/inspector/category-overview');
+    const InspectorGoalsComponent = lookupForReopen('component:budget/inspector/inspector-goals');
+
+    // if the user goes straight to the budget page via bookmark/refresh then we won't have
+    // time to reopen the class before YNAB uses it. In this instance we need to perform the
+    // same logic directly to the DOM :(
+    if (!BudgetTableRowComponent.__toolkitOverrides) {
+      this.firstLoadHack();
+    }
+
+    BudgetTableRowComponent.reopenClass({ __toolkitOverrides: true });
+    BudgetTableRowComponent.reopen({
+      willInsertElement() {
+        this._super(...arguments);
+        if (shouldOverrideColor(this.get('category'))) {
+          this.element.classList.add('toolkit-goal-underfunded');
+        }
+      },
+
+      willUpdate() {
+        this._super(...arguments);
+        if (shouldOverrideColor(this.get('category'))) {
+          this.element.classList.add('toolkit-goal-underfunded');
+        }
+      }
+    });
+
+    CategoryOverviewComponent.reopen({
+      willInsertElement() {
+        if (shouldOverrideColor(this.get('budgetController.activeCategory'))) {
+          this.element.classList.add(UNDERFUNDED_CLASSNAME);
+        } else {
+          this.element.classList.remove(UNDERFUNDED_CLASSNAME);
+        }
+      },
+
+      willUpdate() {
+        if (shouldOverrideColor(this.get('budgetController.activeCategory'))) {
+          this.element.classList.add(UNDERFUNDED_CLASSNAME);
+        } else {
+          this.element.classList.remove(UNDERFUNDED_CLASSNAME);
+        }
+      }
+    });
+
+    InspectorGoalsComponent.reopen({
+      willInsertElement() {
+        if (shouldOverrideColor(this.get('budgetController.activeCategory'))) {
+          this.element.classList.add(UNDERFUNDED_CLASSNAME);
+        } else {
+          this.element.classList.remove(UNDERFUNDED_CLASSNAME);
+        }
+      },
+
+      willUpdate() {
+        if (shouldOverrideColor(this.get('budgetController.activeCategory'))) {
+          this.element.classList.add(UNDERFUNDED_CLASSNAME);
+        } else {
+          this.element.classList.remove(UNDERFUNDED_CLASSNAME);
+        }
+      }
+    });
+  }
+
+  onRouteChanged() {
+    if (this.shouldInvoke()) {
+      this.invoke();
+    }
+  }
+
+  firstLoadHack() {
+    const availableRows = document.getElementsByClassName('budget-table-cell-available-div');
+    for (const row of availableRows) {
+      if (shouldOverrideColor(getEmberView(row.id).category)) {
+        row.classList.add(UNDERFUNDED_CLASSNAME);
+      } else {
+        row.classList.remove(UNDERFUNDED_CLASSNAME);
+      }
+    }
+  }
+}
+
+function shouldOverrideColor(category) {
+  if (!category) {
+    return false;
+  }
+
+  const { goalType, isGoalUnderFunded, goalOverallLeft, isOverSpentOnCash, isOverSpentOnCredit } =
+    category.getProperties('goalType', 'isGoalUnderFunded', 'goalOverallLeft', 'isOverSpentOnCash', 'isOverSpentOnCredit');
+  const isOverSpent = isOverSpentOnCash || isOverSpentOnCredit;
+  const isTargetBalanceUnderFunded = (
+    ynabToolKit.options.TargetBalanceWarning &&
+    goalType === ynab.constants.SubCategoryGoalType.TargetBalance &&
+    goalOverallLeft > 0
+  );
+
+  return goalType && !isOverSpent && (isGoalUnderFunded || isTargetBalanceUnderFunded);
 }

--- a/src/extension/utils/ember.js
+++ b/src/extension/utils/ember.js
@@ -14,11 +14,25 @@ export function componentLookup(componentName) {
   return containerLookup(`component:${componentName}`);
 }
 
-/* Private Functions */
-function getViewRegistry() {
-  return Ember.Component.create().get('_viewRegistry');
+export function lookupForReopen(name) {
+  const appContainer = __ynabapp__.__container__;
+
+  let toReopen = appContainer.factoryCache[name];
+  if (toReopen) {
+    return toReopen;
+  }
+
+  // if it wasn't already cached, do a lookup which should cache it,
+  // if this fails for some reason -- catch it an optimistically try
+  // to resolve the cached version.
+  try {
+    appContainer.lookup(name);
+  } catch (e) { /* not much we can do about it */ }
+
+  return appContainer.factoryCache[name];
 }
 
+/* Private Functions */
 function containerLookup(containerName) {
   const viewRegistry = getViewRegistry();
   const viewId = Ember.keys(viewRegistry)[0];
@@ -32,4 +46,8 @@ function containerLookup(containerName) {
   }
 
   return container;
+}
+
+function getViewRegistry() {
+  return Ember.Component.create().get('_viewRegistry');
 }

--- a/src/extension/utils/ynab.js
+++ b/src/extension/utils/ynab.js
@@ -13,6 +13,24 @@ export function getCurrentBudgetDate() {
   return { year: date.slice(0, 4), month: date.slice(4, 6) };
 }
 
+export function currentRouteIsBudgetPage() {
+  const currentRoute = getCurrentRouteName();
+
+  return (
+    currentRoute === ynab.constants.RouteNames.BudgetSelect ||
+    currentRoute === ynab.constants.RouteNames.BudgetIndex
+  );
+}
+
+export function currentRouteIsAccountsPage() {
+  const currentRoute = getCurrentRouteName();
+
+  return (
+    currentRoute === ynab.constants.RouteNames.AccountsSelect ||
+    currentRoute === ynab.constants.RouteNames.AccountsIndex
+  );
+}
+
 export function getCurrentRouteName() {
   return controllerLookup('application').get('currentRouteName');
 }

--- a/src/extension/ynab-toolkit.js
+++ b/src/extension/ynab-toolkit.js
@@ -96,7 +96,7 @@ export class YNABToolkit {
     (function poll() {
       if (ynabUtils.isYNABReady()) {
         // add a global invokeFeature to the global ynabToolKit for legacy features
-        // once leagcy features have been removed, this should be a global exported function
+        // once legacy features have been removed, this should be a global exported function
         // from this file that features can require and use
         ynabToolKit.invokeFeature = self._invokeFeature;
 


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1302

#### Explanation of Bugfix/Feature/Modification:
This is a complete refactor of the goal-warning-color feature to work independent of the budget-category-info loop in the legacy framework.

I wanted to use this feature as another experiment (next to running balance) where we tap directly into Ember rather than observing changes to the DOM. The only known issue right now is that the first load of the inspector on a goal-underfunded category will use the default coloring. Once clicking another category and going back -- it goes back to the expected blue.
