### PR TITLE
Fixed issue when 'Edit account' icon was hidden but still worked if click at it

### DIFF
--- a/src/extension/features/general/edit-account-button/hide.css
+++ b/src/extension/features/general/edit-account-button/hide.css
@@ -1,3 +1,7 @@
 svg.ember-view.svg-icon.edit {
 	visibility: hidden;
 }
+
+.nav-accounts a.nav-account-row > .nav-account-icons.nav-account-icons-left {
+	pointer-events: none;
+}


### PR DESCRIPTION
Github Issue (if applicable): #1400 

Trello Link (if applicable): n/a

Forum Link (if applicable): n/a

#### Explanation of Bugfix/Feature/Modification:
The icon itself (SVG) was hidden using `visibility` (not `display`),  so it still reacts if you click at the place where the icon was. So I added `pointer-events: none` for icon container and now all clicks at hidden icon are passed to the parent (now it's like usual click at account name)
