### PR TITLE
Fixed: Running balance should recalculate when you change sort order and should be correct the first time you visit your account register now.

### DIFF
--- a/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
@@ -138,7 +138,7 @@ function attachAnyItemChangedListener(accountId, transactionViewModel) {
     });
 
   controllerLookup('accounts').addObserver('sortAscending', function (displayItems) {
-    const updatedAccountId = displayItems.get('firstObject.accountId');
+    const updatedAccountId = displayItems.get('visibleTransactionDisplayItems.firstObject.accountId');
     if (updatedAccountId) {
       calculateRunningBalance(updatedAccountId);
     }
@@ -170,9 +170,10 @@ function calculateRunningBalance(accountId) {
         // if the amounts are equal
         if (res === 0) {
           return Ember.compare(a.getEntityId(), b.getEntityId());
-        } else if (!controllerLookup('accounts').get('sortAscending')) {
-          return -res;
         }
+
+        const sortAscending = localStorage.getItem(`.${accountId}_sortAscending`) || 'true';
+        return sortAscending === 'true' ? res : -res;
       }
 
       return res;


### PR DESCRIPTION
Github Issue (if applicable): #1319 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
The default value of `sortAscending` is always true on the accounts controller. Try to get the current sort from localStorage instead (YNAB stores it there) and default to `true` only if we didn't getit.
