### PR TITLE
Update selectors/styles for goal-warning-color and target balance warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "jest-dot-reporter": "^1.0.3",
     "jest-localstorage-mock": "^2.1.0",
     "jquery": "^3.2.1",
-    "node-sass": "^4.9.2",
+    "node-sass": "^4.9.3",
     "sass-loader": "^7.0.3",
     "style-loader": "^0.21.0",
     "terminate": "^2.1.0",

--- a/src/extension/features/budget/budget-category-features/goal-warning-color/index.css
+++ b/src/extension/features/budget/budget-category-features/goal-warning-color/index.css
@@ -9,6 +9,7 @@
 
 /* row */
 .budget-table-row[data-toolkit-goal-underfunded]:not([data-toolkit-negative-available]) .budget-table-cell-available .ynab-new-budget-available-number:not(.negative):not(.credit) {
+  color: white;
   background-color: var(--tk-color-goal-warning-underfunded);
 }
 .budget-table-row[data-toolkit-goal-underfunded]:not([data-toolkit-negative-available]) .budget-table-cell-available .ynab-new-budget-available-number:not(.negative):not(.credit):hover {
@@ -20,6 +21,7 @@
   color: var(--tk-color-goal-warning-underfunded);
 }
 .budget-inspector[data-toolkit-goal-underfunded]:not([data-toolkit-negative-available]) .budget-inspector-category-overview .ynab-new-budget-available-number {
+  color: white;
   background: var(--tk-color-goal-warning-underfunded);
 }
 .budget-inspector[data-toolkit-goal-underfunded]:not([data-toolkit-negative-available]) .budget-inspector-category-overview .inspector-message {

--- a/src/extension/features/budget/budget-category-features/target-balance-warning/index.js
+++ b/src/extension/features/budget/budget-category-features/target-balance-warning/index.js
@@ -2,6 +2,8 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 import { CategoryAttributes } from 'toolkit/extension/features/budget/budget-category-features';
 
+const REMOVE_CLASSES = ['positive', 'zero'];
+
 export class TargetBalanceWarning extends Feature {
   shouldInvoke() { return isCurrentRouteBudgetPage(); }
 
@@ -9,17 +11,32 @@ export class TargetBalanceWarning extends Feature {
     const targetBalance = ynab.constants.SubCategoryGoalType.TargetBalance;
     const targetBalanceRows = [...document.querySelectorAll(`.budget-table-row[data-${CategoryAttributes.GoalType}="${targetBalance}"`)];
     targetBalanceRows.forEach((element) => {
-      const currencyElement = element.querySelector('.ynab-new-budget-available-number .currency');
-
-      if (!currencyElement) {
-        return;
-      }
+      const inspectorSelectors = [
+        '.budget-inspector .inspector-overview-available dt',
+        '.budget-inspector .inspector-overview-available .ynab-new-budget-available-number',
+        '.budget-inspector .inspector-overview-available .ynab-new-budget-available-number .currency'
+      ].join(',');
+      const rowElements = $('.ynab-new-budget-available-number', element);
+      const inspectorElements = $(inspectorSelectors);
 
       if (element.hasAttribute(`data-${CategoryAttributes.GoalUnderFunded}`)) {
-        currencyElement.classList.remove('positive');
-        currencyElement.classList.add('cautious');
+        REMOVE_CLASSES.forEach((className) => {
+          rowElements.removeClass(className);
+        });
+
+        rowElements.addClass('cautious');
       } else {
-        currencyElement.classList.remove('cautious');
+        rowElements.removeClass('cautious');
+      }
+
+      if ($(`.budget-inspector[data-${CategoryAttributes.GoalUnderFunded}]`).length) {
+        REMOVE_CLASSES.forEach((className) => {
+          inspectorElements.removeClass(className);
+        });
+
+        inspectorElements.addClass('cautious');
+      } else {
+        inspectorElements.removeClass('cautious');
       }
     });
   }

--- a/src/extension/features/budget/remove-positive-highlight/index.css
+++ b/src/extension/features/budget/remove-positive-highlight/index.css
@@ -1,39 +1,39 @@
-.budget-table-row.is-sub-category > .budget-table-cell-available .positive,
-.budget-table-row.is-sub-category.is-checked.goal-progress > .budget-table-cell-available .positive {
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) > .budget-table-cell-available .positive,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked.goal-progress > .budget-table-cell-available .positive {
 	background-color: transparent;
 	color: #16a336;
 	font-weight: bold;
 }
 
-.budget-table-row.is-sub-category > .budget-table-cell-available .positive:hover,
-.inspector-overview-available .positive {
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) > .budget-table-cell-available .positive:hover,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .inspector-overview-available .positive {
 	background-color: transparent;
 	color: #138b2e;
 }
 
-.budget-table-row.is-sub-category > .budget-table-cell-available .zero {
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) > .budget-table-cell-available .zero {
 	background-color: transparent;
 	color: #cfd5d8;
 	font-weight: normal;
 }
 
-.budget-table-row.is-sub-category.is-checked.goal-progress > .budget-table-cell-available .positive {
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked.goal-progress > .budget-table-cell-available .positive {
 	color: #16a336;
 	font-weight: bold;
 }
 
-.budget-table-row.is-sub-category.is-checked > .budget-table-cell-available .positive span,
-.budget-table-row.is-sub-category.is-checked > .budget-table-cell-available .zero span {
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked > .budget-table-cell-available .positive span,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked > .budget-table-cell-available .zero span {
 	color: #fff;
 }
 
 /* play well with check-credit-balances feature */
-.budget-table-row.is-sub-category.is-debt-payment-category[data-toolkit-pif-assist] .ynab-new-budget-available-number {
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-debt-payment-category[data-toolkit-pif-assist] .ynab-new-budget-available-number {
   color: #fff !important;
 }
-.budget-table-row.is-sub-category.is-debt-payment-category[data-toolkit-pif-assist] .ynab-new-budget-available-number:hover {
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-debt-payment-category[data-toolkit-pif-assist] .ynab-new-budget-available-number:hover {
   color: #fff !important;
 }
-.budget-inspector[data-toolkit-pif-assist] .ynab-new-budget-available-number {
+.budget-inspector[data-toolkit-pif-assist]:not([data-toolkit-goal-underfunded]) .ynab-new-budget-available-number {
   color: #fff !important;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,7 +898,11 @@ aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
-aws4@^1.6.0, aws4@^1.8.0:
+aws4@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
@@ -1586,7 +1590,13 @@ combined-stream@1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-combined-stream@~1.0.5, combined-stream@~1.0.6:
+combined-stream@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   dependencies:
@@ -4388,7 +4398,7 @@ node-releases@^1.0.0-alpha.12:
   dependencies:
     semver "^5.3.0"
 
-node-sass@^4.9.2:
+node-sass@^4.9.3:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.3.tgz#f407cf3d66f78308bb1e346b24fa428703196224"
   dependencies:


### PR DESCRIPTION
Github Issue (if applicable): #1422 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
Force the fonts to be white when when we're setting a blue background, update target-goal-warning to actually update the inspector and select the proper elements.
