### PR TITLE
Run content scripts at `document_idle`

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,7 @@
         "https://*.youneedabudget.com/*"
       ],
       "all_frames": true,
-      "run_at": "document_end",
+      "run_at": "document_idle",
       "js": [
         "content-scripts/init.js"
       ]


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
I'm hoping this fixes the issue where YNAB loads with a missing
sidebar. If this doesn't solve it, we may want to look into using
requestAnimationFrame before injecting our stuff into the DOM. This
issue is definitely some sort of race condition so I'll keep playing
with timing related fixes until we hopefully find a fix.
