### PR TITLE
Fixed an issue in privacy mode with overlapping icons after the February 7, 2019 release

### DIFF
--- a/src/extension/features/general/privacy-mode/toggle.css
+++ b/src/extension/features/general/privacy-mode/toggle.css
@@ -4,8 +4,8 @@
 
 #toolkit-togglePrivacy {
   color: #bee6ef;
-  top: 2px;
-  right: 2px;
+  top: 12px;
+  right: 32px;
   position: absolute;
   padding: 10px;
 }


### PR DESCRIPTION
[Today's release](https://www.youneedabudget.com/release-notes/#release_59147) changed the menu in the top-left, which partially obscures the toggle button in the privacy mode extension:

![image](https://user-images.githubusercontent.com/1474671/52456343-48b1b900-2b22-11e9-9a94-ba0ac7657e9a.png)

I've moved the icon to the left of the dropdown arrow:

![image](https://user-images.githubusercontent.com/1474671/52456424-aba35000-2b22-11e9-8418-6388d9950a86.png)

I'm not sure this is the best solution (especially because it comes pretty close to an email address, if the address is particularly long), but I figured I'd at least open the PR to bring it to your attention.

The button works in both the current position and the proposed position.