### PR TITLE
Change polyfill strategy to address issues with Firefox

### DIFF
--- a/.babelrc-legacy
+++ b/.babelrc-legacy
@@ -1,16 +1,12 @@
 {
   "presets": [
     ["@babel/preset-env", {
+      "modules": "umd",
       "useBuiltIns": "usage",
       "targets": {
         "chrome": "58",
         "firefox": "45"
       }
-    }],
-    "@babel/preset-react"
-  ],
-  "plugins": [
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-syntax-object-rest-spread"
+    }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:development": "yarn build:check && yarn webpack:development && yarn build:legacy && yarn manifest:development",
     "build:prod": "yarn build:production",
     "build:production": "yarn build:check && yarn webpack:production && yarn build:legacy && yarn compress",
-    "build:legacy": "babel src/extension/legacy --compact false --quiet --out-dir dist/extension/web-accessibles/legacy",
+    "build:legacy": "babel src/extension/legacy --quiet --no-babelrc --compact false --config-file ./.babelrc-legacy --out-dir dist/extension/web-accessibles/legacy",
     "build:webpack": "webpack",
     "compress": "yarn compress:dist && yarn compress:src",
     "compress:dist": "node scripts/compressDist.js",

--- a/src/core/browser/content-scripts/init.js
+++ b/src/core/browser/content-scripts/init.js
@@ -78,27 +78,27 @@ function handleToolkitError(context) {
   getBrowser().runtime.sendMessage({ type: 'error', context });
 }
 
-function initializeYNABToolkit() {
-  getUserSettings().then((userSettings) => {
-    sendToolkitBootstrap(userSettings);
+async function initializeYNABToolkit() {
+  const userSettings = await getUserSettings();
+  sendToolkitBootstrap(userSettings);
 
-    /* Load this to setup shared utility functions */
-    injectScript('web-accessibles/legacy/features/shared/main.js');
+  /* Load this to setup shared utility functions */
+  injectScript('web-accessibles/legacy/features/shared/main.js');
 
-    /* Global toolkit css. */
-    injectCSS('web-accessibles/legacy/features/shared/main.css');
+  /* Global toolkit css. */
+  injectCSS('web-accessibles/legacy/features/shared/main.css');
 
-    /* This script to be built automatically by the python script */
-    injectScript('web-accessibles/legacy/features/act-on-change/feedChanges.js');
+  /* This script to be built automatically by the python script */
+  injectScript('web-accessibles/legacy/features/act-on-change/feedChanges.js');
 
-    /* Load this to setup behaviors when the DOM updates and shared functions */
-    injectScript('web-accessibles/legacy/features/act-on-change/main.js');
+  /* Load this to setup behaviors when the DOM updates and shared functions */
+  injectScript('web-accessibles/legacy/features/act-on-change/main.js');
 
-    applySettingsToDom(userSettings);
-  });
+  applySettingsToDom(userSettings);
 }
 
-storage.getFeatureSetting('DisableToolkit').then((isToolkitDisabled) => {
+async function init() {
+  const isToolkitDisabled = await storage.getFeatureSetting('DisableToolkit');
   if (isToolkitDisabled) {
     console.log(`${getBrowser().runtime.getManifest().name} is disabled!`);
     return;
@@ -109,4 +109,6 @@ storage.getFeatureSetting('DisableToolkit').then((isToolkitDisabled) => {
 
   // wait for the bundle to tell us it's loaded
   window.addEventListener('message', messageHandler);
-});
+}
+
+init();

--- a/src/core/common/storage/__mocks__/index.js
+++ b/src/core/common/storage/__mocks__/index.js
@@ -1,5 +1,5 @@
 import { mockToolkitStorage } from 'toolkit/test/mocks/toolkit-storage';
 
-export const ToolkitStorage = () => {
+export function ToolkitStorage() {
   return mockToolkitStorage;
-};
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,11 +15,11 @@ module.exports = function (env) {
 
   const config = {
     entry: {
-      'background/background': ['@babel/polyfill', path.resolve(`${CODE_SOURCE_DIR}/core/browser/background/index.js`)],
-      'options/options': ['@babel/polyfill', path.resolve(`${CODE_SOURCE_DIR}/core/browser/options/options.js`)],
-      'popup/popup': ['@babel/polyfill', path.resolve(`${CODE_SOURCE_DIR}/core/browser/popup/index.js`)],
-      'content-scripts/init': ['@babel/polyfill', path.resolve(`${CODE_SOURCE_DIR}/core/browser/content-scripts/init.js`)],
-      'web-accessibles/ynab-toolkit': ['@babel/polyfill', path.resolve(`${CODE_SOURCE_DIR}/extension/index.js`)]
+      'background/background': path.resolve(`${CODE_SOURCE_DIR}/core/browser/background/index.js`),
+      'options/options': path.resolve(`${CODE_SOURCE_DIR}/core/browser/options/options.js`),
+      'popup/popup': path.resolve(`${CODE_SOURCE_DIR}/core/browser/popup/index.js`),
+      'content-scripts/init': path.resolve(`${CODE_SOURCE_DIR}/core/browser/content-scripts/init.js`),
+      'web-accessibles/ynab-toolkit': path.resolve(`${CODE_SOURCE_DIR}/extension/index.js`)
     },
 
     devtool: 'source-map',


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
For some reason Firefox didn't like us injecting @babel/polyfill into
every entry point. Change to allow babel to fill these in based on
usage. Add an additional babel config for the legacy files as well since
they don't go through webpack, we need to use a umd module.
