### PR TITLE
Remove multiple uses of the shared lib

### DIFF
--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -1,5 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 export class EasyTransactionApproval extends Feature {
   initBudgetVersion = true;
@@ -36,7 +37,7 @@ export class EasyTransactionApproval extends Feature {
   addBudgetVersionIdObserver() {
     var _this = this;
 
-    var applicationController = ynabToolKit.shared.containerLookup('controller:application');
+    var applicationController = controllerLookup('application');
     applicationController.addObserver('budgetVersionId', function () {
       Ember.run.scheduleOnce('afterRender', this, function () {
         _this.initKeyLoop = true;
@@ -48,7 +49,7 @@ export class EasyTransactionApproval extends Feature {
   invoke() {
     // get selected transactions
     this.selectedTransactions = undefined;
-    var accountController = ynabToolKit.shared.containerLookup('controller:accounts');
+    var accountController = controllerLookup('accounts');
     var visibleTransactionDisplayItems = accountController.get('visibleTransactionDisplayItems');
     this.selectedTransactions = visibleTransactionDisplayItems.filter(i => i.isChecked && i.get('accepted') === false);
 

--- a/src/extension/features/accounts/spare-change/index.js
+++ b/src/extension/features/accounts/spare-change/index.js
@@ -1,6 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { formatCurrency } from 'toolkit/extension/utils/currency';
 
 export class SpareChange extends Feature {
   selectedTransactions;
@@ -153,7 +154,7 @@ export class SpareChange extends Feature {
         currencySpan.addClass('zero');
       }
 
-      let formatted = ynabToolKit.shared.formatCurrency(spareChange);
+      let formatted = formatCurrency(spareChange);
       spareChangeAmount.attr('title', formatted.string);
 
       let formattedHtml = formatted.string.replace(/\$/g, '<bdi>$</bdi>');

--- a/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
@@ -1,6 +1,7 @@
 import { TransactionGridFeature } from '../feature';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 import { isCurrentRouteAccountsPage, getEntityManager } from 'toolkit/extension/utils/ynab';
+import { formatCurrency } from 'toolkit/extension/utils/currency';
 
 export class RunningBalance extends TransactionGridFeature {
   hasInitialized = false;
@@ -98,7 +99,7 @@ export class RunningBalance extends TransactionGridFeature {
         if (transaction.get('parentEntityId') !== null) {
           currencySpan.text('');
         } else {
-          currencySpan.text(ynabToolKit.shared.formatCurrency(runningBalance));
+          currencySpan.text(formatCurrency(runningBalance));
         }
 
         currentRowRunningBalance.insertAfter($('.ynab-grid-cell-inflow', $currentRow));

--- a/src/extension/features/budget/pacing/index.js
+++ b/src/extension/features/budget/pacing/index.js
@@ -117,7 +117,7 @@ export class Pacing extends Feature {
     const moreOrLess = paceAmount >= 0 ? 'less' : 'more';
     const aheadOrBehind = paceAmount >= 0 ? 'ahead of' : 'behind';
     const hideOrUnhide = isDeemphasized ? 'unhide' : 'hide';
-    const formattedDisplay = ynabToolKit.shared.formatCurrency(Math.abs(paceAmount), false);
+    const formattedDisplay = formatCurrency(Math.abs(paceAmount), false);
     const formattedDisplayInDays = Math.abs(daysOffTarget);
     const days = formattedDisplayInDays === 1 ? 'day' : 'days';
     const transactionsFormat = transactions.length === 1 ? 'transaction' : 'transactions';

--- a/src/extension/features/budget/stealing-from-future/index.js
+++ b/src/extension/features/budget/stealing-from-future/index.js
@@ -100,8 +100,7 @@ export class StealingFromFuture extends Feature {
   }
 
   invoke() {
-    let budgetController = ynabToolKit.shared.containerLookup('controller:budget');
-    let budgetViewModel = budgetController.get('budgetViewModel');
+    const budgetViewModel = controllerLookup('budget').get('budgetViewModel');
     if (budgetViewModel) {
       budgetViewModel.get('allBudgetMonthsViewModel.monthlyBudgetCalculationsCollection').forEach((month) => {
         month.addObserver('availableToBudget', this.onAvailableToBudgetChange.bind(this, budgetViewModel));

--- a/src/extension/features/general/import-notification/index.js
+++ b/src/extension/features/general/import-notification/index.js
@@ -1,4 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
+import { getEmberView } from 'toolkit/extension/utils/ember';
 
 export class ImportNotification extends Feature {
   isActive = false;
@@ -48,7 +49,7 @@ export class ImportNotification extends Feature {
 
     $('.' + this.importClass).remove();
     $('.nav-account-row').each((index, row) => {
-      let account = ynabToolKit.shared.getEmberView($(row).attr('id')).get('data');
+      let account = getEmberView($(row).attr('id')).get('data');
 
       // Check for both functions should be temporary until all users have been switched to new bank data
       // provider but of course we have no good way of knowing when that has occurred.

--- a/src/extension/features/general/privacy-mode/index.js
+++ b/src/extension/features/general/privacy-mode/index.js
@@ -1,4 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
+import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 
 const Settings = {
   AlwaysOn: '1',
@@ -21,9 +22,9 @@ export class PrivacyMode extends Feature {
   }
 
   invoke() {
-    let toggle = ynabToolKit.shared.getToolkitStorageKey('privacy-mode');
+    let toggle = getToolkitStorageKey('privacy-mode');
     if (typeof toggle === 'undefined') {
-      ynabToolKit.shared.setToolkitStorageKey('privacy-mode', false);
+      setToolkitStorageKey('privacy-mode', false);
     }
 
     if (ynabToolKit.options.PrivacyMode === Settings.Toggle) {
@@ -36,7 +37,7 @@ export class PrivacyMode extends Feature {
         });
       }
     } else if (ynabToolKit.options.PrivacyMode === Settings.AlwaysOn) {
-      ynabToolKit.shared.setToolkitStorageKey('privacy-mode', true);
+      setToolkitStorageKey('privacy-mode', true);
     }
 
     this.updatePrivacyMode();
@@ -45,13 +46,13 @@ export class PrivacyMode extends Feature {
   togglePrivacyMode() {
     $('button#toolkit-togglePrivacy').toggleClass('active');
 
-    let toggle = ynabToolKit.shared.getToolkitStorageKey('privacy-mode');
-    ynabToolKit.shared.setToolkitStorageKey('privacy-mode', !toggle);
+    let toggle = getToolkitStorageKey('privacy-mode');
+    setToolkitStorageKey('privacy-mode', !toggle);
     this.updatePrivacyMode();
   }
 
   updatePrivacyMode() {
-    let toggle = ynabToolKit.shared.getToolkitStorageKey('privacy-mode');
+    let toggle = getToolkitStorageKey('privacy-mode');
 
     if (toggle) {
       $('body').addClass('toolkit-privacyMode');

--- a/src/extension/ynab-toolkit.js
+++ b/src/extension/ynab-toolkit.js
@@ -36,7 +36,10 @@ export class YNABToolkit {
       event.source === window &&
       event.data.type === TOOLKIT_BOOTSTRAP_MESSAGE
     ) {
-      window.ynabToolKit = event.data.ynabToolKit;
+      window.ynabToolKit = {
+        ...window.ynabToolKit,
+        ...event.data.ynabToolKit
+      };
       this._setupErrorTracking();
       this._createFeatureInstances();
       this._removeMessageListener();


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
We're getting multiple errors about the shared lib not being defined which is actually pretty alarming but it shouldn't be getting used at all anyway. This updates almost all of those leaving some date-specific and formatting specific ones alone for a refactor.
