### PR TITLE
Make first column in income vs expense sticky

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-totals-row/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-totals-row/styles.scss
@@ -23,5 +23,8 @@
     padding-top: 0.1rem;
     padding-bottom: 0.1rem;
     padding-right: 0.5rem;
+    position: sticky;
+    left: 0;
+    background: inherit;
   }
 }

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/styles.scss
@@ -4,6 +4,8 @@
   &__child-row,
   &__child-summary-row,
   &__title-row--collapsed {
+    background-color: white;
+
     &:hover {
       background-color: aliceblue;
     }


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
The header column would scroll out of view when looking at later months in the table which is annoying, this makes it so the header is always visible.
