### PR TITLE
Don't calculate running balance if accountId is null (all accounts)

### DIFF
--- a/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
@@ -156,7 +156,11 @@ function calculateRunningBalance(accountId) {
   if (!accountController.__tkSortFieldsListener) {
     accountController.addObserver('sortFields', function (controller) {
       accountController.__tkSortFieldsListener = true;
-      calculateRunningBalance(controller.get('filters.entityId'));
+
+      const observedAccountId = controller.get('filters.entityId');
+      if (observedAccountId) {
+        calculateRunningBalance(observedAccountId);
+      }
     });
   }
 


### PR DESCRIPTION
Github Issue (if applicable): #1462 #1463

#### Explanation of Bugfix/Feature/Modification:
Wasn't checking for a `null` accountId meaning "on All Accounts" in our new listener for sortField changes.
