### PR TITLE
Fixed an issue causing the background of master category rows to have no highlight while progress bars were enabled.

### DIFF
--- a/src/extension/features/budget/budget-progress-bars/index.css
+++ b/src/extension/features/budget/budget-progress-bars/index.css
@@ -1,13 +1,10 @@
 :root {
-  /* General color definitions */
-  /* ReSharper disable Redundant, used implicitly in js code */
   --tk-color-progress-bar-goal: rgba(22, 163, 54, 0.3);
   --tk-color-progress-bar-goal-spacing: rgba(0, 0, 0, 0);
   --tk-color-progress-bar-pacing: rgb(192, 226, 233);
   --tk-color-progress-bar-pacing-month-progress-indicator: rgb(207, 213, 216);
   --tk-color-progress-bar-pacing-spacing: rgba(0, 0, 0, 0);
-  --tk-color-progress-bar-pacing-master-spacing: rgba(0, 0, 0, 0);
-  /* ReSharper restore Redundant */
+  --tk-color-progress-bar-pacing-master-spacing: rgb(229, 245, 249);
 }
 
 /* Fix position of head monthly progress indicator by moving the bg slightly to the right and making it shorter. Also move the text back */


### PR DESCRIPTION
Github Issue (if applicable): #1474 #1460

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
We want to progress the month-progress indicator through the master
category rows but master categories don't have any sort of actual progress
to track so keep the background color the constant default throughout.
