### PR TITLE
Ensure we get data back from Collection.find methods

### DIFF
--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -17,14 +17,19 @@ export class DaysOfBuffering extends Feature {
 
   invoke() {
     const eligibleTransactions = getEntityManager().getAllTransactions().filter(this._eligibleTransactionFilter);
-    const onBudgetBalance = Collections.accountsCollection.getOnBudgetAccounts().reduce((reduced, current) => {
-      const calculation = current.getAccountCalculation();
-      if (calculation && !calculation.getAccountIsTombstone()) {
-        reduced += calculation.getBalance();
-      }
+    const onBudgetAccounts = Collections.accountsCollection.getOnBudgetAccounts();
 
-      return reduced;
-    }, 0);
+    let onBudgetBalance = 0;
+    if (onBudgetAccounts) {
+      onBudgetBalance = onBudgetAccounts.reduce((reduced, current) => {
+        const calculation = current.getAccountCalculation();
+        if (calculation && !calculation.getAccountIsTombstone()) {
+          reduced += calculation.getBalance();
+        }
+
+        return reduced;
+      }, 0);
+    }
 
     const calculation = this._calculateDaysOfBuffering(onBudgetBalance, eligibleTransactions);
     this._updateDisplay(calculation);

--- a/src/extension/features/budget/income-from-last-month/index.js
+++ b/src/extension/features/budget/income-from-last-month/index.js
@@ -35,7 +35,7 @@ export class IncomeFromLastMonth extends Feature {
           const subTransactionSubCategory = subTransaction.get('subCategory');
           const subTransactionAmount = subTransaction.get('amount');
 
-          if (!transactionSubCategory) {
+          if (!subTransactionSubCategory) {
             return;
           }
 

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.jsx
@@ -5,6 +5,8 @@ import { LabeledCheckbox } from 'toolkit-reports/common/components/labeled-check
 import './styles.scss';
 
 export class AccountFilterComponent extends React.Component {
+  _accountsCollection = Collections.accountsCollection;
+
   static propTypes = {
     accountFilterIds: PropTypes.any.isRequired,
     activeReportKey: PropTypes.string.isRequired,
@@ -17,11 +19,13 @@ export class AccountFilterComponent extends React.Component {
   }
 
   get onBudgetAccounts() {
-    return Collections.accountsCollection.getOnBudgetAccounts().toArray();
+    const onBudgetAccounts = this._accountsCollection.getOnBudgetAccounts();
+    return onBudgetAccounts ? onBudgetAccounts.toArray() : [];
   }
 
   get offBudgetAccounts() {
-    return Collections.accountsCollection.getOffBudgetAccounts().toArray();
+    const offBudgetAccounts = this._accountsCollection.getOffBudgetAccounts();
+    return offBudgetAccounts ? offBudgetAccounts.toArray() : [];
   }
 
   render() {


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
Basically anywhere we were doing `find*` against a collection, we have a chance of getting `null` back so this PR adds checks to make sure we got something we can work with and does the right thing if we didn't.
