### PR TITLE
Namespace keys with the currently active budget

### DIFF
--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -169,11 +169,12 @@ export class NetWorthComponent extends React.Component {
     }
 
     // make sure we have a label for any months which have empty data
+    const { fromDate, toDate } = this.props.filters.dateFilter;
     if (transactions.length) {
       let currentIndex = 0;
       const transactionMonth = transactions[0].get('date').clone().startOfMonth();
-      const lastTransactionMonth = transactions[transactions.length - 1].get('date').clone().startOfMonth();
-      while (transactionMonth.isBefore(lastTransactionMonth)) {
+      const lastFilterMonth = toDate.clone().addMonths(1).startOfMonth();
+      while (transactionMonth.isBefore(lastFilterMonth)) {
         if (!allReportData.labels.includes(localizedMonthAndYear(transactionMonth))) {
           const { assets, debts, netWorths, labels } = allReportData;
           labels.splice(currentIndex, 0, localizedMonthAndYear(transactionMonth));
@@ -189,12 +190,11 @@ export class NetWorthComponent extends React.Component {
 
     // Net Worth is calculated from the start of time so we need to handle "filters" here
     // rather than using `filteredTransactions` from context.
-    const { fromDate, toDate } = this.props.filters.dateFilter;
     const { labels, assets, debts, netWorths } = allReportData;
     let startIndex = labels.findIndex((label) => label === localizedMonthAndYear(fromDate));
     startIndex = startIndex === -1 ? 0 : startIndex;
-    let endIndex = labels.findIndex((label) => label === localizedMonthAndYear(toDate)) + 1;
-    endIndex = endIndex === -1 ? labels.length - 1 : endIndex;
+    let endIndex = labels.findIndex((label) => label === localizedMonthAndYear(toDate));
+    endIndex = endIndex === -1 ? (labels.length + 1) : (endIndex + 1);
 
     const filteredLabels = labels.slice(startIndex, endIndex);
     const filteredDebts = debts.slice(startIndex, endIndex);

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/index.js
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/index.js
@@ -1,2 +1,1 @@
 export * from './container';
-export { getStoredAccountFilters } from './component';

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/category-filter/index.js
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/category-filter/index.js
@@ -1,2 +1,1 @@
 export * from './container';
-export { getStoredCategoryFilters } from './component';

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/index.js
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/index.js
@@ -1,2 +1,1 @@
 export * from './container';
-export { getStoredDateFilters } from './component';

--- a/src/extension/features/toolkit-reports/utils/storage.js
+++ b/src/extension/features/toolkit-reports/utils/storage.js
@@ -1,9 +1,12 @@
 import { getFirstMonthOfBudget, getToday } from 'toolkit/extension/utils/date';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
 
-const ACCOUNT_FILTERS_PREFIX = 'account-filters';
-const CATEGORY_FILTERS_PREFIX = 'category-filters';
-const DATE_FILTERS_PREFIX = 'date-filters';
+const FilterType = {
+  Account: 'account-filters',
+  Category: 'category-filters',
+  Date: 'date-filters'
+};
 
 export function getStoredFilters(reportKey) {
   return {
@@ -13,26 +16,38 @@ export function getStoredFilters(reportKey) {
   };
 }
 
-export function getStoredAccountFilters(reportKey) {
-  const accountFilterIds = getToolkitStorageKey(`${ACCOUNT_FILTERS_PREFIX}-${reportKey}`, []);
-  return new Set(accountFilterIds);
-}
-
 export function storeAccountFilters(reportKey, accountFilterIds) {
-  setToolkitStorageKey(`${ACCOUNT_FILTERS_PREFIX}-${reportKey}`, Array.from(accountFilterIds));
-}
-
-export function getStoredCategoryFilters(reportKey) {
-  const categoryFilterIds = getToolkitStorageKey(`${CATEGORY_FILTERS_PREFIX}-${reportKey}`, []);
-  return new Set(categoryFilterIds);
+  setToolkitStorageKey(generateStorageKey(reportKey, FilterType.Account), Array.from(accountFilterIds));
 }
 
 export function storeCategoryFilters(reportKey, categoryFilterIds) {
-  setToolkitStorageKey(`${CATEGORY_FILTERS_PREFIX}-${reportKey}`, Array.from(categoryFilterIds));
+  setToolkitStorageKey(generateStorageKey(reportKey, FilterType.Category), Array.from(categoryFilterIds));
 }
 
-export function getStoredDateFilters(reportKey) {
-  const stored = getToolkitStorageKey(`${DATE_FILTERS_PREFIX}-${reportKey}`, { fromDate: null, toDate: null });
+export function storeDateFilters(reportKey, filters) {
+  setToolkitStorageKey(generateStorageKey(reportKey, FilterType.Date), {
+    fromDate: filters.fromDate ? filters.fromDate.toISOString() : null,
+    toDate: filters.toDate ? filters.toDate.toISOString() : null
+  });
+}
+
+function generateStorageKey(reportKey, filterType) {
+  const budgetVersionId = controllerLookup('application').get('budgetVersionId');
+  return `${budgetVersionId}-${reportKey}-${filterType}`;
+}
+
+function getStoredAccountFilters(reportKey) {
+  const accountFilterIds = getToolkitStorageKey(generateStorageKey(reportKey, FilterType.Account), []);
+  return new Set(accountFilterIds);
+}
+
+function getStoredCategoryFilters(reportKey) {
+  const categoryFilterIds = getToolkitStorageKey(generateStorageKey(reportKey, FilterType.Category), []);
+  return new Set(categoryFilterIds);
+}
+
+function getStoredDateFilters(reportKey) {
+  const stored = getToolkitStorageKey(generateStorageKey(reportKey, FilterType.Date), { fromDate: null, toDate: null });
 
   let fromDate = getFirstMonthOfBudget();
   let toDate = getToday();
@@ -44,9 +59,3 @@ export function getStoredDateFilters(reportKey) {
   return { fromDate, toDate };
 }
 
-export function storeDateFilters(reportKey, filters) {
-  setToolkitStorageKey(`${DATE_FILTERS_PREFIX}-${reportKey}`, {
-    fromDate: filters.fromDate ? filters.fromDate.toISOString() : null,
-    toDate: filters.toDate ? filters.toDate.toISOString() : null
-  });
-}


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
Each budget will have different date ranges, make sure not to use a different budget's filters when looking at reports. Also fixed a bug where we weren't showing months in net worth all the way up to the `toDate` (should just be `===` the previous month until we get to the latest month)
