### PR TITLE
Fixed removal of negative categories when covering over-spending

### DIFF
--- a/src/extension/features/budget/remove-zero-categories/index.js
+++ b/src/extension/features/budget/remove-zero-categories/index.js
@@ -9,7 +9,10 @@ export class RemoveZeroCategories extends Feature {
   invoke() {
     let coverOverbudgetingCategories = $('.modal-budget-overspending .dropdown-list > li');
     coverOverbudgetingCategories.each(function () {
-      let t = $(this).find('.category-available').text(); // Category balance text.
+      let t = $(this).find('.category-available').attr('title'); // Category balance text.
+      if (t == null) {
+        return;
+      }
       let categoryBalance = parseInt(t.replace(/[^\d-]/g, ''));
       if (categoryBalance <= 0) {
         $(this).remove();


### PR DESCRIPTION
Explanation of Bugfix/Feature/Modification:
This fixes the feature "Remove Zero and Negative Categories When Covering Over-Budgeting" for negative categories, which it was not correctly removing.