### PR TITLE
Fixed Progress bar on master categories for past months

### DIFF
--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -90,6 +90,18 @@ export class BudgetProgressBars extends Feature {
     }
   }
 
+  addMasterPacingProgress(target) {
+    if (!isCurrentMonthSelected()) {
+      $(target).css('background', '');
+      return;
+    }
+
+    $(target).css('background', this.generateProgressBarStyle(
+      ['var(--tk-color-progress-bar-pacing-master-spacing)', 'var(--tk-color-progress-bar-pacing-month-progress-indicator)', 'var(--tk-color-progress-bar-pacing-master-spacing)'],
+      [this.monthProgress - progressIndicatorWidth, this.monthProgress]
+    ));
+  }
+
   addPacingProgress(subCategory, target) {
     if (!isCurrentMonthSelected()) {
       $(target).css('background', '');
@@ -178,17 +190,11 @@ export class BudgetProgressBars extends Feature {
       if ($(element).hasClass('is-master-category')) {
         switch (this.settings.enabled) {
           case 'pacing':
-            $(this).css('background', this.generateProgressBarStyle(
-              ['var(--tk-color-progress-bar-pacing-master-spacing)', 'var(--tk-color-progress-bar-pacing-month-progress-indicator)', 'var(--tk-color-progress-bar-pacing-master-spacing)'],
-              [this.monthProgress - progressIndicatorWidth, this.monthProgress]
-            ));
+            this.addMasterPacingProgress($(element));
             break;
           case 'both':
             nameCell = $(element).find('li.budget-table-cell-name');// [0];
-            $(nameCell).css('background', this.generateProgressBarStyle(
-              ['var(--tk-color-progress-bar-pacing-master-spacing)', 'var(--tk-color-progress-bar-pacing-month-progress-indicator)', 'var(--tk-color-progress-bar-pacing-master-spacing)'],
-              [this.monthProgress - progressIndicatorWidth, this.monthProgress]
-            ));
+            this.addMasterPacingProgress($(nameCell));
             break;
         }
       }


### PR DESCRIPTION
#### Explanation of Bugfix:

Dear god, I am so sorry. I forgot a few things while fixing this feature ._.

I just realized the master category monthly progress indicator is displayed for past months too, which it should not be. The subcategories had this fix already.  
I moved the CSS addition to a function too, to go conform with the other calls like this.

Also I forgot to change one `$(this)` to `$(element)`, which lead to the idicator not working if only the pacing bar was displayed, not pacing and goal both.