### PR TITLE
Feature: Resizing of Side Menu

### DIFF
--- a/src/extension/features/general/resize-sidebar/index.css
+++ b/src/extension/features/general/resize-sidebar/index.css
@@ -1,8 +1,10 @@
+/* ReSharper disable UnknownCssVariable */
 :root {
   --tk-number-resize-sidebar-original-width: 260;
   --tk-number-resize-sidebar-resizer-width: 3;
-  --tk-number-resize-sidebar-width: var(--tk-number-resize-sidebar-width, var(--tk-number-resize-sidebar-original-width));
+  --tk-number-resize-sidebar-width: var(--tk-number-resize-sidebar-width-from-code, var(--tk-number-resize-sidebar-original-width));
 }
+/* ReSharper restore UnknownCssVariable */
 
 .sidebar-resizer {
   position: fixed;

--- a/src/extension/features/general/resize-sidebar/index.css
+++ b/src/extension/features/general/resize-sidebar/index.css
@@ -6,7 +6,7 @@
 }
 /* ReSharper restore UnknownCssVariable */
 
-.sidebar-resizer {
+.tk-sidebar-resizer {
   position: fixed;
   top: 0;
   bottom: 0;

--- a/src/extension/features/general/resize-sidebar/index.css
+++ b/src/extension/features/general/resize-sidebar/index.css
@@ -1,0 +1,34 @@
+:root {
+  --tk-number-resize-sidebar-original-width: 260;
+  --tk-number-resize-sidebar-resizer-width: 3;
+  --tk-number-resize-sidebar-width: var(--tk-number-resize-sidebar-width, var(--tk-number-resize-sidebar-original-width));
+}
+
+.sidebar-resizer {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: calc((var(--tk-number-resize-sidebar-width) - var(--tk-number-resize-sidebar-resizer-width)) * 1px);
+  width: calc(var(--tk-number-resize-sidebar-resizer-width) * 1px);
+  z-index: 999;
+  cursor: ew-resize;
+  background: transparent;
+}
+
+/* Sidebar width */
+.sidebar,
+.sidebar .referral-program,
+.sidebar .button-prefs-user {
+  width: calc(var(--tk-number-resize-sidebar-width) * 1px) !important;
+}
+
+/* Match content left position to the width of the sidebar */
+.content,
+.budget-header {
+  left: calc(var(--tk-number-resize-sidebar-width) * 1px) !important;
+}
+
+/* Change max-width of account name texts accourding to original YNAB value (6.2rem) and the difference how much we have resized the sidebar */
+.sidebar .nav-account-name .nav-account-name-val {
+  max-width: calc(6.2rem + (var(--tk-number-resize-sidebar-width) - var(--tk-number-resize-sidebar-original-width)) * 1px);
+}

--- a/src/extension/features/general/resize-sidebar/index.js
+++ b/src/extension/features/general/resize-sidebar/index.js
@@ -3,8 +3,8 @@ import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/ut
 /* global $, console, require */
 
 const resizerClass = 'sidebar-resizer';
-const widthCssVar = '--tk-number-resize-sidebar-width';
-const widthStorageKey = 'resize-sidebar-widthsssssssss';
+const widthCssVar = '--tk-number-resize-sidebar-width-from-code';
+const widthStorageKey = 'resize-sidebar-width';
 const mindWidth = 200;
 const maxWidth = 800;
 
@@ -52,11 +52,14 @@ export class ResizeSidebar extends Feature {
     this.toggleResize(false, event);
   }
 
-  toggleResize(isResizing, event) {
+  toggleResize(isMouseDown, event) {
     event.preventDefault();
     event.stopPropagation();
-    this.isMouseDown = isResizing;
-    if (isResizing) {
+    this.isMouseDown = isMouseDown;
+
+    // Bind or unbind the events based on if the mouse is down.
+    // Use a local property so that unbinding works.
+    if (isMouseDown) {
       $('body').on('mousemove', this.bindOnMouseMove = this.onMouseMove.bind(this));
       $('body').on('mouseup', this.bindOnMouseUp = this.onMouseUp.bind(this));
     } else {

--- a/src/extension/features/general/resize-sidebar/index.js
+++ b/src/extension/features/general/resize-sidebar/index.js
@@ -1,12 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
-/* global $, console, require */
 
-const resizerClass = 'sidebar-resizer';
-const widthCssVar = '--tk-number-resize-sidebar-width-from-code';
-const widthStorageKey = 'resize-sidebar-width';
-const mindWidth = 200;
-const maxWidth = 800;
+const RESIZER_CLASS = 'tk-sidebar-resizer';
+const WIDTH_CSS_VAR = '--tk-number-resize-sidebar-width-from-code';
+const WIDTH_STORAGE_KEY = 'resize-sidebar-width';
+const MIN_WIDTH = 200;
+const MAX_WIDTH = 800;
 
 export class ResizeSidebar extends Feature {
   injectCSS() {
@@ -18,7 +17,7 @@ export class ResizeSidebar extends Feature {
   shouldInvoke() { return true; }
 
   invoke() {
-    const width = getToolkitStorageKey(widthStorageKey);
+    const width = getToolkitStorageKey(WIDTH_STORAGE_KEY);
     this.updateProperty(width);
     this.addSidebarResizer();
   }
@@ -27,7 +26,7 @@ export class ResizeSidebar extends Feature {
     const sidebar = $('nav.sidebar');
 
     // Build the resizer element
-    const resizer = $('<div>', { class: resizerClass });
+    const resizer = $('<div>', { class: RESIZER_CLASS });
 
     // Adds the resizer after the sidebar now
     $(sidebar).after(resizer);
@@ -72,9 +71,9 @@ export class ResizeSidebar extends Feature {
     if (typeof width !== 'number') { return; }
 
     // Keep the width between our defined borders
-    width = Math.max(mindWidth, Math.min(width, maxWidth));
+    const realWidth = Math.max(MIN_WIDTH, Math.min(width, MAX_WIDTH));
 
-    $(':root')[0].style.setProperty(widthCssVar, width);
-    setToolkitStorageKey(widthStorageKey, width);
+    $(':root')[0].style.setProperty(WIDTH_CSS_VAR, realWidth);
+    setToolkitStorageKey(WIDTH_STORAGE_KEY, realWidth);
   }
 }

--- a/src/extension/features/general/resize-sidebar/index.js
+++ b/src/extension/features/general/resize-sidebar/index.js
@@ -1,0 +1,77 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+/* global $, console, require */
+
+const resizerClass = 'sidebar-resizer';
+const widthCssVar = '--tk-number-resize-sidebar-width';
+const widthStorageKey = 'resize-sidebar-widthsssssssss';
+const mindWidth = 200;
+const maxWidth = 800;
+
+export class ResizeSidebar extends Feature {
+  injectCSS() {
+    return require('./index.css');
+  }
+
+  isMouseDown = false;
+
+  shouldInvoke() { return true; }
+
+  invoke() {
+    const width = getToolkitStorageKey(widthStorageKey);
+    this.updateProperty(width);
+    this.addSidebarResizer();
+  }
+
+  addSidebarResizer() {
+    const sidebar = $('nav.sidebar');
+
+    // Build the resizer element
+    const resizer = $('<div>', { class: resizerClass });
+
+    // Adds the resizer after the sidebar now
+    $(sidebar).after(resizer);
+
+    // Subscribe event on resizer to start resizing
+    $(resizer).click((event) => event.stopPropagation())
+      .mousedown((event) => {
+        this.toggleResize(true, event);
+      });
+  }
+
+  onMouseMove(event) {
+    if (!this.isMouseDown) { return; }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.updateProperty(event.clientX);
+  }
+
+  onMouseUp(event) {
+    this.toggleResize(false, event);
+  }
+
+  toggleResize(isResizing, event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isMouseDown = isResizing;
+    if (isResizing) {
+      $('body').on('mousemove', this.bindOnMouseMove = this.onMouseMove.bind(this));
+      $('body').on('mouseup', this.bindOnMouseUp = this.onMouseUp.bind(this));
+    } else {
+      $('body').off('mousemove', this.bindOnMouseMove);
+      $('body').off('mouseup', this.bindOnMouseUp);
+    }
+  }
+
+  updateProperty(width) {
+    if (typeof width !== 'number') { return; }
+
+    // Keep the width between our defined borders
+    width = Math.max(mindWidth, Math.min(width, maxWidth));
+
+    $(':root')[0].style.setProperty(widthCssVar, width);
+    setToolkitStorageKey(widthStorageKey, width);
+  }
+}

--- a/src/extension/features/general/resize-sidebar/settings.js
+++ b/src/extension/features/general/resize-sidebar/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'ResizeSidebar',
+  type: 'checkbox',
+  default: false,
+  section: 'general',
+  title: 'Allow Resizing of Side Menu',
+  description: 'Allows the Side Menu on the left to be resized. Resizing also allows longer account names to show up completely.'
+};


### PR DESCRIPTION
Trello Link: https://trello.com/c/0IiFXEE1/

#### Explanation of Feature:

The toolkit has allowed the inspector to change it's size for quite some time.
Up until now, the Side Menu was fixed though. Which is an issue for some people, because long account names get cut off.

I have implemented a feature which makes the Side Menu resizable.
It's quite flexible. Just move your mouse to the right border of the Side Menu. The cursor will change and allow you to drag the side menu width to your preferred size.
I have capped the resizing at a minimum of `200px` and a maximum of `800px`. I guess that's reasonable.

I am open for any suggestions or additions to this feature!

Would be also cool if someone would do a quick check of this feature before we do an official release. I have thoroughly tested it, but more testing is never wrong (: