### PR TITLE
Add required fields for Edge extensions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,4 +1,5 @@
 {
+  "author": "Toolkit for YNAB",
   "name": "Toolkit for YNAB",
   "description": "UI customizations and tweaks for the web version of YNAB.",
   "version": "2.9.3",
@@ -27,7 +28,8 @@
     "web-accessibles/*"
   ],
   "background": {
-    "page": "background/index.html"
+    "page": "background/index.html",
+    "persistent": true
   },
   "homepage_url": "https://github.com/toolkit-for-ynab/toolkit-for-ynab/",
   "options_ui": {


### PR DESCRIPTION
Trello Link (if applicable): https://trello.com/c/jWbRRYMG

#### Explanation of Bugfix/Feature/Modification:
Looks like the only thing needed were some new required manifest fields (I tried this back when we first added web-extensions and it definitely wasn't that easy before but I'll take it!)
