### PR TITLE
Fixed: Days of buffering was showing as 0.0 for users who navigate to the budget page through "Select a Budget" after login.

### DIFF
--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -48,17 +48,19 @@ export class EasyTransactionApproval extends Feature {
 
   invoke() {
     // get selected transactions
-    this.selectedTransactions = undefined;
+    this.selectedTransactions = null;
     const accountController = controllerLookup('accounts');
     if (!accountController) {
       return;
     }
 
     const visibleTransactionDisplayItems = accountController.get('visibleTransactionDisplayItems');
-    this.selectedTransactions = visibleTransactionDisplayItems.filter(i => i.isChecked && i.get('accepted') === false);
+    if (visibleTransactionDisplayItems) {
+      this.selectedTransactions = visibleTransactionDisplayItems.filter(i => i.isChecked && i.get('accepted') === false);
+    }
 
     // only watch for keydown if there are selected, unaccepted transactions
-    if (this.selectedTransactions.length > 0) {
+    if (this.selectedTransactions && this.selectedTransactions.length > 0) {
       this.watchForKeys = true;
     }
 

--- a/src/extension/features/accounts/toggle-transaction-filters/index.js
+++ b/src/extension/features/accounts/toggle-transaction-filters/index.js
@@ -76,14 +76,13 @@ export class ToggleTransactionFilters extends Feature {
   }
 
   initToggleButtons() {
-    // get internal filters
     const controller = controllerLookup('accounts');
     if (!controller) {
       return;
     }
 
-    const settingReconciled = controller.filters.get('reconciled');
-    const settingScheduled = controller.filters.get('scheduled');
+    const settingReconciled = controller.get('filters.reconciled');
+    const settingScheduled = controller.get('filters.scheduled');
 
     // insert or edit buttons
     if (!$('#toolkit-toggleReconciled').length) {

--- a/src/extension/utils/collections.js
+++ b/src/extension/utils/collections.js
@@ -1,24 +1,15 @@
 import { getEntityManager } from './ynab';
 
 export class Collections {
-  static _accountsCollection = null;
-  static _accountCalculationsCollection = null;
-
   static get accountsCollection() {
-    if (!this._accountsCollection) {
-      Collections._accountsCollection = new ynab.collections.AccountsCollection();
-      Collections._accountsCollection.addItemsFromArray(getEntityManager().getAllAccounts());
-    }
-
-    return Collections._accountsCollection;
+    const collection = new ynab.collections.AccountsCollection();
+    collection.addItemsFromArray(getEntityManager().getAllAccounts());
+    return collection;
   }
 
   static get accountCalculationsCollection() {
-    if (!this._accountCalculationsCollection) {
-      Collections._accountCalculationsCollection = new ynab.collections.AccountCalculationsCollection();
-      Collections._accountCalculationsCollection.addItemsFromArray(getEntityManager().getAllAccountCalculations());
-    }
-
-    return Collections._accountCalculationsCollection;
+    const collection = new ynab.collections.AccountCalculationsCollection();
+    collection.addItemsFromArray(getEntityManager().getAllAccountCalculations());
+    return collection;
   }
 }


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1393

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
Our custom `Collections` class was trying to be nice and keep collections around after they were created but this doesn't work well since the first time they're created might be with no transactions/accounts. We'll just recreate them every time until that seems like a bad performance issue.
