### PR TITLE
Fixed an issue where account grid headers were misaligned after collapsing the sidebar.

### DIFF
--- a/src/extension/features/general/collapse-side-menu/index.js
+++ b/src/extension/features/general/collapse-side-menu/index.js
@@ -64,6 +64,9 @@ export class CollapseSideMenu extends Feature {
         $('.ynabtk-collapse-link span').addClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-icon').removeClass('left-circle-4').addClass('right-circle-4');
         this.getHideElements().hide();
+        Ember.run.next(() => {
+          window.dispatchEvent(new Event('resize'));
+        });
       });
     } else {
       Promise.all([
@@ -76,6 +79,9 @@ export class CollapseSideMenu extends Feature {
         $('.ynabtk-collapse-link span').removeClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-icon').removeClass('right-circle-4').addClass('left-circle-4');
         this.getHideElements().show();
+        Ember.run.next(() => {
+          window.dispatchEvent(new Event('resize'));
+        });
       });
     }
   }

--- a/src/extension/features/general/resize-sidebar/index.js
+++ b/src/extension/features/general/resize-sidebar/index.js
@@ -49,6 +49,9 @@ export class ResizeSidebar extends Feature {
 
   onMouseUp(event) {
     this.toggleResize(false, event);
+    Ember.run.next(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
   }
 
   toggleResize(isMouseDown, event) {


### PR DESCRIPTION
Github Issue (if applicable): #1335 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
YNAB seems to have event listeners on resize for the account grid
which we should invoke after changing the size of the visible area.
