### PR TITLE
Feature: Edit Multiple Flags at Once

### DIFF
--- a/src/extension/features/accounts/set-multiple-flags/index.css
+++ b/src/extension/features/accounts/set-multiple-flags/index.css
@@ -1,0 +1,8 @@
+.tk-multi-flags__icon {
+  margin: 0 .5em;
+}
+
+.tk-multi-flags__button {
+  display: flex;
+  align-items: center;
+}

--- a/src/extension/features/accounts/set-multiple-flags/index.js
+++ b/src/extension/features/accounts/set-multiple-flags/index.js
@@ -1,0 +1,115 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { getToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+import { isCurrentRouteAccountsPage, getEntityManager } from 'toolkit/extension/utils/ynab';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
+
+const FLAG_COLORS = ['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Purple'];
+
+export class SetMultipleFlags extends Feature {
+  get _checkedRows() {
+    return controllerLookup('accounts').get('areChecked');
+  }
+
+  get _isAnyCheckedTransactionFlagged() {
+    return this._checkedRows.some((transaction) => transaction.get('flag'));
+  }
+
+  injectCSS() { return require('./index.css'); }
+
+  shouldInvoke() { return isCurrentRouteAccountsPage(); }
+
+  invoke() {
+    const $editModal = $('.modal-account-edit-transaction-list');
+    if (!$editModal.length) {
+      return;
+    }
+
+
+    this._injectButtons($editModal);
+  }
+
+  observe(changedNodes) {
+    if (changedNodes.has('ynab-u modal-popup modal-account-edit-transaction-list ember-view modal-overlay active')) {
+      this.invoke();
+    }
+  }
+
+  _closeModal() {
+    controllerLookup('application').send('closeModal');
+  }
+
+  _injectButtons($editModal) {
+    if (!$('#tk-add-flags', $editModal).length) {
+      $('hr', $editModal).first().parent().after($(`
+        <li id="tk-add-flags">
+          <button class="button-list tk-multi-flags__button">
+            <svg class="ynab-flag ynab-flag-header tk-multi-flags__icon">
+              <g>
+                <path d="M 0,4 16,4 12,9 16,14 0,14 z"></path>
+              </g>
+            </svg>
+            Set Flag${this._checkedRows.length > 1 ? 's' : ''}
+          </button>
+        </li>
+      `).click(this._handleAddFlags));
+    }
+
+    if (!$('#tk-remove-flags', $editModal).length) {
+      $('#tk-add-flags', $editModal).after($(`
+        <li id="tk-remove-flags">
+          <button class="button-list tk-multi-flags__button ${!this._isAnyCheckedTransactionFlagged ? 'button-disabled' : ''}">
+            <svg class="ynab-flag ynab-flag-none tk-multi-flags__icon">
+              <g>
+                <path d="M 0,4 16,4 12,9 16,14 0,14 z"></path>
+              </g>
+            </svg>
+            Remove Flag${this._checkedRows.length > 1 ? 's' : ''}
+          </button>
+        </li>
+      `).click(this._handleRemoveFlags));
+    }
+
+    if (!$('#tk-separator', $editModal).length) {
+      $('#tk-remove-flags', $editModal).after($('<li id="tk-separator"><hr></li>'));
+    }
+  }
+
+  _handleAddFlags = () => {
+    const customColorNames = getToolkitStorageKey('flags');
+
+    $('.modal-account-edit-transaction-list').removeClass('modal-account-edit-transaction-list').addClass('modal-account-flags');
+    const $modalList = $('.modal-list').empty();
+    FLAG_COLORS.forEach((color) => {
+      let colorDisplayName = color;
+      if (ynabToolKit.options.CustomFlagNames) {
+        colorDisplayName = customColorNames[color.toLowerCase()].label;
+      }
+
+      $modalList.append($('<li>')
+        .append($('<button>', { class: `ynab-flag-${color.toLowerCase()}` })
+          .click(() => this._applyColor(color))
+          .append($('<div>', { class: 'label-bg', text: colorDisplayName }))
+          .append($('<div>', { class: 'label', text: colorDisplayName }))));
+    });
+  }
+
+  _handleRemoveFlags = () => {
+    if (!this._isAnyCheckedTransactionFlagged) {
+      return this._closeModal();
+    }
+
+    this._applyColor('');
+  }
+
+  _applyColor = (color) => {
+    const { transactionsCollection } = getEntityManager();
+    getEntityManager().batchChangeProperties(() => {
+      this._checkedRows.forEach((transaction) => {
+        const entity = transactionsCollection.findItemByEntityId(transaction.get('entityId'));
+        entity.set('flag', color);
+      });
+    });
+
+    this._closeModal();
+  }
+}

--- a/src/extension/features/accounts/set-multiple-flags/settings.js
+++ b/src/extension/features/accounts/set-multiple-flags/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'SetMultipleFlags',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Edit Multiple Flags at Once',
+  description: 'Adds a button to the edit dialog which allows you to set the flag. If multiple transactions are selected, all transactions are updated.'
+};


### PR DESCRIPTION
Trello Link (if applicable): https://trello.com/c/2oR6QFRH

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
This one has been wanted for a while and it was pretty straight forward so I just went ahead and added it! Simply adds two buttons to the transaction edit modal to add/remove flags. If multiple transactions were selected, it updates all of them.
