### PR TITLE
Fixed an issue causing available amounts with Target Balance Goals to un-highlight as soon as you achieve your target.

### DIFF
--- a/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.js
+++ b/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.js
@@ -25,7 +25,7 @@ export class DisplayTargetGoalAmount extends Feature {
     const userSetting = this.settings.enabled;
     const budgetRows = [...document.getElementsByClassName('budget-table-row')];
     budgetRows.forEach((element) => {
-      const { category } = getEmberView(element.id);
+      const category = getEmberView(element.id, 'category');
       if (!category) {
         return;
       }

--- a/src/extension/features/budget/budget-category-features/index.js
+++ b/src/extension/features/budget/budget-category-features/index.js
@@ -32,7 +32,7 @@ export class BudgetCategoryFeatures extends Feature {
 
     const categories = [...document.getElementsByClassName('budget-table-row')];
     categories.forEach((element) => {
-      const { category } = getEmberView(element.id);
+      const category = getEmberView(element.id, 'category');
       if (category) {
         const { isMasterCategory, subCategory } = category.getProperties('isMasterCategory', 'subCategory');
         if (!isMasterCategory && subCategory) {

--- a/src/extension/features/budget/budget-category-features/target-balance-warning/index.js
+++ b/src/extension/features/budget/budget-category-features/target-balance-warning/index.js
@@ -1,5 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
+import { getEmberView } from 'toolkit/extension/utils/ember';
 import { CategoryAttributes } from 'toolkit/extension/features/budget/budget-category-features';
 
 const REMOVE_CLASSES = ['positive', 'zero'];
@@ -16,27 +17,34 @@ export class TargetBalanceWarning extends Feature {
         '.budget-inspector .inspector-overview-available .ynab-new-budget-available-number',
         '.budget-inspector .inspector-overview-available .ynab-new-budget-available-number .currency'
       ].join(',');
-      const rowElements = $('.ynab-new-budget-available-number', element);
+      const availableNumberElement = $('.ynab-new-budget-available-number', element);
+      const originalClass = getEmberView(availableNumberElement.attr('id')).get('currencyClass');
       const inspectorElements = $(inspectorSelectors);
 
       if (element.hasAttribute(`data-${CategoryAttributes.GoalUnderFunded}`)) {
         REMOVE_CLASSES.forEach((className) => {
-          rowElements.removeClass(className);
+          availableNumberElement.removeClass(className);
         });
 
-        rowElements.addClass('cautious');
+        availableNumberElement.addClass('cautious');
       } else {
-        rowElements.removeClass('cautious');
+        availableNumberElement.removeClass('cautious');
+        availableNumberElement.addClass(originalClass);
       }
 
-      if ($(`.budget-inspector[data-${CategoryAttributes.GoalUnderFunded}]`).length) {
-        REMOVE_CLASSES.forEach((className) => {
-          inspectorElements.removeClass(className);
-        });
+      const budgetInspectorView = getEmberView($('.budget-inspector').attr('id'));
+      const activeCategoryId = budgetInspectorView && budgetInspectorView.get('activeCategory.categoryId');
+      if (activeCategoryId && activeCategoryId === element.dataset.entityId) {
+        if ($(`.budget-inspector[data-${CategoryAttributes.GoalUnderFunded}]`).length) {
+          REMOVE_CLASSES.forEach((className) => {
+            inspectorElements.removeClass(className);
+          });
 
-        inspectorElements.addClass('cautious');
-      } else {
-        inspectorElements.removeClass('cautious');
+          inspectorElements.addClass('cautious');
+        } else {
+          inspectorElements.removeClass('cautious');
+          inspectorElements.addClass(originalClass);
+        }
       }
     });
   }

--- a/src/extension/features/budget/budget-category-features/target-balance-warning/index.js
+++ b/src/extension/features/budget/budget-category-features/target-balance-warning/index.js
@@ -18,7 +18,7 @@ export class TargetBalanceWarning extends Feature {
         '.budget-inspector .inspector-overview-available .ynab-new-budget-available-number .currency'
       ].join(',');
       const availableNumberElement = $('.ynab-new-budget-available-number', element);
-      const originalClass = getEmberView(availableNumberElement.attr('id')).get('currencyClass');
+      const originalCurrencyClass = getEmberView(availableNumberElement.attr('id'), 'currencyClass');
       const inspectorElements = $(inspectorSelectors);
 
       if (element.hasAttribute(`data-${CategoryAttributes.GoalUnderFunded}`)) {
@@ -29,11 +29,10 @@ export class TargetBalanceWarning extends Feature {
         availableNumberElement.addClass('cautious');
       } else {
         availableNumberElement.removeClass('cautious');
-        availableNumberElement.addClass(originalClass);
+        availableNumberElement.addClass(originalCurrencyClass);
       }
 
-      const budgetInspectorView = getEmberView($('.budget-inspector').attr('id'));
-      const activeCategoryId = budgetInspectorView && budgetInspectorView.get('activeCategory.categoryId');
+      const activeCategoryId = getEmberView($('.budget-inspector').attr('id'), 'activeCategory.categoryId');
       if (activeCategoryId && activeCategoryId === element.dataset.entityId) {
         if ($(`.budget-inspector[data-${CategoryAttributes.GoalUnderFunded}]`).length) {
           REMOVE_CLASSES.forEach((className) => {
@@ -43,7 +42,7 @@ export class TargetBalanceWarning extends Feature {
           inspectorElements.addClass('cautious');
         } else {
           inspectorElements.removeClass('cautious');
-          inspectorElements.addClass(originalClass);
+          inspectorElements.addClass(originalCurrencyClass);
         }
       }
     });

--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -163,7 +163,7 @@ export class BudgetProgressBars extends Feature {
       }
 
       if ($(element).hasClass('is-sub-category')) {
-        const subCategory = getEmberView(element.id).category;
+        const subCategory = getEmberView(element.id, 'category');
         let subCategoryName = $(element).find('li.budget-table-cell-name>div>div')[0].title.match(/.[^\n]*/);
 
         subCategoryName = masterCategoryName + subCategoryName;

--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -10,11 +10,14 @@ export class DisplayTotalMonthlyGoals extends Feature {
 
   extractCategoryGoalInformation(element) {
     const emberId = element.id;
-    const viewData = getEmberView(emberId).category;
+    const category = getEmberView(emberId, 'category');
+    if (!category) {
+      return;
+    }
 
-    const goalType = viewData.get('subCategory.goalType');
-    const monthlyFunding = viewData.get('subCategory.monthlyFunding');
-    const targetBalanceDate = viewData.get('monthlySubCategoryBudgetCalculation.goalTarget');
+    const goalType = category.get('subCategory.goalType');
+    const monthlyFunding = category.get('subCategory.monthlyFunding');
+    const targetBalanceDate = category.get('monthlySubCategoryBudgetCalculation.goalTarget');
 
     let monthlyGoalAmount = 0;
 
@@ -33,7 +36,7 @@ export class DisplayTotalMonthlyGoals extends Feature {
     // object. just convert everything into a number just in case.
     return {
       monthlyGoalAmount: parseInt(monthlyGoalAmount, 10),
-      isChecked: viewData.get('isChecked')
+      isChecked: category.get('isChecked')
     };
   }
 

--- a/src/extension/features/budget/display-upcoming-amount/index.js
+++ b/src/extension/features/budget/display-upcoming-amount/index.js
@@ -12,7 +12,7 @@ export class DisplayUpcomingAmount extends Feature {
 
   invoke() {
     $('.budget-table-row.is-sub-category').each((_, element) => {
-      const { monthlySubCategoryBudgetCalculation, subCategory } = getEmberView(element.id).category;
+      const { monthlySubCategoryBudgetCalculation, subCategory } = getEmberView(element.id, 'category');
 
       if (monthlySubCategoryBudgetCalculation && monthlySubCategoryBudgetCalculation.upcomingTransactions) {
         $('.budget-table-cell-activity', element)

--- a/src/extension/features/budget/pacing/index.js
+++ b/src/extension/features/budget/pacing/index.js
@@ -34,7 +34,7 @@ export class Pacing extends Feature {
       .not('.is-debt-payment-category')
       .not('.is-master-category')
       .each((index, element) => {
-        const { category } = getEmberView(element.id);
+        const category = getEmberView(element.id, 'category');
         const pacingCalculation = pacingForCategory(category);
 
         const $display = this.generateDisplay(category.get('subCategory.entityId'), pacingCalculation);

--- a/src/extension/features/general/import-notification/index.js
+++ b/src/extension/features/general/import-notification/index.js
@@ -49,7 +49,7 @@ export class ImportNotification extends Feature {
     this.isActive = true;
 
     $('.nav-account-row').each((index, row) => {
-      let account = getEmberView($(row).attr('id')).get('data');
+      let account = getEmberView($(row).attr('id'), 'data');
       let accountSpan = $(row).find('.nav-account-name > .nav-account-name-val > span');
       if (accountSpan.length) {
         // Remove the title attribute and our underline class in case the account no longer has txns to be imported

--- a/src/extension/utils/ember.js
+++ b/src/extension/utils/ember.js
@@ -1,5 +1,10 @@
-export function getEmberView(viewId) {
-  return getViewRegistry()[viewId];
+export function getEmberView(viewId, getterString) {
+  const view = getViewRegistry()[viewId];
+  if (getterString && view) {
+    return view.get(getterString);
+  }
+
+  return view;
 }
 
 export function getRouter() {


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
We were always updating the inspector after a category amount changed
for the target-balance-warning feature but we should only do it if
the balance of the category currently inspected was updated.
