### PR TITLE
Fixed bug when 'Hide Age of Money Calculation' hides 'Days of buffering'

### DIFF
--- a/src/extension/features/budget/hide-age-of-money/index.css
+++ b/src/extension/features/budget/hide-age-of-money/index.css
@@ -1,4 +1,4 @@
-.budget-header-days {
+.budget-header-days:not(.toolkit-days-of-buffering) {
 	display: none;
 	border-left: none;
 }


### PR DESCRIPTION
Github Issue (if applicable): #1409 

Trello Link (if applicable): n/a

Forum Link (if applicable): n/a

#### Explanation of Bugfix/Feature/Modification:

Both 'Age of money' and 'Days of buffering' use the same class (`.budget-header-days`), which is hidden if 'Hide Age of Money Calculation' is enabled. I little changed CSS file of feature to hide only 'Age of money' metric
