### PR TITLE
Fixed an issue causing "Total Monthly Goals" to show a number so large it turned into scientific notation.

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -29,8 +29,10 @@ export class DisplayTotalMonthlyGoals extends Feature {
       }
     }
 
+    // if the user edits a goal amount, it's turned into a string on the `subCategory`
+    // object. just convert everything into a number just in case.
     return {
-      monthlyGoalAmount,
+      monthlyGoalAmount: parseInt(monthlyGoalAmount, 10),
       isChecked: viewData.get('isChecked')
     };
   }


### PR DESCRIPTION
Github Issue (if applicable): #1435

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
If a user edits their goal amount it gets stored on the underlying
object as a string causing the calculation to become a string itself.
Account for this by just always `parseInt`ing the goal amount.
