### PR TITLE
Updated Report Menu styling to match YNAB branding

### DIFF
--- a/src/extension/features/toolkit-reports/pages/root/components/report-selector/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-selector/styles.scss
@@ -5,9 +5,14 @@
 
   &__item {
     cursor: pointer;
+    border-radius: 1000px;
+    color: #ffffff;
+    font-size: .9em;
+    padding: .4em 1em;
+    margin-right: 1em;
 
     &--active {
-      color: #fed168;
+      background-color: #16a336;
     }
   }
 }


### PR DESCRIPTION
Updated the report selector menu to match the current YNAB branding.

#### Explanation of ~~Bugfix~~/~~Feature~~/Modification:

The report selector menu along the top of the Toolkit tab looked a little odd so I've updated the styling to make it fit in with the rest of the YNAB app a little better. Not sure if there was a reason it was being kept distinct but I thought I would offer a PR on it.