### PR TITLE
Updated Show Import Notification in Navigation Sidebar

### DIFF
--- a/src/extension/features/general/import-notification/index.css
+++ b/src/extension/features/general/import-notification/index.css
@@ -1,7 +1,9 @@
-.import-notification {
-  background-color: #227e99;
+.ynabtk-import-notification-underline {
+  text-decoration: none;
+  border-bottom: 1.75px solid white;
 }
 
-.import-notification-red {
-  background-color: #FF0000;
+.ynabtk-import-notification-underline-red {
+  text-decoration: none;
+  border-bottom: 1.75px solid red;
 }

--- a/src/extension/features/general/import-notification/index.js
+++ b/src/extension/features/general/import-notification/index.js
@@ -1,9 +1,10 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
+import { l10n } from 'toolkit/extension/utils/toolkit';
 
 export class ImportNotification extends Feature {
   isActive = false;
-  importClass = 'import-notification';
+  importClass = 'ynabtk-import-notification-underline';
 
   injectCSS() { return require('./index.css'); }
 
@@ -47,24 +48,31 @@ export class ImportNotification extends Feature {
   checkImportTransactions() {
     this.isActive = true;
 
-    $('.' + this.importClass).remove();
     $('.nav-account-row').each((index, row) => {
       let account = getEmberView($(row).attr('id')).get('data');
+      let accountSpan = $(row).find('.nav-account-name > .nav-account-name-val > span');
+      if (accountSpan.length) {
+        // Remove the title attribute and our underline class in case the account no longer has txns to be imported
+        $(accountSpan).removeAttr('title').removeClass(this.importClass);
 
-      // Check for both functions should be temporary until all users have been switched to new bank data
-      // provider but of course we have no good way of knowing when that has occurred.
-      if (typeof account.getDirectConnectEnabled === 'function' && account.getDirectConnectEnabled() ||
-          typeof account.getIsDirectImportActive === 'function' && account.getIsDirectImportActive()) {
-        let t = new ynab.managers.DirectImportManager(ynab.YNABSharedLib.defaultInstance.entityManager, account);
-        let transactions = t.getImportTransactionsForAccount(account);
+        let currentTitle = $(row).find('.nav-account-name').prop('title');
 
-        if (transactions.length >= 1) {
-          $(row)
-            .find('.nav-account-notification')
-            .append('<a class="notification ' + this.importClass + '">' + transactions.length + '</a>');
+        // Check for both functions should be temporary until all users have been switched to new bank data
+        // provider but of course we have no good way of knowing when that has occurred.
+        if (typeof account.getDirectConnectEnabled === 'function' && account.getDirectConnectEnabled() ||
+            typeof account.getIsDirectImportActive === 'function' && account.getIsDirectImportActive()) {
+          let t = new ynab.managers.DirectImportManager(ynab.YNABSharedLib.defaultInstance.entityManager, account);
+          let transactions = t.getImportTransactionsForAccount(account);
+
+          if (transactions.length >= 1) {
+            $(accountSpan)
+              .addClass(this.importClass)
+              .attr('title', currentTitle + ` - ${transactions.length} ` + l10n('toolkit.import.notification', 'transaction(s) to be imported.'));
+          }
         }
       }
     });
+
     this.isActive = false;
   }
 }

--- a/src/extension/features/general/import-notification/settings.js
+++ b/src/extension/features/general/import-notification/settings.js
@@ -3,11 +3,11 @@ module.exports = {
   type: 'select',
   default: '0',
   section: 'general',
-  title: 'Show Import Notifications in Sidebar',
-  description: 'Display a notification in the sidebar when there are transactions to be imported.',
+  title: 'Show Import Notifications in Navigation Sidebar',
+  description: 'Underline account names in the navigation sidebar that have transactions to be imported. Hovering the mouse over the account name will display the number of transactions to be imported.',
   options: [
     { name: 'Off', value: '0' },
-    { name: 'On - Default Indicator Color', value: '1', style: 'background-color: #227e99' },
-    { name: 'On - Red Indicator Color', value: '2', style: 'background-color: #FF0000' }
+    { name: 'On - Underline account names in white', value: '1' },
+    { name: 'On - Underline account names in red', value: '2' }
   ]
 };


### PR DESCRIPTION
to use underlining to indicate accounts with transactions to be imported.
The account name will be underlined in white or red depending on the users
selection.

<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1342

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
The code change adds a class (for white or red underlining) and title attribute (dynamically created to contain the current number of transactions to be imported) to the <span> element. Adding these to the <span> element means there is no need to track the original values for the purpose of resetting after the transactions have been imported. Each time the code runs these are removed from all the <span> elements which allows the original title attribute to be used and there is no longer a need for the underline class.
