### PR TITLE
Fixed an issue with erronous whitespace on the right side when using a collapsed view

### DIFF
--- a/src/extension/features/general/collapse-side-menu/index.css
+++ b/src/extension/features/general/collapse-side-menu/index.css
@@ -20,7 +20,8 @@
 	left: 40px;
 }
 
-.layout.collapsed .content .scroll-wrap {
+.layout.collapsed .content .scroll-wrap,
+.layout.collapsed .content .register-flex-columns {
 	width: inherit;
 	min-width: 838px;
 }

--- a/src/extension/features/general/collapse-side-menu/index.js
+++ b/src/extension/features/general/collapse-side-menu/index.js
@@ -59,6 +59,7 @@ export class CollapseSideMenu extends Feature {
         $('.ynab-u.content').animate({ left: '3rem' }).promise(),
         $('.budget-header').animate({ left: '3rem' }).promise()
       ]).then(() => {
+        $('.layout.user-logged-in').addClass('collapsed');
         $('.ynabtk-navlink-reports-link span').addClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-link span').addClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-icon').removeClass('left-circle-4').addClass('right-circle-4');
@@ -70,6 +71,7 @@ export class CollapseSideMenu extends Feature {
         $('.ynab-u.content').animate({ left: '260px' }).promise(),
         $('.budget-header').animate({ left: '260px' }).promise()
       ]).then(() => {
+        $('.layout.user-logged-in').removeClass('collapsed');
         $('.ynabtk-navlink-reports-link span').removeClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-link span').removeClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-icon').removeClass('right-circle-4').addClass('left-circle-4');


### PR DESCRIPTION
*No other trackers or references exist of this to my knowledge.*

## Explanation of bug fix

The stylesheet for the collapsable menu feature was dependant on a certain container having a `collapsed` class, which unfortunately wasn't present. I didn't look too close at the blame for the file, but the history seemed fairly straightforward, and I guess the change might've happened at some other point for hitherto unknown reasons, most likely unintentionally, or with YNAB changing their layouts a bit too much for it to have been caught.

In summary, the fix means that this doesn't happen anymore:
![Animation of issue before fixing it](http://yeeaaaah.org/p/s/2018-09-16_14-38-22.gif)
