### PR TITLE
Fixed an issue with Income from last month in Privacy mode

### DIFF
--- a/src/extension/features/budget/income-from-last-month/index.js
+++ b/src/extension/features/budget/income-from-last-month/index.js
@@ -38,9 +38,9 @@ export class IncomeFromLastMonth extends Feature {
       $('.budget-header-totals-details-values')
         .prepend($('<div>', {
           class: 'budget-header-totals-cell-value toolkit-income-from-last-month user-data'
-        }).append('<span>', {
+        }).append($('<span>', {
           class: 'user-data currency positive'
-        }));
+        })));
 
       $('.budget-header-totals-details-names')
         .prepend($('<div>', {


### PR DESCRIPTION
Github Issue (if applicable): #1403 

Trello Link (if applicable): n/a

Forum Link (if applicable): n/a

#### Explanation of Bugfix/Feature/Modification:

For the span tag there was no constructor so that the jQuery ignored the passed class list and because of this the privacy mode did not hide this information. I just added missing `$()`
