### PR TITLE
Fixed master category pacing (month progress bar) missing, also made colors customizable

### DIFF
--- a/docs/building-features.md
+++ b/docs/building-features.md
@@ -35,7 +35,7 @@ follow these steps:
 3. Create an `index.js` file which has the following:
   <!-- spacing is intentionally weird here because of markdown -->
   ```javascript
-  import { Feature } from 'toolkit/core/feature';
+  import { Feature } from 'toolkit/extension/features/feature';
 
   export class MyCoolFeature extends Feature {
     shouldInvoke() {

--- a/src/extension/features/budget/budget-progress-bars/index.css
+++ b/src/extension/features/budget/budget-progress-bars/index.css
@@ -1,3 +1,25 @@
+:root {
+  /* General color definitions */
+  /* ReSharper disable Redundant, used implicitly in js code */
+  --progress-bar-goal-color: rgba(22, 163, 54, 0.3);
+  --progress-bar-goal-spacing-color: rgba(0, 0, 0, 0);
+  --progress-bar-pacing-color: rgb(192, 226, 233);
+  --progress-bar-pacing-month-progress-indicator-color: rgb(207, 213, 216);
+  --progress-bar-pacing-spacing-color: rgba(0, 0, 0, 0);
+  --progress-bar-pacing-master-spacing-color: rgba(0, 0, 0, 0);
+  /* ReSharper restore Redundant */
+}
+
+/* Fix position of head monthly progress indicator by moving the bg slightly to the right and making it shorter. Also move the text back */
+.budget-table-row.is-master-category .budget-table-cell-name {
+  margin-left: 0.5rem;
+  width: 39%;
+}
+.budget-table-cell-name-static-width {
+  margin-left: -0.4rem;
+}
+
+
 .budget-table-row.is-checked,
 .budget-table-row.is-checked .budget-table-cell-name,
 .budget-table-row.is-checked .budget-table-cell-budgeted {

--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -100,17 +100,20 @@ export class BudgetProgressBars extends Feature {
     const balancePriorToSpending = subCategory.get('balancePriorToSpending');
     const { budgetedPace, monthPace } = pacingCalculation;
 
+    // For pacing progress bars we can't use budgeted pace higher than 100%, otherwise the bars get screwed. So we cap it at 100% width
+    const cappedBudgetedPace = Math.min(budgetedPace, 1);
+
     if (!pacingCalculation.isDeemphasized) {
       if (balancePriorToSpending > 0) {
         if (monthPace > budgetedPace) {
           $(target).css('background', this.generateProgressBarStyle(
             ['var(--progress-bar-pacing-color)', 'var(--progress-bar-pacing-spacing-color)', 'var(--progress-bar-pacing-month-progress-indicator-color)', 'var(--progress-bar-pacing-spacing-color)'],
-            [budgetedPace, this.monthProgress - progressIndicatorWidth, this.monthProgress]
+            [cappedBudgetedPace, this.monthProgress - progressIndicatorWidth, this.monthProgress]
           ));
         } else {
           $(target).css('background', this.generateProgressBarStyle(
             ['var(--progress-bar-pacing-color)', 'var(--progress-bar-pacing-month-progress-indicator-color)', 'var(--progress-bar-pacing-color)', 'var(--progress-bar-pacing-spacing-color)'],
-            [this.monthProgress - progressIndicatorWidth, this.monthProgress, budgetedPace]
+            [this.monthProgress - progressIndicatorWidth, this.monthProgress, cappedBudgetedPace]
           ));
         }
       } else {

--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -84,7 +84,7 @@ export class BudgetProgressBars extends Feature {
 
     if (hasGoal) {
       let percent = Math.round(parseFloat(status));
-      $(target).css('background', 'linear-gradient(to right, rgba(22, 163, 54, 0.3) ' + percent + '%, white ' + percent + '%)');
+      $(target).css('background', 'linear-gradient(to right, var(--progress-bar-goal-color) ' + percent + '%, var(--progress-bar-goal-spacing-color) ' + percent + '%)');
     } else {
       $(target).css('background', '');
     }
@@ -104,18 +104,18 @@ export class BudgetProgressBars extends Feature {
       if (balancePriorToSpending > 0) {
         if (monthPace > budgetedPace) {
           $(target).css('background', this.generateProgressBarStyle(
-            ['#c0e2e9', 'white', '#CFD5D8', 'white'],
+            ['var(--progress-bar-pacing-color)', 'var(--progress-bar-pacing-spacing-color)', 'var(--progress-bar-pacing-month-progress-indicator-color)', 'var(--progress-bar-pacing-spacing-color)'],
             [budgetedPace, this.monthProgress - progressIndicatorWidth, this.monthProgress]
           ));
         } else {
           $(target).css('background', this.generateProgressBarStyle(
-            ['#c0e2e9', '#CFD5D8', '#c0e2e9', 'white'],
+            ['var(--progress-bar-pacing-color)', 'var(--progress-bar-pacing-month-progress-indicator-color)', 'var(--progress-bar-pacing-color)', 'var(--progress-bar-pacing-spacing-color)'],
             [this.monthProgress - progressIndicatorWidth, this.monthProgress, budgetedPace]
           ));
         }
       } else {
         $(target).css('background', this.generateProgressBarStyle(
-          ['white', '#CFD5D8', 'white'],
+          ['var(--progress-bar-pacing-spacing-color)', 'var(--progress-bar-pacing-month-progress-indicator-color)', 'var(--progress-bar-pacing-spacing-color)'],
           [this.monthProgress - progressIndicatorWidth, this.monthProgress]
         ));
       }
@@ -172,18 +172,18 @@ export class BudgetProgressBars extends Feature {
         }
       }
 
-      if ($(this).hasClass('is-master-category')) {
+      if ($(element).hasClass('is-master-category')) {
         switch (this.settings.enabled) {
           case 'pacing':
             $(this).css('background', this.generateProgressBarStyle(
-              ['#E5F5F9', '#CFD5D8', '#E5F5F9'],
+              ['var(--progress-bar-pacing-master-spacing-color)', 'var(--progress-bar-pacing-month-progress-indicator-color)', 'var(--progress-bar-pacing-master-spacing-color)'],
               [this.monthProgress - progressIndicatorWidth, this.monthProgress]
             ));
             break;
           case 'both':
-            nameCell = $(this).find('li.budget-table-cell-name');// [0];
+            nameCell = $(element).find('li.budget-table-cell-name');// [0];
             $(nameCell).css('background', this.generateProgressBarStyle(
-              ['#E5F5F9', '#CFD5D8', '#E5F5F9'],
+              ['var(--progress-bar-pacing-master-spacing-color)', 'var(--progress-bar-pacing-month-progress-indicator-color)', 'var(--progress-bar-pacing-master-spacing-color)'],
               [this.monthProgress - progressIndicatorWidth, this.monthProgress]
             ));
             break;


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:

Since quite some time the monthly progress indicator for pacing was missing in the master categories. It still worked for the normal budgeting categories.  
I made a fix so that it works again. I also made some slight CSS adjustments so that the position progress indicator **exactly** matches the ones of the budget categories. It was slightly misaligned, especially on larger resolutions.

This PR also inclodes a small changes to the building-features.md where the folder was wrong. I noticed it while trying to develop a new feature.

The last - and big - change in this PR is switching the pacing bars to customizable colors.
Up until now, the pacing bars where generated in JS and set directly to the element with predefined colors. Making it impossible to modify them via styles or other CSS changes.  
I have introduced CSS variables for this case, so that they can be overriden. I also changed the spacing fields to transparent, instead of white. Maybe YNAB will change colors in the future, which would look strange then.