### PR TITLE
Fixed: Goal Warning Color was not updating properly the first time you visit the budget page.

### DIFF
--- a/src/extension/features/budget/goal-warning-color/index.js
+++ b/src/extension/features/budget/goal-warning-color/index.js
@@ -1,10 +1,13 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { currentRouteIsBudgetPage } from 'toolkit/extension/utils/ynab';
-import { getEmberView, lookupForReopen } from 'toolkit/extension/utils/ember';
+import { controllerLookup, getEmberView, lookupForReopen } from 'toolkit/extension/utils/ember';
 
 const UNDERFUNDED_CLASSNAME = 'toolkit-goal-underfunded';
 
 export class GoalWarningColor extends Feature {
+  blockObserve = false;
+  useFirstLoadHack = true;
+
   injectCSS() { return require('./index.css'); }
 
   shouldInvoke() { return currentRouteIsBudgetPage(); }
@@ -17,23 +20,31 @@ export class GoalWarningColor extends Feature {
     // if the user goes straight to the budget page via bookmark/refresh then we won't have
     // time to reopen the class before YNAB uses it. In this instance we need to perform the
     // same logic directly to the DOM :(
-    if (!BudgetTableRowComponent.__toolkitOverrides) {
+    if (this.useFirstLoadHack) {
       this.firstLoadHack();
     }
 
-    BudgetTableRowComponent.reopenClass({ __toolkitOverrides: true });
+    const _this = this;
     BudgetTableRowComponent.reopen({
       willInsertElement() {
         this._super(...arguments);
+
+        _this.useFirstLoadHack = false;
         if (shouldOverrideColor(this.get('category'))) {
           this.element.classList.add('toolkit-goal-underfunded');
+        } else {
+          this.element.classList.remove(UNDERFUNDED_CLASSNAME);
         }
       },
 
       willUpdate() {
         this._super(...arguments);
+
+        _this.useFirstLoadHack = false;
         if (shouldOverrideColor(this.get('category'))) {
           this.element.classList.add('toolkit-goal-underfunded');
+        } else {
+          this.element.classList.remove(UNDERFUNDED_CLASSNAME);
         }
       }
     });
@@ -78,6 +89,43 @@ export class GoalWarningColor extends Feature {
   onRouteChanged() {
     if (this.shouldInvoke()) {
       this.invoke();
+    }
+  }
+
+  // This is a really bad example of an observe function because it's listening
+  // for changes to elements we're mutating which means infinite loops. Unfortunately,
+  // this is just the quickest way around the problem introduced by implmenting the feature
+  // with Ember. If I ever get around to it -- we'll probably remove this implementation
+  // and go back to the original method (using observe for everything).
+  observe(changedNodes) {
+    if (this.blockObserve || !this.useFirstLoadHack) {
+      return;
+    }
+
+    if (changedNodes.has('budget-table-cell-available-div user-data')) {
+      this.blockObserve = true;
+      const activeCategory = controllerLookup('budget').get('activeCategory');
+      if (!activeCategory) {
+        // if the available div changed but the user doesn't have anything selected
+        // they may have moved money or something so just run first load hack in that case
+        this.firstLoadHack();
+        this.blockObserve = false;
+        return;
+      }
+
+      const element = document.querySelector(`.budget-table-row[data-entity-id='${activeCategory.get('subCategory.entityId')}'] .budget-table-cell-available-div`);
+      if (!element) {
+        this.blockObserve = false;
+        return;
+      }
+
+      if (shouldOverrideColor(activeCategory)) {
+        element.classList.add(UNDERFUNDED_CLASSNAME);
+      } else {
+        element.classList.remove(UNDERFUNDED_CLASSNAME);
+      }
+
+      this.blockObserve = false;
     }
   }
 


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1313 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
This fix is really hacky to the point that I think we should just migrate the original implementation (budget-category-info) and use that. For some reason that implementation was able to get a better experience through observe than this solution is. I want to investigate that first but for now we've got to deal with a small flicker of orange when going from blue -> green.
