### PR TITLE
Don't worry about sort direction when calculating running balance

### DIFF
--- a/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
@@ -137,13 +137,6 @@ function attachAnyItemChangedListener(accountId, transactionViewModel) {
         calculateRunningBalance(updatedAccountId);
       }
     });
-
-  controllerLookup('accounts').addObserver('sortAscending', function (displayItems) {
-    const updatedAccountId = displayItems.get('visibleTransactionDisplayItems.firstObject.accountId');
-    if (updatedAccountId) {
-      calculateRunningBalance(updatedAccountId);
-    }
-  });
 }
 
 function calculateRunningBalance(accountId) {
@@ -152,6 +145,9 @@ function calculateRunningBalance(accountId) {
       attachAnyItemChangedListener(accountId, transactionViewModel);
     }
 
+    // Sort all transactions is ascending order first. If the dates match, sort transactions
+    // in ascending order (outflows are negative when using `.getAmount`). If the dates are
+    // equal, the amounts are always sorted in descending order.
     const transactions = transactionViewModel.get('visibleTransactionDisplayItems');
     const sorted = transactions.slice().sort((a, b) => {
       let propA = a.get('date');
@@ -160,23 +156,17 @@ function calculateRunningBalance(accountId) {
       if (propA instanceof ynab.utilities.DateWithoutTime) propA = propA.getUTCTime();
       if (propB instanceof ynab.utilities.DateWithoutTime) propB = propB.getUTCTime();
 
-      // compare the dates
-      let res = Ember.compare(propA, propB);
-
-      // if the dates are equal
-      if (res === 0) {
-        // compare the amounts
-        res = Ember.compare(a.getAmount(), b.getAmount());
-
-        // if the amounts are equal
-        if (res === 0) {
+      const dateCompare = Ember.compare(propA, propB);
+      if (dateCompare === 0) {
+        const amountCompare = Ember.compare(a.getAmount(), b.getAmount());
+        if (amountCompare === 0) {
           return Ember.compare(a.getEntityId(), b.getEntityId());
         }
 
-        return -res;
+        return -amountCompare;
       }
 
-      return res;
+      return dateCompare;
     });
 
     let runningBalance = 0;

--- a/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
@@ -173,8 +173,7 @@ function calculateRunningBalance(accountId) {
           return Ember.compare(a.getEntityId(), b.getEntityId());
         }
 
-        const sortAscending = localStorage.getItem(`.${accountId}_sortAscending`) || 'true';
-        return sortAscending === 'true' ? res : -res;
+        return -res;
       }
 
       return res;


### PR DESCRIPTION
Github Issue (if applicable): #1357

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
We used to need to change how we calculated running balance based on sort order but now that YNAB is performing a direct inverse sort of DESCENDING when the user chooses ASCENDING we can just simply calculate running balance in a descending order and trust it will be correct in both directions.

https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/1319#issuecomment-392857214
