### PR TITLE
Fix resize behavior of highcharts reports

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/series-legend/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/series-legend/component.jsx
@@ -26,14 +26,14 @@ export const SeriesLegendComponent = (props) => {
   );
 
   return (
-    <div className="tk-series-legend tk-pd-1 tk-flex-grow-1 tk-border-l">
+    <div className="tk-series-legend tk-pd-1 tk-flex-grow tk-overflow-scroll tk-border-l">
       {totalSummary}
       {averageSummary}
       <div className="tk-series-legend__table-row tk-series-legend__table-row--header tk-mg-t-05 tk-flex tk-justify-content-between">
         <div>{props.sourceName}</div>
         <div>{props.tableName}</div>
       </div>
-      <div className="tk-full-height tk-overflow-scroll">
+      <div className="tk-full-height">
         {sortedSeries.map((seriesData) => (
           <div className="tk-series-legend__table-row tk-flex tk-justify-content-between" key={seriesData.id} onMouseEnter={() => props.onDataHover(seriesData.id)}>
             <div className="tk-flex">

--- a/src/extension/features/toolkit-reports/common/scss/helpers.scss
+++ b/src/extension/features/toolkit-reports/common/scss/helpers.scss
@@ -13,7 +13,10 @@
 .tk-flex-row { flex-direction: row; }
 .tk-flex-column { flex-direction: column; }
 
-.tk-flex-grow-1 { flex-grow: 1; }
+.tk-flex-grow { flex-grow: 1; }
+.tk-flex-grow-none { flex-grow: 0; }
+.tk-flex-shrink { flex-shrink: 1; }
+.tk-flex-shrink-none { flex-shrink: 0; }
 
 .tk-justify-content-center { justify-content: center; }
 .tk-justify-content-between { justify-content: space-between; }

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -30,7 +30,7 @@ export class NetWorthComponent extends React.Component {
 
   render() {
     return (
-      <div className="tk-flex tk-flex-column tk-flex-grow-1">
+      <div className="tk-flex tk-flex-column tk-flex-grow">
         <div className="tk-flex tk-justify-content-end">
           {this.state.hoveredData && (
             <Legend
@@ -40,7 +40,7 @@ export class NetWorthComponent extends React.Component {
             />
           )}
         </div>
-        <div className="tk-flex-grow-1" id="tk-net-worth-chart" />
+        <div className="tk-highcharts-report-container" id="tk-net-worth-chart" />
       </div>
     );
   }

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.jsx
@@ -25,7 +25,7 @@ export class ReportFiltersComponent extends React.Component {
     });
 
     return (
-      <div className="tk-flex tk-pd-05 tk-border-b">
+      <div className="tk-flex tk-pd-05 tk-flex-shrink-none tk-border-b">
         <div className="tk-flex">
           <div className="tk-mg-r-05">
             <button onClick={this._showCategoryFilterModal} className={categoryButtonClasses}>

--- a/src/extension/features/toolkit-reports/pages/root/components/report-selector/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-selector/component.jsx
@@ -12,7 +12,7 @@ export class ReportSelectorComponent extends React.Component {
 
   render() {
     return (
-      <div className="tk-flex tk-pd-l-05 tk-align-items-center tk-report-selector">
+      <div className="tk-flex tk-pd-l-05 tk-flex-shrink-none tk-align-items-center tk-report-selector">
         {REPORT_TYPES.map(({ key, name }) => {
           const reportNameClasses = classnames('tk-mg-r-05', 'tk-report-selector__item', {
             'tk-report-selector__item--active': this.props.activeReportKey === key

--- a/src/extension/features/toolkit-reports/pages/root/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/root/styles.scss
@@ -1,3 +1,11 @@
 .tk-reports-root {
   left: 260px;
 }
+
+.tk-highcharts-report-container {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}

--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -59,8 +59,8 @@ export class SpendingByCategoryComponent extends React.Component {
     }
 
     return (
-      <div className="tk-flex tk-flex-grow-1">
-        <div className="tk-flex tk-justify-content-center tk-align-items-center tk-flex-grow-1" id="tk-spending-by-category" />
+      <div className="tk-flex tk-flex-grow">
+        <div className="tk-highcharts-report-container" id="tk-spending-by-category" />
         <div className="tk-spending-by-category__totals-legend tk-flex">
           {legendSeries && spendingByMasterCategory && (
             <SeriesLegend

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -43,8 +43,8 @@ export class SpendingByPayeeComponent extends React.Component {
     const { seriesData, spendingByPayeeData } = this.state;
 
     return (
-      <div className="tk-flex tk-flex-grow-1">
-        <div className="tk-flex tk-justify-content-center tk-align-items-center tk-flex-grow-1" id="tk-spending-by-payee" />
+      <div className="tk-flex tk-flex-grow">
+        <div className="tk-highcharts-report-container" id="tk-spending-by-payee" />
         <div className="tk-spending-by-payee__totals-legend tk-flex">
           {seriesData && spendingByPayeeData && (
             <SeriesLegend


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
Made the report selector and the filters divs stop shrinking when
you resize so they stay a consistent height, hid the overflow on the
highcharts container whenever you resize the browser.
