### PR TITLE
Fix off-by-1-cent errors when auto-distributing split transactions

### DIFF
--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -103,15 +103,21 @@ export class AutoDistributeSplits extends Feature {
         'are you sure you want to subtract from them?');
   }
 
-  getUpdatedSubValues(subValues, total, remaining) {
-    return subValues.map(this.proportionalValue(total, remaining));
-  }
-
-  proportionalValue(total, remaining) {
-    return value => {
-      const proportionalValue = value + value / (total - remaining) * remaining;
-      return Math.round(proportionalValue * 100) / 100;
-    };
+  getUpdatedSubValues(subValues, total, originalRemainingAmount) {
+    const subTotal = total - originalRemainingAmount;
+    let remainingAmountToDistribute = originalRemainingAmount;
+    return subValues.map((subValue, i) => {
+      let proportionOfRemaining = (subValue / subTotal) * originalRemainingAmount;
+      proportionOfRemaining = Math.round(proportionOfRemaining * 100) / 100;
+      const isLastSubValue = (i + 1) === subValues.length;
+      const amountToAdd = (isLastSubValue &&
+        (proportionOfRemaining === 0 ||
+          proportionOfRemaining > remainingAmountToDistribute))
+        ? remainingAmountToDistribute
+        : proportionOfRemaining;
+      remainingAmountToDistribute -= amountToAdd;
+      return Math.round((subValue + amountToAdd) * 100) / 100;
+    });
   }
 
   adjustValues(subCells, newSubValues) {

--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -72,10 +72,8 @@ export class AutoDistributeSplits extends Feature {
       return;
     }
 
-    this.adjustValues(
-      subCells,
-      subValues.map(this.proportionalValue(total, remaining))
-    );
+    const newSubValues = this.getUpdatedSubValues(subValues, total, remaining);
+    this.adjustValues(subCells, newSubValues);
   }
 
   getCellsAndValues() {
@@ -105,14 +103,21 @@ export class AutoDistributeSplits extends Feature {
         'are you sure you want to subtract from them?');
   }
 
+  getUpdatedSubValues(subValues, total, remaining) {
+    return subValues.map(this.proportionalValue(total, remaining));
+  }
+
   proportionalValue(total, remaining) {
-    return value => value + value / (total - remaining) * remaining;
+    return value => {
+      const proportionalValue = value + value / (total - remaining) * remaining;
+      return Math.round(proportionalValue * 100) / 100;
+    };
   }
 
   adjustValues(subCells, newSubValues) {
     subCells.forEach((cell, i) => {
       $(cell).val(actualNumber(newSubValues[i])
-        ? (Math.round(newSubValues[i] * 100) / 100).toFixed(2)
+        ? newSubValues[i].toFixed(2)
         : '');
       $(cell).trigger('change');
     });

--- a/src/extension/features/accounts/auto-distribute-splits/index.test.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.test.js
@@ -1,0 +1,50 @@
+import { AutoDistributeSplits } from './index';
+
+describe('AutoDistributeSplits', () => {
+  let extension;
+
+  beforeEach(() => {
+    extension = new AutoDistributeSplits();
+  });
+
+  it('should distribute remaining value proportionally across all subvalues', () => {
+    const total = 6.06;
+    const remaining = 0.06;
+    const originalSubValues = [1.00, 2.00, 3.00];
+    const expectedSubValues = [1.01, 2.02, 3.03];
+    testDistributionLogic(total, remaining, originalSubValues, expectedSubValues);
+  });
+
+  it('should distribute 1 cent correctly when one subvalue is greater than half of subtotal', () => {
+    const total = 0.11;
+    const remaining = 0.01;
+    const originalSubValues = [0.06, 0.04];
+    const expectedSubValues = [0.07, 0.04];
+    testDistributionLogic(total, remaining, originalSubValues, expectedSubValues);
+  });
+
+  it('should distribute 1 cent correctly when both subvalues are half of subtotal', () => {
+    const total = 0.11;
+    const remaining = 0.01;
+    const originalSubValues = [0.05, 0.05];
+    const expectedSubValues = [0.06, 0.05];
+    testDistributionLogic(total, remaining, originalSubValues, expectedSubValues);
+  });
+
+  it('should distribute 1 cent correctly when all subvalues are less than half of subtotal', () => {
+    const total = 0.10;
+    const remaining = 0.01;
+    const originalSubValues = [0.03, 0.03, 0.03];
+    const expectedSubValues = [0.03, 0.03, 0.04];
+    testDistributionLogic(total, remaining, originalSubValues, expectedSubValues);
+  });
+
+  function testDistributionLogic(total, remaining, subValues, expectedSubValues) {
+    const newSubValues = extension.getUpdatedSubValues(subValues, total, remaining);
+
+    const newTotal = newSubValues.reduce((a, b) => a + b);
+    expect(newTotal).toBeCloseTo(total, 2);
+
+    expect(newSubValues).toEqual(expectedSubValues);
+  }
+});


### PR DESCRIPTION
Github Issue: #1389

#### Explanation of Bugfix:

The original logic for auto-distributing the remaining amount of a split transaction across all sub-transactions was sometimes off by $0.01 due to rounding errors. This PR updates the distribution logic to ensure that we always distribute the full remaining amount -- no more and no less! ⚖️ 

This PR includes three commits:
1. The first commit makes the `AutoDistributeSplits` class easier to test by exposing a `getUpdatedSubValues()` method, which accepts a collection of sub-transaction values and returns the updated values. This enables us to test the distribution logic without creating/manipulating DOM elements.
2. The second commit adds unit tests for the new `getUpdatedSubValues()` method, including tests that reproduce #1389. The first two tests pass with the existing implementation, while the other two fail. The failing tests correspond to the +$0.01 and -$0.01 rounding errors that underlie #1389.
3. The third and final commit updates the implementation of `getUpdatedSubValues()` so all of the unit tests pass. The new algorithm keeps track of the remaining amount to distribute, which is subtracted from as each sub-transaction is processed. On the last sub-transaction, we use this remaining amount as a boundary to avoid off-by-1-cent errors.