### PR TITLE
Use isCurrentRouteAccounts page and isCurrentRouteBudgetPage

### DIFF
--- a/docs/building-features.md
+++ b/docs/building-features.md
@@ -109,12 +109,12 @@ should be invoked. You should also use this function in your `observe()`, or
 Example:
 
 ```javascript
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 ...
 
 shouldInvoke() {
-  return getCurrentRoute().includes('accounts');
+  return isCurrentRouteBudgetPage();
 }
 ```
 

--- a/src/README.md
+++ b/src/README.md
@@ -109,12 +109,12 @@ should be invoked. You should also use this function in your `observe()`, or
 Example:
 
 ```javascript
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 ...
 
 shouldInvoke() {
-  return getCurrentRoute().includes('accounts');
+  return isCurrentRouteBudgetPage();
 }
 ```
 

--- a/src/extension/features/accounts/adjustable-column-widths/index.js
+++ b/src/extension/features/accounts/adjustable-column-widths/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { getToolkitStorageKey, removeToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 
 const RESIZABLES = [
@@ -22,7 +22,7 @@ export class AdjustableColumnWidths extends Feature {
   currentX = null;
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1;
+    return isCurrentRouteAccountsPage();
   }
 
   onMouseMove(event) {

--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 const DISTRIBUTE_BUTTON_ID = 'toolkit-auto-distribute-splits-button';
 
@@ -22,7 +22,7 @@ export class AutoDistributeSplits extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().includes('account');
+    return isCurrentRouteAccountsPage();
   }
 
   invoke() {

--- a/src/extension/features/accounts/change-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-enter-behavior/index.js
@@ -1,10 +1,9 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class ChangeEnterBehavior extends Feature {
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1 &&
-           $('.ynab-grid-body-row.is-adding').length;
+    return isCurrentRouteAccountsPage() && $('.ynab-grid-body-row.is-adding').length;
   }
 
   invoke() {

--- a/src/extension/features/accounts/custom-flag-names/index.js
+++ b/src/extension/features/accounts/custom-flag-names/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 let flags;
@@ -24,7 +24,7 @@ export class CustomFlagNames extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1;
+    return isCurrentRouteAccountsPage();
   }
 
   invoke() {

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class EasyTransactionApproval extends Feature {
   initBudgetVersion = true;
@@ -9,7 +9,7 @@ export class EasyTransactionApproval extends Feature {
   selectedTransactions = undefined;
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1;
+    return isCurrentRouteAccountsPage();
   }
 
   observe(changedNodes) {

--- a/src/extension/features/accounts/right-click-to-edit/index.js
+++ b/src/extension/features/accounts/right-click-to-edit/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class RightClickToEdit extends Feature {
   isCurrentlyRunning = false;
@@ -9,7 +9,7 @@ export class RightClickToEdit extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1;
+    return isCurrentRouteAccountsPage();
   }
 
   // Supporting functions,

--- a/src/extension/features/accounts/show-category-balance/index.js
+++ b/src/extension/features/accounts/show-category-balance/index.js
@@ -1,12 +1,12 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName, getAllBudgetMonthsViewModel } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage, getAllBudgetMonthsViewModel } from 'toolkit/extension/utils/ynab';
 import { getCurrentDate } from 'toolkit/extension/utils/date';
 import { componentLookup } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 
 export class ShowCategoryBalance extends Feature {
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1;
+    return isCurrentRouteAccountsPage();
   }
 
   invoke() {

--- a/src/extension/features/accounts/spare-change/index.js
+++ b/src/extension/features/accounts/spare-change/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 export class SpareChange extends Feature {
@@ -13,7 +13,7 @@ export class SpareChange extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') > -1;
+    return isCurrentRouteAccountsPage();
   }
 
   // invoke has potential of being pretty processing heavy (needing to sort content, then update calculation for every row)
@@ -36,7 +36,7 @@ export class SpareChange extends Feature {
     Ember.run.debounce(this, function () {
       this.accountsController.addObserver('areChecked', this, 'onYnabSelectionChanged');
 
-      if (getCurrentRouteName().indexOf('accounts') > -1) {
+      if (isCurrentRouteAccountsPage()) {
         if (this.applicationController.get('selectedAccountId')) {
           this.onYnabGridyBodyChanged();
         } else {

--- a/src/extension/features/accounts/split-keyboard-shortcut/index.js
+++ b/src/extension/features/accounts/split-keyboard-shortcut/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 const BUDGET_CATEGORIES_DROPDOWN_NODE = 'ynab-u modal-popup modal-account-dropdown modal-account-categories ember-view modal-overlay active';
 
@@ -9,7 +9,7 @@ export class SplitKeyboardShortcut extends Feature {
   }
 
   observe(changedNodes) {
-    if (getCurrentRouteName().indexOf('account') !== -1) {
+    if (isCurrentRouteAccountsPage()) {
       if (changedNodes.has(BUDGET_CATEGORIES_DROPDOWN_NODE)) {
         const splitButton = $('.button.button-primary.modal-account-categories-split-transaction');
 

--- a/src/extension/features/accounts/split-transaction-auto-adjust/index.js
+++ b/src/extension/features/accounts/split-transaction-auto-adjust/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class SplitTransactionAutoAdjust extends Feature {
   addAnotherSplit;
@@ -9,7 +9,7 @@ export class SplitTransactionAutoAdjust extends Feature {
   deletingSplit;
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1;
+    return isCurrentRouteAccountsPage();
   }
 
   invoke() {

--- a/src/extension/features/accounts/swap-cleared-flagged/index.js
+++ b/src/extension/features/accounts/swap-cleared-flagged/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class SwapClearedFlagged extends Feature {
   injectCSS() {
@@ -7,7 +7,7 @@ export class SwapClearedFlagged extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') > -1;
+    return isCurrentRouteAccountsPage();
   }
 
   invoke() {

--- a/src/extension/features/accounts/toggle-splits/index.js
+++ b/src/extension/features/accounts/toggle-splits/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 
@@ -19,7 +19,7 @@ export class ToggleSplits extends Feature {
   injectCSS() { return require('./index.css'); }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1 && !$(`#${this.idName}`).length;
+    return isCurrentRouteAccountsPage() && !$(`#${this.idName}`).length;
   }
 
   invoke() {

--- a/src/extension/features/accounts/toggle-transaction-filters/index.js
+++ b/src/extension/features/accounts/toggle-transaction-filters/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 export class ToggleTransactionFilters extends Feature {
@@ -8,7 +8,7 @@ export class ToggleTransactionFilters extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') > -1;
+    return isCurrentRouteAccountsPage();
   }
 
   onRouteChanged() {

--- a/src/extension/features/accounts/transaction-grid-features/check-numbers/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/check-numbers/index.js
@@ -1,5 +1,5 @@
 import { TransactionGridFeature } from '../feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 export class CheckNumbers extends TransactionGridFeature {
@@ -32,9 +32,9 @@ export class CheckNumbers extends TransactionGridFeature {
   }
 
   // Should return a boolean that informs AdditionalColumns feature that it
-  // is on a page that should recevie the new column.
+  // is on a page that should receive the new column.
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1;
+    return isCurrentRouteAccountsPage();
   }
 
   // Called when one of the grid rows is getting inserted into the dom but

--- a/src/extension/features/accounts/transaction-grid-features/reconciled-text-color/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/reconciled-text-color/index.js
@@ -1,5 +1,5 @@
 import { TransactionGridFeature } from '../feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 const TOOLKIT_RECONCILED_CLASS = 'toolkit-is-reconciled';
 const YNAB_IS_CHECKED_CLASS = 'is-checked';
@@ -20,7 +20,7 @@ export class ReconciledTextColor extends TransactionGridFeature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('account') !== -1;
+    return isCurrentRouteAccountsPage();
   }
 
   didUpdate() {

--- a/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
@@ -1,6 +1,6 @@
 import { TransactionGridFeature } from '../feature';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
-import { getCurrentRouteName, getEntityManager } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage, getEntityManager } from 'toolkit/extension/utils/ynab';
 
 export class RunningBalance extends TransactionGridFeature {
   hasInitialized = false;
@@ -21,7 +21,7 @@ export class RunningBalance extends TransactionGridFeature {
 
   shouldInvoke() {
     return (
-      getCurrentRouteName().includes('account') &&
+      isCurrentRouteAccountsPage() &&
       controllerLookup('application').get('selectedAccountId') !== null
     );
   }

--- a/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.js
+++ b/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.js
@@ -1,7 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
-import { currentRouteIsBudgetPage } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 import { CategoryAttributes, GOAL_TABLE_CELL_CLASSNAME } from 'toolkit/extension/features/budget/budget-category-features';
 
 export const Settings = {
@@ -17,7 +17,7 @@ const EmphasisColor = {
 };
 
 export class DisplayTargetGoalAmount extends Feature {
-  shouldInvoke() { return currentRouteIsBudgetPage(); }
+  shouldInvoke() { return isCurrentRouteBudgetPage(); }
 
   invoke() {
     const userSetting = this.settings.enabled;

--- a/src/extension/features/budget/budget-category-features/goal-indicator/index.js
+++ b/src/extension/features/budget/budget-category-features/goal-indicator/index.js
@@ -1,11 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { currentRouteIsBudgetPage } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 import { CategoryAttributes, GOAL_TABLE_CELL_CLASSNAME } from 'toolkit/extension/features/budget/budget-category-features';
 
 export class GoalIndicator extends Feature {
   injectCSS() { return require('./index.css'); }
 
-  shouldInvoke() { return currentRouteIsBudgetPage(); }
+  shouldInvoke() { return isCurrentRouteBudgetPage(); }
 
   invoke() {
     // these need to be defined inside `invoke` because ynab must be on the window

--- a/src/extension/features/budget/budget-category-features/index.js
+++ b/src/extension/features/budget/budget-category-features/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { currentRouteIsBudgetPage } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup, getEmberView } from 'toolkit/extension/utils/ember';
 import { Settings as DisplayGoalAmountSettings } from './display-target-goal-amount';
 
@@ -25,7 +25,7 @@ export class BudgetCategoryFeatures extends Feature {
     }
   }
 
-  shouldInvoke() { return currentRouteIsBudgetPage(); }
+  shouldInvoke() { return isCurrentRouteBudgetPage(); }
 
   invoke() {
     this.ensureGoalContainer();

--- a/src/extension/features/budget/budget-category-features/target-balance-warning/index.js
+++ b/src/extension/features/budget/budget-category-features/target-balance-warning/index.js
@@ -1,9 +1,9 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { currentRouteIsBudgetPage } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 import { CategoryAttributes } from 'toolkit/extension/features/budget/budget-category-features';
 
 export class TargetBalanceWarning extends Feature {
-  shouldInvoke() { return currentRouteIsBudgetPage(); }
+  shouldInvoke() { return isCurrentRouteBudgetPage(); }
 
   invoke() {
     const targetBalance = ynab.constants.SubCategoryGoalType.TargetBalance;

--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName, getEntityManager, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage, getEntityManager, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
 import { migrateLegacyPacingStorage, pacingForCategory } from 'toolkit/extension/utils/pacing';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 
@@ -20,7 +20,7 @@ export class BudgetProgressBars extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') > -1;
+    return isCurrentRouteBudgetPage();
   }
 
   // Takes N colors and N-1 sorted points from (0, 1) to make color1|color2|color3 bg style.

--- a/src/extension/features/budget/category-activity-copy/index.js
+++ b/src/extension/features/budget/category-activity-copy/index.js
@@ -1,10 +1,10 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName, getEntityManager } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage, getEntityManager } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 export class CategoryActivityCopy extends Feature {
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') !== -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getAllBudgetMonthsViewModel, getCurrentBudgetDate, getCurrentBudgetMonth, getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { getAllBudgetMonthsViewModel, getCurrentBudgetDate, getCurrentBudgetMonth, isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class CheckCreditBalances extends Feature {
   budgetView = null;
@@ -9,7 +9,7 @@ export class CheckCreditBalances extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') !== -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -1,7 +1,7 @@
 import { l10n } from 'toolkit/extension/utils/toolkit';
 import { getEntityManager } from 'toolkit/extension/utils/ynab';
 import { Feature } from 'toolkit/extension/features/feature';
-import { currentRouteIsBudgetPage, getSidebarViewModel } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage, getSidebarViewModel } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 
 export class DaysOfBuffering extends Feature {
@@ -11,7 +11,7 @@ export class DaysOfBuffering extends Feature {
   injectCSS() { return require('./index.css'); }
 
   shouldInvoke() {
-    return currentRouteIsBudgetPage() && !document.querySelector('toolkit-days-of-buffering');
+    return isCurrentRouteBudgetPage() && !document.querySelector('toolkit-days-of-buffering');
   }
 
   invoke() {

--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -1,11 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class DisplayTotalMonthlyGoals extends Feature {
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') !== -1;
+    return isCurrentRouteBudgetPage();
   }
 
   extractCategoryGoalInformation(element) {

--- a/src/extension/features/budget/display-upcoming-amount/index.js
+++ b/src/extension/features/budget/display-upcoming-amount/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 
@@ -7,7 +7,7 @@ export class DisplayUpcomingAmount extends Feature {
   injectCSS() { return require('./index.css'); }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') !== -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/features/budget/enlarge-categories-dropdown/index.js
+++ b/src/extension/features/budget/enlarge-categories-dropdown/index.js
@@ -1,12 +1,12 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 const DEFAULT_ADDITIONAL_HEIGHT = 100; // 4 pixels of padding
 const BOTTOM_OF_PAGE_PADDING = 4;
 
 export class EnlargeCategoriesDropdown extends Feature {
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') > -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/features/budget/enter-to-move/index.js
+++ b/src/extension/features/budget/enter-to-move/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 const MOVE_POPUP =
   'ynab-u modal-popup modal-budget modal-budget-move-money ember-view modal-overlay active';
@@ -12,7 +12,7 @@ export class EnterToMove extends Feature {
   modalIsOpen = false;
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') !== -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {}

--- a/src/extension/features/budget/highlight-current-month/index.js
+++ b/src/extension/features/budget/highlight-current-month/index.js
@@ -1,11 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class CurrentMonthIndicator extends Feature {
   injectCSS() { return require('./index.css'); }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') !== -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/features/budget/income-from-last-month/index.js
+++ b/src/extension/features/budget/income-from-last-month/index.js
@@ -1,12 +1,12 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { currentRouteIsBudgetPage, getBudgetViewModel, getEntityManager } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage, getBudgetViewModel, getEntityManager } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 
 export class IncomeFromLastMonth extends Feature {
   injectCSS() { return require('./index.css'); }
 
-  shouldInvoke() { return currentRouteIsBudgetPage(); }
+  shouldInvoke() { return isCurrentRouteBudgetPage(); }
 
   invoke() {
     // Do nothing if no header found.

--- a/src/extension/features/budget/pacing/index.js
+++ b/src/extension/features/budget/pacing/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { getDeemphasizedCategories, migrateLegacyPacingStorage, pacingForCategory, setDeemphasizedCategories } from 'toolkit/extension/utils/pacing';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
@@ -13,7 +13,7 @@ export class Pacing extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().includes('budget') && isCurrentMonthSelected();
+    return isCurrentRouteBudgetPage() && isCurrentMonthSelected();
   }
 
   invoke() {

--- a/src/extension/features/budget/quick-budget-warning/index.js
+++ b/src/extension/features/budget/quick-budget-warning/index.js
@@ -1,9 +1,9 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class QuickBudgetWarning extends Feature {
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') > -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/features/budget/remove-zero-categories/index.js
+++ b/src/extension/features/budget/remove-zero-categories/index.js
@@ -1,9 +1,9 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class RemoveZeroCategories extends Feature {
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') > -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/features/budget/resize-inspector/index.js
+++ b/src/extension/features/budget/resize-inspector/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 const HIDEIMAGE = 'toolkit-modal-item-hide-image';
 const BUTTONDISABLED = 'button-disabled';
@@ -12,7 +12,7 @@ export class ResizeInspector extends Feature {
   }
 
   shouldInvoke() {
-    return getCurrentRouteName().includes('budget');
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/features/budget/stealing-from-future/index.js
+++ b/src/extension/features/budget/stealing-from-future/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName, transitionTo } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage, transitionTo } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 // TODO: move income-from-last-month to the new framework and just export this
@@ -10,7 +10,7 @@ export class StealingFromFuture extends Feature {
   injectCSS() { return require('./index.css'); }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') !== -1;
+    return isCurrentRouteBudgetPage();
   }
 
   isMonthABeforeB(a, b) {

--- a/src/extension/features/budget/to-be-budgeted-warning/index.js
+++ b/src/extension/features/budget/to-be-budgeted-warning/index.js
@@ -1,11 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class ToBeBudgetedWarning extends Feature {
   injectCSS() { return require('./index.css'); }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('budget') !== -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/features/reports/compact-income-vs-expense/index.js
+++ b/src/extension/features/reports/compact-income-vs-expense/index.js
@@ -1,11 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class CompactIncomeVsExpense extends Feature {
   injectCSS() { return require('./index.css'); }
 
   shouldInvoke() {
-    return getCurrentRouteName().indexOf('reports.income-expense') > -1;
+    return isCurrentRouteBudgetPage();
   }
 
   invoke() {

--- a/src/extension/utils/ynab.js
+++ b/src/extension/utils/ynab.js
@@ -13,7 +13,7 @@ export function getCurrentBudgetDate() {
   return { year: date.slice(0, 4), month: date.slice(4, 6) };
 }
 
-export function currentRouteIsBudgetPage() {
+export function isCurrentRouteBudgetPage() {
   const currentRoute = getCurrentRouteName();
 
   return (
@@ -22,7 +22,7 @@ export function currentRouteIsBudgetPage() {
   );
 }
 
-export function currentRouteIsAccountsPage() {
+export function isCurrentRouteAccountsPage() {
   const currentRoute = getCurrentRouteName();
 
   return (


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Fixes Sentry Issue: https://sentry.io/share/issue/1263bb6f88034375839822f189c9e936

#### Explanation of Bugfix/Feature/Modification:
These helpers do a better job validating the current route than the previous
`indexOf` or `includes` methods did because they check against the actual
route. Before, some features were running on incorrect pages (like the select
a budget screen) because the route contained the word "budget" (`/users/budget`).
