### PR TITLE
Remove legacy toolkit report classes, add currency to react-reports

### DIFF
--- a/src/extension/features/general/privacy-mode/index.css
+++ b/src/extension/features/general/privacy-mode/index.css
@@ -1,65 +1,47 @@
-.toolkit-privacyMode .currency,
-.toolkit-privacyMode .button-prefs-user,
-
-.toolkit-privacyMode .reports-inspector .currency,
-
-.toolkit-privacyMode .ynabtk-category-entry-amount,
-.toolkit-privacyMode .ynabtk-payee-entry-amount,
-.toolkit-privacyMode .ynabtk-tbody .col-data,
-.toolkit-privacyMode .net-income .ynabtk-header-row .col-data,
-.toolkit-privacyMode .ynabtk-footer-row .col-data {
+.toolkit-privacyMode .currency,          /* global .currency handler */
+.toolkit-privacyMode .button-prefs-user  /* user e-mail */
+{
   filter: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg"><filter id="filter"><feGaussianBlur stdDeviation="3" /></filter></svg>#filter');
   -webkit-filter: blur(10px);
   filter: blur(10px);
 }
 
-.toolkit-privacyMode .button-prefs-user:hover,
-.toolkit-privacyMode *:hover > .currency,
-.toolkit-privacyMode *:hover > * > .currency,
-.toolkit-privacyMode .currency:hover,
-
-.toolkit-privacyMode .c3-tooltip-container .currency,
-
-.toolkit-privacyMode .ynabtk-category-entry:hover .ynabtk-category-entry-amount,
-.toolkit-privacyMode .ynabtk-payee-entry:hover .ynabtk-payee-entry-amount,
-.toolkit-privacyMode .ynabtk-tbody .col-data:hover,
-.toolkit-privacyMode .net-income .ynabtk-header-row .col-data:hover,
-.toolkit-privacyMode .ynabtk-footer-row .col-data:hover {
+.toolkit-privacyMode *:hover > .currency,            /* global .currency handler */
+.toolkit-privacyMode *:hover > * > .currency,        /* global .currency handler */
+.toolkit-privacyMode .currency:hover,                /* global .currency handler */
+.toolkit-privacyMode .button-prefs-user:hover,       /* user e-mail */
+.toolkit-privacyMode .c3-tooltip-container .currency /* ynab report tooltips */
+{
   -webkit-filter: initial;
   filter: initial;
 }
 
-/* YNAB Reports: Spending */
+/* YNAB Reports don't use .currency class so we gotta do special stuff for those. */
 .toolkit-privacyMode .c3-chart-arcs .c3-chart-arcs-title tspan:last-child,
 .toolkit-privacyMode .c3-axis-y text tspan {
-    fill: #ffffff !important;
-    color: #ffffff !important;
+  fill: #ffffff !important;
+  color: #ffffff !important;
 }
+
 .toolkit-privacyMode .c3-chart-arcs .c3-chart-arcs-title:hover tspan:last-child,
 .toolkit-privacyMode .c3-axis-y:hover text tspan {
-    color: #0d233a !important;
-    fill: #0d233a !important;
+  color: #0d233a !important;
+  fill: #0d233a !important;
 }
 
-/* Toolkit Reports: Net Worth */
-.toolkit-privacyMode .highcharts-yaxis-labels text tspan {
-    fill: #ffffff !important;
-    color: #ffffff !important;
-}
-.toolkit-privacyMode .highcharts-yaxis-labels:hover text tspan {
-    fill: #606060 !important;
-    color: #606060 !important;
-}
-
-/* Toolkit Reports: Spending by category, payee */
-.toolkit-privacyMode .highcharts-title tspan:last-child,
-.toolkit-privacyMode .highcharts-data-labels text tspan:last-child {
-    fill: #ffffff !important;
-    color: #ffffff !important;
+/* Higcharts doesn't seem to like `filters` so we need to special stuff for those too */
+.toolkit-privacyMode .highcharts-yaxis-labels text tspan,          /* net-worth */
+.toolkit-privacyMode .highcharts-title tspan:last-child,           /* spending */
+.toolkit-privacyMode .highcharts-data-labels text tspan:last-child /* spending */
+{
+  fill: #ffffff !important;
+  color: #ffffff !important;
 }
 
-.toolkit-privacyMode .highcharts-title:hover tspan:last-child,
-.toolkit-privacyMode .highcharts-data-labels text:hover tspan:last-child {
-    color: #0d233a !important;
-    fill: #0d233a !important;
+.toolkit-privacyMode .highcharts-yaxis-labels:hover text tspan,          /* net-worth */
+.toolkit-privacyMode .highcharts-title:hover tspan:last-child,           /* spending */
+.toolkit-privacyMode .highcharts-data-labels text:hover tspan:last-child /* spending */
+{
+  fill: #606060 !important;
+  color: #606060 !important;
 }

--- a/src/extension/features/toolkit-reports/common/components/currency/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/currency/component.jsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { formatCurrency } from 'toolkit/extension/utils/currency';
+
+export const Currency = (props) => (
+  <span className="currency">{formatCurrency(props.value)}</span>
+);
+
+Currency.propTypes = {
+  value: PropTypes.number.isRequired
+};

--- a/src/extension/features/toolkit-reports/common/components/currency/index.js
+++ b/src/extension/features/toolkit-reports/common/components/currency/index.js
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/extension/features/toolkit-reports/common/components/series-legend/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/series-legend/component.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { formatCurrency } from 'toolkit/extension/utils/currency';
+import { Currency } from 'toolkit-reports/common/components/currency';
 import './styles.scss';
 
 export const SeriesLegendComponent = (props) => {
@@ -12,7 +12,9 @@ export const SeriesLegendComponent = (props) => {
   const totalSummary = (
     <div className="tk-flex tk-flex-column tk-justify-content tk-align-items-center tk-border-b tk-pd-b-1">
       <div>Total {props.tableName}</div>
-      <div className="tk-series-legend__summary-total">{formatCurrency(seriesTotal)}</div>
+      <div className="tk-series-legend__summary-total">
+        <Currency value={seriesTotal} />
+      </div>
       <div>For this time period.</div>
     </div>
   );
@@ -20,7 +22,9 @@ export const SeriesLegendComponent = (props) => {
   const averageSummary = (
     <div className="tk-flex tk-flex-column tk-justify-content tk-align-items-center tk-border-b tk-pd-y-1">
       <div>Average {props.tableName}</div>
-      <div className="tk-series-legend__summary-total">{formatCurrency(seriesTotal / totalMonths)}</div>
+      <div className="tk-series-legend__summary-total">
+        <Currency value={seriesTotal / totalMonths} />
+      </div>
       <div>Per month.</div>
     </div>
   );
@@ -40,7 +44,9 @@ export const SeriesLegendComponent = (props) => {
               <div className="tk-series-legend__legend-icon tk-mg-r-05" style={{ backgroundColor: seriesData.color }} />
               <div>{seriesData.name}</div>
             </div>
-            <div>{formatCurrency(seriesData.y)}</div>
+            <div>
+              <Currency value={seriesData.y} />
+            </div>
           </div>
         ))}
       </div>

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-totals-row/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-totals-row/component.jsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import classnames from 'classnames';
 import * as PropTypes from 'prop-types';
-import { formatCurrency } from 'toolkit/extension/utils/currency';
+import * as React from 'react';
 import { localizedMonthAndYear } from 'toolkit/extension/utils/date';
 import { MonthStyle } from 'toolkit/extension/utils/toolkit';
-import classnames from 'classnames';
+import { Currency } from 'toolkit-reports/common/components/currency';
 import './styles.scss';
 
 export const MonthlyTotalsRow = (props) => {
@@ -27,15 +27,17 @@ export const MonthlyTotalsRow = (props) => {
 
             return (
               <div key={monthData.get('date').toISOString()} className={className}>
-                {props.titles ? localizedMonthAndYear(monthData.get('date'), MonthStyle.Short) : formatCurrency(monthData.get('total'))}
+                {props.titles
+                  ? localizedMonthAndYear(monthData.get('date'), MonthStyle.Short)
+                  : <Currency value={monthData.get('total')} />}
               </div>
             );
           })}
           <div key="average" className={allMonthsClassName}>
-            {props.titles ? 'Average' : formatCurrency(allMonthsTotal / props.monthlyTotals.length)}
+            {props.titles ? 'Average' : <Currency value={allMonthsTotal / props.monthlyTotals.length} />}
           </div>
           <div key="total" className={allMonthsClassName}>
-            {props.titles ? 'Total' : formatCurrency(allMonthsTotal)}
+            {props.titles ? 'Total' : <Currency value={allMonthsTotal} />}
           </div>
         </React.Fragment>
       )}

--- a/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { formatCurrency } from 'toolkit/extension/utils/currency';
+import { Currency } from 'toolkit-reports/common/components/currency';
 import './styles.scss';
 
 export const Legend = (props) => ((
@@ -10,21 +10,21 @@ export const Legend = (props) => ((
         <div className="tk-net-worth-legend__icon-debts"></div>
         <div className="tk-mg-l-05">Debts</div>
       </div>
-      <div>{formatCurrency(props.debts)}</div>
+      <div><Currency value={props.debts} /></div>
     </div>
     <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-net-worth-legend__icon-assets"></div>
         <div className="tk-mg-l-05">Assets</div>
       </div>
-      <div>{formatCurrency(props.assets)}</div>
+      <div><Currency value={props.assets} /></div>
     </div>
     <div className="tk-mg-05 tk-pd-r-1">
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-net-worth-legend__icon-net-worths"></div>
         <div className="tk-mg-l-05">Net Worth</div>
       </div>
-      <div>{formatCurrency(props.netWorth)}</div>
+      <div><Currency value={props.netWorth} /></div>
     </div>
   </React.Fragment>
 ));

--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -194,7 +194,7 @@ export class SpendingByCategoryComponent extends React.Component {
           dataLabels: {
             formatter: function () {
               let formattedNumber = formatCurrency(this.y);
-              return `${this.point.name}<br>${formattedNumber} (${Math.round(this.percentage)}%)`;
+              return `${this.point.name}<br><span class="currency">${formattedNumber} (${Math.round(this.percentage)}%)</span>`;
             }
           }
         }
@@ -205,7 +205,7 @@ export class SpendingByCategoryComponent extends React.Component {
       title: {
         align: 'center',
         verticalAlign: 'middle',
-        text: `Total Spending<br>${formatCurrency(totalSpending)}`
+        text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>`
       },
       series: [{
         name: 'Total Spending',

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -164,7 +164,7 @@ export class SpendingByPayeeComponent extends React.Component {
           dataLabels: {
             formatter: function () {
               let formattedNumber = formatCurrency(this.y);
-              return `${this.point.name}<br>${formattedNumber} (${Math.round(this.percentage)}%)`;
+              return `${this.point.name}<br><span class="currency">${formattedNumber} (${Math.round(this.percentage)}%)</span>`;
             }
           }
         }
@@ -175,7 +175,7 @@ export class SpendingByPayeeComponent extends React.Component {
       title: {
         align: 'center',
         verticalAlign: 'middle',
-        text: `Total Spending<br>${formatCurrency(totalSpending)}`
+        text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>`
       },
       series: [{
         name: 'Total Spending',


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
The new react reports weren't using the `currency` class which powers `privacy-mode`, added that, removed the legacy toolkit report classes from `privacy-mode` and commented what each thing is for.
