### PR TITLE
Fixed: You can now filter closed accounts from Toolkit Reports.

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
@@ -13,7 +13,8 @@ export const SelectedReportContextPropType = {
   key: PropTypes.string.isRequired,
   filterSettings: PropTypes.shape({
     disableCategoryFilter: PropTypes.bool,
-    disableTrackingAccounts: PropTypes.bool
+    disableTrackingAccounts: PropTypes.bool,
+    includeTrackingAccounts: PropTypes.bool
   })
 };
 
@@ -32,25 +33,29 @@ const REPORT_COMPONENTS = [{
   component: NetWorth,
   key: ReportKeys.NetWorth,
   filterSettings: {
-    disableCategoryFilter: true
+    disableCategoryFilter: true,
+    includeTrackingAccounts: true
   }
 }, {
   component: SpendingByPayee,
   key: ReportKeys.SpendingByPayee,
   filterSettings: {
-    disableTrackingAccounts: true
+    disableTrackingAccounts: true,
+    includeTrackingAccounts: false
   }
 }, {
   component: SpendingByCategory,
   key: ReportKeys.SpendingByCategory,
   filterSettings: {
-    disableTrackingAccounts: true
+    disableTrackingAccounts: true,
+    includeTrackingAccounts: false
   }
 }, {
   component: IncomeVsExpense,
   key: ReportKeys.IncomeVsExpense,
   filterSettings: {
-    disableTrackingAccounts: true
+    disableTrackingAccounts: true,
+    includeTrackingAccounts: false
   }
 }];
 

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.jsx
@@ -55,6 +55,7 @@ export class ReportFiltersComponent extends React.Component {
   _showAccountFilterModal = () => {
     this.props.showAccountFilterModal({
       accountFilterIds: this.props.filters.accountFilterIds,
+      includeTrackingAccounts: this.props.selectedReport.filterSettings.includeTrackingAccounts,
       onCancel: this.props.closeModal,
       onSave: this._handleAccountsChanged
     });


### PR DESCRIPTION

<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1470

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
On-budget, closed accounts should still show up in our accounts filter
but off-budget accounts should only ever show up for net worth. Made
it so.
