### PR TITLE
Fixed the edit account button not hiding when ynab had it set to hidden

### DIFF
--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -18,8 +18,8 @@ Adds a button that can collapse the menu on the left so you can see more of your
 ## Colour Blind Mode
 Changes colours like red, yellow and green in the interface to colours and shapes that are more easily distinguishable by colourblind people.
 
-## Edit Account Button Position
-Allows you to move or hide the edit account button to help prevent accidentally clicking on it.
+## Hide Edit Account Button
+Allows you to hide the edit account button to help prevent accidentally clicking on it.
 
 ## Hide Account Balances
 Allows you to hide account type totals and/or account balances.

--- a/src/extension/features/general/edit-account-button/hide.css
+++ b/src/extension/features/general/edit-account-button/hide.css
@@ -1,11 +1,3 @@
-.nav-account-row:hover .nav-account-name .edit-account-icon {
-	display: none;
-}
-
-.nav-account-row:hover .nav-account-notification .edit-account-icon {
-	display: none;
-}
-
-.nav-account-row .nav-account-name:hover button {
-	max-width: 100%;
+.nav-account-icons {
+	visibility: hidden;
 }

--- a/src/extension/features/general/edit-account-button/index.js
+++ b/src/extension/features/general/edit-account-button/index.js
@@ -3,8 +3,6 @@ import { Feature } from 'toolkit/extension/features/feature';
 export class EditAccountButton extends Feature {
   injectCSS() {
     if (this.settings.enabled === '1' && !YNABFEATURES['edit-account-icon']) {
-      return require('./left.css');
-    } else if (this.settings.enabled === '2') {
       return require('./hide.css');
     }
   }

--- a/src/extension/features/general/edit-account-button/left.css
+++ b/src/extension/features/general/edit-account-button/left.css
@@ -1,6 +1,0 @@
-.nav-account-row .nav-account-name i {
-  padding-top: 2px;
-  padding-right: 4px;
-  float:left;
-  transition: opacity .25s ease-in-out;
-}

--- a/src/extension/features/general/edit-account-button/settings.js
+++ b/src/extension/features/general/edit-account-button/settings.js
@@ -3,11 +3,10 @@ module.exports = {
   type: 'select',
   default: '0',
   section: 'general',
-  title: 'Edit Account Button Position',
-  description: 'Allows you to move or hide the edit account button to help prevent accidentally clicking on it.',
+  title: 'Hide Edit Account Button',
+  description: 'Allows you to hide the edit account button to help prevent accidentally clicking on it.',
   options: [
     { name: 'Default', value: '0' },
-    { name: 'Left of name', value: '1' },
-    { name: 'Hidden (right-click to edit)', value: '2' }
+    { name: 'Hidden (right-click to edit)', value: '1' }
   ]
 };


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1343 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:

It looks like this feature was done a while ago. The css for the icons has most likely changed. I'm just setting the visibility of the icons to hidden when the option is set.
