### PR TITLE
Fixed an issue where "Unhighlight Positive Inflows" hid the new budget page icons added by YNAB.

### DIFF
--- a/src/extension/features/budget/remove-positive-highlight/index.css
+++ b/src/extension/features/budget/remove-positive-highlight/index.css
@@ -1,39 +1,134 @@
-.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) > .budget-table-cell-available .positive,
-.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked.goal-progress > .budget-table-cell-available .positive {
-	background-color: transparent;
-	color: #16a336;
-	font-weight: bold;
+/* default positive color overrides */
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .inspector-overview-available .positive,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .inspector-overview-available .positive,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .positive,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .positive {
+  background-color: transparent;
+  color: var(--tk-color-positive);
+  font-weight: bold;
 }
 
-.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) > .budget-table-cell-available .positive:hover,
-.budget-inspector:not([data-toolkit-goal-underfunded]) .inspector-overview-available .positive {
-	background-color: transparent;
-	color: #138b2e;
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .inspector-overview-available .positive .icon-goal .inner,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .inspector-overview-available .positive .icon-goal .inner,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .positive .icon-goal .inner,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .positive .icon-goal .inner {
+  fill: var(--tk-color-positive);
 }
 
-.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) > .budget-table-cell-available .zero {
-	background-color: transparent;
-	color: #cfd5d8;
-	font-weight: normal;
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .inspector-overview-available .positive .icon-goal .outer,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .inspector-overview-available .positive .icon-goal .outer,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .positive .icon-goal .outer,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .positive .icon-goal .outer {
+  stroke: var(--tk-color-positive);
 }
 
-.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked.goal-progress > .budget-table-cell-available .positive {
-	color: #16a336;
-	font-weight: bold;
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .inspector-overview-available .zero,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .inspector-overview-available .zero,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .zero,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .zero {
+  background-color: transparent;
+  color: var(--tk-color-gray);
+  font-weight: bold;
 }
 
-.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked > .budget-table-cell-available .positive span,
-.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked > .budget-table-cell-available .zero span {
-	color: #fff;
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .inspector-overview-available .zero .icon-goal .inner,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .inspector-overview-available .zero .icon-goal .inner,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .zero .icon-goal .inner,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .zero .icon-goal .inner {
+  fill: var(--tk-color-gray);
 }
 
-/* play well with check-credit-balances feature */
-.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-debt-payment-category[data-toolkit-pif-assist] .ynab-new-budget-available-number {
-  color: #fff !important;
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .inspector-overview-available .zero .icon-goal .outer,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .inspector-overview-available .zero .icon-goal .outer,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .zero .icon-goal .outer,
+.budget-inspector:not([data-toolkit-goal-underfunded]) .budget-table-cell-available .zero .icon-goal .outer {
+  stroke: var(--tk-color-gray);
 }
-.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-debt-payment-category[data-toolkit-pif-assist] .ynab-new-budget-available-number:hover {
-  color: #fff !important;
+
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .positive,
+.budget-inspector:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .positive,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .zero,
+.budget-inspector:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .zero {
+  color: var(--tk-color-white);
 }
-.budget-inspector[data-toolkit-pif-assist]:not([data-toolkit-goal-underfunded]) .ynab-new-budget-available-number {
-  color: #fff !important;
+
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .positive .icon-goal .inner,
+.budget-inspector:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .positive .icon-goal .inner,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .zero .icon-goal .inner,
+.budget-inspector:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .zero .icon-goal .inner {
+  fill: var(--tk-color-white);
 }
+
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .positive .icon-goal .outer,
+.budget-inspector:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .positive .icon-goal .outer,
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .zero .icon-goal .outer,
+.budget-inspector:not([data-toolkit-goal-underfunded]).is-checked .budget-table-cell-available .zero .icon-goal .outer {
+  stroke: var(--tk-color-white);
+}
+
+.budget-inspector[data-toolkit-pif-assist] .ynab-new-budget-available-number .currency,
+.budget-table-row.is-sub-category.is-debt-payment-category[data-toolkit-pif-assist] .ynab-new-budget-available-number .currency {
+  color: var(--tk-color-white);
+}
+
+/* Above CSS generated from the following SASS
+**
+** using: https://www.cssportal.com/scss-to-css/
+**
+.budget-table-row.is-sub-category:not([data-toolkit-goal-underfunded]),
+.budget-inspector:not([data-toolkit-goal-underfunded]) {
+  .inspector-overview-available .positive,
+  .budget-table-cell-available .positive {
+    background-color: transparent;
+    color: var(--tk-color-positive);
+    font-weight: bold;
+
+    .icon-goal .inner {
+      fill: var(--tk-color-positive);
+    }
+
+    .icon-goal .outer {
+      stroke: var(--tk-color-positive);
+    }
+  }
+
+  .inspector-overview-available .zero,
+  .budget-table-cell-available .zero {
+    background-color: transparent;
+    color: var(--tk-color-gray);
+    font-weight: bold;
+
+    .icon-goal .inner {
+      fill: var(--tk-color-gray);
+    }
+
+    .icon-goal .outer {
+      stroke: var(--tk-color-gray);
+    }
+  }
+
+  &.is-checked {
+    .budget-table-cell-available .positive,
+    .budget-table-cell-available .zero {
+      color: var(--tk-color-white);
+
+      .icon-goal .inner {
+        fill: var(--tk-color-white);
+      }
+
+      .icon-goal .outer {
+        stroke: var(--tk-color-white);
+      }
+    }
+  }
+}
+
+.budget-inspector[data-toolkit-pif-assist],
+.budget-table-row.is-sub-category.is-debt-payment-category[data-toolkit-pif-assist] {
+  .ynab-new-budget-available-number .currency {
+    color: var(--tk-color-white);
+  }
+}
+**
+**
+**/

--- a/src/extension/features/general/privacy-mode/index.css
+++ b/src/extension/features/general/privacy-mode/index.css
@@ -1,65 +1,47 @@
-.toolkit-privacyMode .currency,
-.toolkit-privacyMode .button-prefs-user,
-
-.toolkit-privacyMode .reports-inspector .currency,
-
-.toolkit-privacyMode .ynabtk-category-entry-amount,
-.toolkit-privacyMode .ynabtk-payee-entry-amount,
-.toolkit-privacyMode .ynabtk-tbody .col-data,
-.toolkit-privacyMode .net-income .ynabtk-header-row .col-data,
-.toolkit-privacyMode .ynabtk-footer-row .col-data {
+.toolkit-privacyMode .currency,          /* global .currency handler */
+.toolkit-privacyMode .button-prefs-user  /* user e-mail */
+{
   filter: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg"><filter id="filter"><feGaussianBlur stdDeviation="3" /></filter></svg>#filter');
   -webkit-filter: blur(10px);
   filter: blur(10px);
 }
 
-.toolkit-privacyMode .button-prefs-user:hover,
-.toolkit-privacyMode *:hover > .currency,
-.toolkit-privacyMode *:hover > * > .currency,
-.toolkit-privacyMode .currency:hover,
-
-.toolkit-privacyMode .c3-tooltip-container .currency,
-
-.toolkit-privacyMode .ynabtk-category-entry:hover .ynabtk-category-entry-amount,
-.toolkit-privacyMode .ynabtk-payee-entry:hover .ynabtk-payee-entry-amount,
-.toolkit-privacyMode .ynabtk-tbody .col-data:hover,
-.toolkit-privacyMode .net-income .ynabtk-header-row .col-data:hover,
-.toolkit-privacyMode .ynabtk-footer-row .col-data:hover {
+.toolkit-privacyMode *:hover > .currency,            /* global .currency handler */
+.toolkit-privacyMode *:hover > * > .currency,        /* global .currency handler */
+.toolkit-privacyMode .currency:hover,                /* global .currency handler */
+.toolkit-privacyMode .button-prefs-user:hover,       /* user e-mail */
+.toolkit-privacyMode .c3-tooltip-container .currency /* ynab report tooltips */
+{
   -webkit-filter: initial;
   filter: initial;
 }
 
-/* YNAB Reports: Spending */
+/* YNAB Reports don't use .currency class so we gotta do special stuff for those. */
 .toolkit-privacyMode .c3-chart-arcs .c3-chart-arcs-title tspan:last-child,
 .toolkit-privacyMode .c3-axis-y text tspan {
-    fill: #ffffff !important;
-    color: #ffffff !important;
+  fill: #ffffff !important;
+  color: #ffffff !important;
 }
+
 .toolkit-privacyMode .c3-chart-arcs .c3-chart-arcs-title:hover tspan:last-child,
 .toolkit-privacyMode .c3-axis-y:hover text tspan {
-    color: #0d233a !important;
-    fill: #0d233a !important;
+  color: #0d233a !important;
+  fill: #0d233a !important;
 }
 
-/* Toolkit Reports: Net Worth */
-.toolkit-privacyMode .highcharts-yaxis-labels text tspan {
-    fill: #ffffff !important;
-    color: #ffffff !important;
-}
-.toolkit-privacyMode .highcharts-yaxis-labels:hover text tspan {
-    fill: #606060 !important;
-    color: #606060 !important;
-}
-
-/* Toolkit Reports: Spending by category, payee */
-.toolkit-privacyMode .highcharts-title tspan:last-child,
-.toolkit-privacyMode .highcharts-data-labels text tspan:last-child {
-    fill: #ffffff !important;
-    color: #ffffff !important;
+/* Higcharts doesn't seem to like `filters` so we need to special stuff for those too */
+.toolkit-privacyMode .highcharts-yaxis-labels text tspan,          /* net-worth */
+.toolkit-privacyMode .highcharts-title tspan:last-child,           /* spending */
+.toolkit-privacyMode .highcharts-data-labels text tspan:last-child /* spending */
+{
+  fill: #ffffff !important;
+  color: #ffffff !important;
 }
 
-.toolkit-privacyMode .highcharts-title:hover tspan:last-child,
-.toolkit-privacyMode .highcharts-data-labels text:hover tspan:last-child {
-    color: #0d233a !important;
-    fill: #0d233a !important;
+.toolkit-privacyMode .highcharts-yaxis-labels:hover text tspan,          /* net-worth */
+.toolkit-privacyMode .highcharts-title:hover tspan:last-child,           /* spending */
+.toolkit-privacyMode .highcharts-data-labels text:hover tspan:last-child /* spending */
+{
+  fill: #606060 !important;
+  color: #606060 !important;
 }

--- a/src/extension/features/toolkit-reports/common/components/currency/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/currency/component.jsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { formatCurrency } from 'toolkit/extension/utils/currency';
+
+export const Currency = (props) => (
+  <span className="currency">{formatCurrency(props.value)}</span>
+);
+
+Currency.propTypes = {
+  value: PropTypes.number.isRequired
+};

--- a/src/extension/features/toolkit-reports/common/components/currency/index.js
+++ b/src/extension/features/toolkit-reports/common/components/currency/index.js
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/extension/features/toolkit-reports/common/components/series-legend/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/series-legend/component.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { formatCurrency } from 'toolkit/extension/utils/currency';
+import { Currency } from 'toolkit-reports/common/components/currency';
 import './styles.scss';
 
 export const SeriesLegendComponent = (props) => {
@@ -12,7 +12,9 @@ export const SeriesLegendComponent = (props) => {
   const totalSummary = (
     <div className="tk-flex tk-flex-column tk-justify-content tk-align-items-center tk-border-b tk-pd-b-1">
       <div>Total {props.tableName}</div>
-      <div className="tk-series-legend__summary-total">{formatCurrency(seriesTotal)}</div>
+      <div className="tk-series-legend__summary-total">
+        <Currency value={seriesTotal} />
+      </div>
       <div>For this time period.</div>
     </div>
   );
@@ -20,7 +22,9 @@ export const SeriesLegendComponent = (props) => {
   const averageSummary = (
     <div className="tk-flex tk-flex-column tk-justify-content tk-align-items-center tk-border-b tk-pd-y-1">
       <div>Average {props.tableName}</div>
-      <div className="tk-series-legend__summary-total">{formatCurrency(seriesTotal / totalMonths)}</div>
+      <div className="tk-series-legend__summary-total">
+        <Currency value={seriesTotal / totalMonths} />
+      </div>
       <div>Per month.</div>
     </div>
   );
@@ -40,7 +44,9 @@ export const SeriesLegendComponent = (props) => {
               <div className="tk-series-legend__legend-icon tk-mg-r-05" style={{ backgroundColor: seriesData.color }} />
               <div>{seriesData.name}</div>
             </div>
-            <div>{formatCurrency(seriesData.y)}</div>
+            <div>
+              <Currency value={seriesData.y} />
+            </div>
           </div>
         ))}
       </div>

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-totals-row/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-totals-row/component.jsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import classnames from 'classnames';
 import * as PropTypes from 'prop-types';
-import { formatCurrency } from 'toolkit/extension/utils/currency';
+import * as React from 'react';
 import { localizedMonthAndYear } from 'toolkit/extension/utils/date';
 import { MonthStyle } from 'toolkit/extension/utils/toolkit';
-import classnames from 'classnames';
+import { Currency } from 'toolkit-reports/common/components/currency';
 import './styles.scss';
 
 export const MonthlyTotalsRow = (props) => {
@@ -27,15 +27,17 @@ export const MonthlyTotalsRow = (props) => {
 
             return (
               <div key={monthData.get('date').toISOString()} className={className}>
-                {props.titles ? localizedMonthAndYear(monthData.get('date'), MonthStyle.Short) : formatCurrency(monthData.get('total'))}
+                {props.titles
+                  ? localizedMonthAndYear(monthData.get('date'), MonthStyle.Short)
+                  : <Currency value={monthData.get('total')} />}
               </div>
             );
           })}
           <div key="average" className={allMonthsClassName}>
-            {props.titles ? 'Average' : formatCurrency(allMonthsTotal / props.monthlyTotals.length)}
+            {props.titles ? 'Average' : <Currency value={allMonthsTotal / props.monthlyTotals.length} />}
           </div>
           <div key="total" className={allMonthsClassName}>
-            {props.titles ? 'Total' : formatCurrency(allMonthsTotal)}
+            {props.titles ? 'Total' : <Currency value={allMonthsTotal} />}
           </div>
         </React.Fragment>
       )}

--- a/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { formatCurrency } from 'toolkit/extension/utils/currency';
+import { Currency } from 'toolkit-reports/common/components/currency';
 import './styles.scss';
 
 export const Legend = (props) => ((
@@ -10,21 +10,21 @@ export const Legend = (props) => ((
         <div className="tk-net-worth-legend__icon-debts"></div>
         <div className="tk-mg-l-05">Debts</div>
       </div>
-      <div>{formatCurrency(props.debts)}</div>
+      <div><Currency value={props.debts} /></div>
     </div>
     <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-net-worth-legend__icon-assets"></div>
         <div className="tk-mg-l-05">Assets</div>
       </div>
-      <div>{formatCurrency(props.assets)}</div>
+      <div><Currency value={props.assets} /></div>
     </div>
     <div className="tk-mg-05 tk-pd-r-1">
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-net-worth-legend__icon-net-worths"></div>
         <div className="tk-mg-l-05">Net Worth</div>
       </div>
-      <div>{formatCurrency(props.netWorth)}</div>
+      <div><Currency value={props.netWorth} /></div>
     </div>
   </React.Fragment>
 ));

--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -194,7 +194,7 @@ export class SpendingByCategoryComponent extends React.Component {
           dataLabels: {
             formatter: function () {
               let formattedNumber = formatCurrency(this.y);
-              return `${this.point.name}<br>${formattedNumber} (${Math.round(this.percentage)}%)`;
+              return `${this.point.name}<br><span class="currency">${formattedNumber} (${Math.round(this.percentage)}%)</span>`;
             }
           }
         }
@@ -205,7 +205,7 @@ export class SpendingByCategoryComponent extends React.Component {
       title: {
         align: 'center',
         verticalAlign: 'middle',
-        text: `Total Spending<br>${formatCurrency(totalSpending)}`
+        text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>`
       },
       series: [{
         name: 'Total Spending',

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -164,7 +164,7 @@ export class SpendingByPayeeComponent extends React.Component {
           dataLabels: {
             formatter: function () {
               let formattedNumber = formatCurrency(this.y);
-              return `${this.point.name}<br>${formattedNumber} (${Math.round(this.percentage)}%)`;
+              return `${this.point.name}<br><span class="currency">${formattedNumber} (${Math.round(this.percentage)}%)</span>`;
             }
           }
         }
@@ -175,7 +175,7 @@ export class SpendingByPayeeComponent extends React.Component {
       title: {
         align: 'center',
         verticalAlign: 'middle',
-        text: `Total Spending<br>${formatCurrency(totalSpending)}`
+        text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>`
       },
       series: [{
         name: 'Total Spending',

--- a/src/extension/ynab-toolkit.css
+++ b/src/extension/ynab-toolkit.css
@@ -1,3 +1,12 @@
+/* global reusable colors */
+:root {
+  --tk-color-black: #000000;
+  --tk-color-gray: #cfd5d8;
+  --tk-color-positive: #16a336;
+  --tk-color-positive--hover: #138b2e;
+  --tk-color-white: #ffffff;
+}
+
 .accounts-toolbar {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
Github Issue (if applicable): #1387

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
The hope was to rewrite this using SASS but unfortunately, SASS injects
styles into the bundle which means we can't be smart about when we load
it, it's always loaded. There may be things we can do in the future
to make it so features can use SASS but until then, I'll just commit the
compiled css.
