### PR TITLE
Fixed: Stealing from Future alert will now provide the current month when you're over budget without any future budgeting rather than incorrectly alerting about the proceeding month.

### DIFF
--- a/src/extension/features/budget/stealing-from-future/index.js
+++ b/src/extension/features/budget/stealing-from-future/index.js
@@ -30,7 +30,7 @@ export class StealingFromFuture extends Feature {
     let earliestNegativeMonth = null;
     let earliestNegativeMonthCalculation = null;
     budgetViewModel.get('allBudgetMonthsViewModel.monthlyBudgetCalculationsCollection').forEach((monthCalculation) => {
-      if (this.isMonthEntityIdFuture(monthCalculation.get('entityId'))) {
+      if (!this.isMonthEntityIdPast(monthCalculation.get('entityId'))) {
         const entityDate = monthCalculation.get('entityId').match(/mbc\/(.*)\/.*/)[1];
         const entityMonth = entityDate.split('-').map((val) => parseInt(val))[1];
 
@@ -69,12 +69,12 @@ export class StealingFromFuture extends Feature {
 
     const availableToBudget = earliestNegativeMonthCalculation.getAvailableToBudget();
     $('#ynabtk-stealing-amount', name).remove();
-    name.append('<span id="ynabtk-stealing-amount"> (' +
-        '<strong class="currency">' +
-          `${ynab.formatCurrency(availableToBudget)} in ` +
-          `<a class="ynabtk-month-link">${ynabToolKit.shared.monthsFull[earliestNegativeMonth - 1]}</a>` +
-        '</strong>' +
-      ')</span>');
+    name.append(`<span id="ynabtk-stealing-amount"> (
+        <strong class="currency">
+          ${ynab.formatCurrency(availableToBudget)} in
+          <a class="ynabtk-month-link">${ynabToolKit.shared.monthsFull[earliestNegativeMonth - 1]}</a>
+        </strong>
+      )</span>`);
 
     $('.ynabtk-month-link', name).click((event) => {
       event.preventDefault();
@@ -84,19 +84,19 @@ export class StealingFromFuture extends Feature {
     });
   }
 
-  isMonthEntityIdFuture(entityId) {
+  isMonthEntityIdPast(entityId) {
     const currentYear = parseInt(moment().format('YYYY'));
     const currentMonth = parseInt(moment().format('MM'));
     const entityDate = entityId.match(/mbc\/(.*)\/.*/)[1];
     const [entityYear, entityMonth] = entityDate.split('-').map((val) => parseInt(val));
 
     const isNextYear = entityYear > currentYear;
-    const isCurrentYearFutureMonth = entityYear === currentYear && entityMonth > currentMonth;
+    const isCurrentYearFutureMonth = entityYear === currentYear && entityMonth >= currentMonth;
     if (isNextYear || isCurrentYearFutureMonth) {
-      return true;
+      return false;
     }
 
-    return false;
+    return true;
   }
 
   invoke() {


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #847

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
We were only considering dates in the future becasue that's what the feature
is for but it's still of course possible to overbudget in the current month
while having this feature enabled. We'd show you that you're stealing from the
next month but in reality, you're just overbudget in the current month. Inverting
the logic to check we're not looking at a past month fixes this issue.
