### PR TITLE
Fixes Regexp error for malformed regex

### DIFF
--- a/src/extension/features/accounts/split-keyboard-shortcut/index.js
+++ b/src/extension/features/accounts/split-keyboard-shortcut/index.js
@@ -39,8 +39,8 @@ export class SplitKeyboardShortcut extends Feature {
             }
           }
         }).on('keyup', function () {
-          const categoryInputString = new RegExp('^' + $(this).val());
-          if (categoryInputString.test('split') && categoryList.find('li').length === 3) {
+          const categoryInputString = new RegExp('^s(?:p|$)(?:l|$)(?:i|$)(?:t|$)', 'i');
+          if (categoryInputString.test($(this).val()) && categoryList.find('li').length === 3) {
             // highlight new split button if input contains part of
             // 'split' and there are no other categories available
             categoryList.addClass('toolkit-hide-firstchild');


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #XXX

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:

This changes how the keyword "split" is looked for in the categories for a transaction.

Before:
A regex string was created using user input from the category textbox. This was then used to test against the string "split". I assume this was done to allow any substring of the word "split" be matched. Ex: User types "spl". regex was created "^spl", and this regex was tested against "split", which matched.

Problem:
User input is not guaranteed to be valid regex matches. E.g. if they have an open parenthesis and no close parenthesis then it would be malformed and an error thrown.

Change:
A static regex test string is completed that will match any sub string of "split". Functionality does not change, but readability of the regex is lower. This does prevent errors from being thrown, however. Also, made it case insensitive, in case user types "Split", or has caps lock key on, etc.

