### PR TITLE
Fixed issues with the Toggle Splits feature to work better with YNAB's new single-split feature. The toggle now works as a "collapse/expand all."

### DIFF
--- a/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
+++ b/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+import { l10n } from 'toolkit/extension/utils/toolkit';
+import { getEmberView } from 'toolkit/extension/utils/ember';
+import { getEntityManager } from 'toolkit/extension/utils/ynab';
+
+export class ToggleSplitButton extends React.Component {
+  static propTypes = {
+    toggleSplits: PropTypes.func.isRequired
+  }
+
+  state = {
+    areAllSplitsExpanded: getToolkitStorageKey('are-all-splits-expanded', true)
+  }
+
+  componentDidMount() {
+    if (this.state.areAllSplitsExpanded) {
+      this.hideAllSplits();
+    }
+  }
+
+  render() {
+    return (
+      <button className="button tk-toggle-splits" onClick={this.toggleSplits}>
+        {this.state.areAllSplitsExpanded && <i className="flaticon stroke down"></i>}
+        {!this.state.areAllSplitsExpanded && <i className="flaticon stroke right"></i>}
+        {l10n('toolkit.toggleSplits', 'Toggle Splits')}
+      </button>
+    );
+  }
+
+  toggleSplits = () => {
+    let newAreAllSplitsExpanded = !this.state.areAllSplitsExpanded;
+    if (newAreAllSplitsExpanded) {
+      this.showAllSplits();
+    } else {
+      this.hideAllSplits();
+    }
+
+    setToolkitStorageKey('are-all-splits-expanded', newAreAllSplitsExpanded);
+    this.setState({ areAllSplitsExpanded: newAreAllSplitsExpanded });
+  }
+
+  hideAllSplits = () => {
+    const collapsedSplitsMap = getEntityManager().transactionsCollection.reduce((reduced, transaction) => {
+      if (transaction.getIsSplit()) {
+        reduced[transaction.get('entityId')] = true;
+      }
+
+      return reduced;
+    }, {});
+
+    getEmberView($('.ynab-grid').attr('id')).set('collapsedSplits', collapsedSplitsMap);
+  }
+
+  showAllSplits = () => {
+    getEmberView($('.ynab-grid').attr('id')).set('collapsedSplits', {});
+  }
+}

--- a/src/extension/features/accounts/toggle-splits/index.js
+++ b/src/extension/features/accounts/toggle-splits/index.js
@@ -1,84 +1,29 @@
+import * as React from 'react';
 import { Feature } from 'toolkit/extension/features/feature';
+import { componentAfter } from 'toolkit/extension/utils/react';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
-import { controllerLookup } from 'toolkit/extension/utils/ember';
-import { l10n } from 'toolkit/extension/utils/toolkit';
-
-function isNotSubTransaction(transaction) {
-  const displayItemType = transaction.get('displayItemType');
-  return displayItemType !== ynab.constants.TransactionDisplayItemType.SubTransaction &&
-          displayItemType !== ynab.constants.TransactionDisplayItemType.ScheduledSubTransaction;
-}
+import { ToggleSplitButton } from './components/toggle-split-button';
 
 export class ToggleSplits extends Feature {
-  expanded = false;
-
-  get idName() {
-    return 'toggle-splits';
-  }
-
   injectCSS() { return require('./index.css'); }
 
   shouldInvoke() {
-    return isCurrentRouteAccountsPage() && !$(`#${this.idName}`).length;
+    return isCurrentRouteAccountsPage();
   }
 
   invoke() {
-    this.accountsController = controllerLookup('accounts');
+    if (document.querySelector('.tk-toggle-splits')) {
+      return;
+    }
 
-    const buttonText = l10n('toolkit.toggleSplits', 'Toggle Splits');
-    this.$button = $('<button>', { id: this.idName, class: 'ember-view button' })
-      .append($('<i>', { class: 'ember-view flaticon stroke right' }).toggle(!this.expanded))
-      .append($('<i>', { class: 'ember-view flaticon stroke down' }).toggle(this.expanded))
-      .append(buttonText)
-      .insertAfter('.accounts-toolbar .undo-redo-container');
+    componentAfter(<ToggleSplitButton />, $('.accounts-toolbar .undo-redo-container')[0]);
 
     $('.accounts-toolbar-left').addClass('toolkit-accounts-toolbar-left');
-
-    this.$button.click(() => this.toggle());
-
-    // Only want to wrap contentResults once
-    if (typeof this.accountsController.get('toolkitShowSubTransactions') === 'undefined') {
-      const ynabContentResults = this.accountsController.contentResults;
-      this.accountsController.reopen({
-        toolkitShowSubTransactions: this.expanded,
-        toolkitShowSubTransactionsChanged: Ember.observer('toolkitShowSubTransactions', function () {
-          Ember.run.debounce(() => {
-            this.notifyPropertyChange('contentResults');
-          }, 25);
-        }),
-        contentResults: Ember.computed(...ynabContentResults._dependentKeys, {
-          get: function () {
-            let contentResults = ynabContentResults._getter.apply(this);
-            if (!this.get('toolkitShowSubTransactions')) {
-              contentResults = contentResults.filter(isNotSubTransaction);
-            }
-            return contentResults;
-          },
-          set: function (_key, val) {
-            return val;
-          }
-        })
-      });
-    }
-
-    // Trigger default state
-    this.accountsController.notifyPropertyChange('contentResults');
-  }
-
-  onserve(changedNodes) {
-    if (changedNodes.has('ynab-grid-body') && this.shouldInvoke()) {
-      this.invoke();
-    }
   }
 
   onRouteChanged() {
     if (this.shouldInvoke()) {
       this.invoke();
     }
-  }
-
-  toggle() {
-    this.accountsController.set('toolkitShowSubTransactions', this.expanded = !this.expanded);
-    $('> i', this.$button).toggle();
   }
 }

--- a/src/extension/features/accounts/toggle-splits/settings.js
+++ b/src/extension/features/accounts/toggle-splits/settings.js
@@ -4,5 +4,5 @@ module.exports = {
   default: false,
   section: 'accounts',
   title: 'Add a Toggle Splits Button to the Account(s) toolbar',
-  description: 'Clicking the Toggle Splits button shows or hides all sub-transactions within all split transactions. *__Note__: you must toggle splits open before editing a split transaction!*'
+  description: 'Clicking the Toggle Splits button shows or hides all sub-transactions within all split transactions.'
 };


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

#### Explanation of Bugfix/Feature/Modification:
Just setting the `collapsedSplits` map on the grid controller to all split transactions or clearing it out based on previous state.
