### PR TITLE
Fixed an issue causing a double-render in the "Show Upcoming Transaction Total" feature

### DIFF
--- a/src/extension/features/budget/display-upcoming-amount/index.js
+++ b/src/extension/features/budget/display-upcoming-amount/index.js
@@ -11,6 +11,9 @@ export class DisplayUpcomingAmount extends Feature {
   }
 
   invoke() {
+    $('.toolkit-activity-upcoming').removeClass('.toolkit-activity-upcoming');
+    $('.toolkit-activity-upcoming-amount').remove();
+
     $('.budget-table-row.is-sub-category').each((_, element) => {
       const { monthlySubCategoryBudgetCalculation, subCategory } = getEmberView(element.id, 'category');
 


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue: #1468 

#### Explanation of Bugfix:

I experienced what I think is the same issue as in #1468, though with a different series of convoluted reproduction steps. It turns out it was actually caused by navigating too quickly between months. I'm not sure exactly why, but I think the row element in the DOM only gets cleared if you wait for the month to load before navigating to a different month, so the `invoke()` function was getting called multiple times and prepending a new div to the same `<li>` element over and over. The result looked like this:

![image](https://user-images.githubusercontent.com/1474671/50719338-9beaa480-1068-11e9-88cd-81e38965e228.png)

I fixed this by just clearing out the effect of any previous `invoke()` call on the same DOM elements.