### PR TITLE
Fixed privacy feature for upcoming transaction amount

### DIFF
--- a/src/extension/features/budget/display-upcoming-amount/index.js
+++ b/src/extension/features/budget/display-upcoming-amount/index.js
@@ -18,7 +18,7 @@ export class DisplayUpcomingAmount extends Feature {
         $('.budget-table-cell-activity', element)
           .addClass('toolkit-activity-upcoming')
           .prepend($('<div>', {
-            class: 'toolkit-activity-upcoming-amount',
+            class: 'toolkit-activity-upcoming-amount currency',
             title: `Total upcoming transaction amount in this month for ${subCategory.get('name')}`,
             text: formatCurrency(monthlySubCategoryBudgetCalculation.upcomingTransactions)
           }));


### PR DESCRIPTION
Github Issue (if applicable): #1423

#### Explanation of Bugfix:

The feature for showing upcoming transaction amounts for each budget category was missing the currency class, meaning that the privacy feature did not hide the amount when it was activated.
I fixed that.

Thanks @apturtia for reporting it.