### PR TITLE
Don't emit the budgetChanged listener until data loads

### DIFF
--- a/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
+++ b/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
@@ -1,15 +1,10 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { getEntityManager } from 'toolkit/extension/utils/ynab';
 
 export class ToggleSplitButton extends React.Component {
-  static propTypes = {
-    toggleSplits: PropTypes.func.isRequired
-  }
-
   state = {
     areAllSplitsExpanded: getToolkitStorageKey('are-all-splits-expanded', true)
   }

--- a/src/extension/listeners/routeChangeListener.js
+++ b/src/extension/listeners/routeChangeListener.js
@@ -1,5 +1,6 @@
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 import { withToolkitError } from 'toolkit/core/common/errors/with-toolkit-error';
+import { getEntityManager } from 'toolkit/extension/utils/ynab';
 
 let instance = null;
 
@@ -22,7 +23,11 @@ export class RouteChangeListener {
         (controller, changedProperty) => {
           if (changedProperty === 'budgetVersionId') {
             (function poll() {
-              if (controller.get('budgetVersionId') === controller.get('budgetViewModel.budgetVersionId')) {
+              const applicationBudgetVersion = controllerLookup('application').get('budgetVersionId');
+              const { activeBudgetVersion } = getEntityManager().getSharedLibInstance();
+              const entityManagerBudgetVersion = activeBudgetVersion.entityId;
+
+              if (applicationBudgetVersion === entityManagerBudgetVersion) {
                 Ember.run.scheduleOnce('afterRender', controller, 'emitBudgetRouteChange');
               } else {
                 Ember.run.next(poll, 250);


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #1520

#### Explanation of Bugfix/Feature/Modification:
We were depending on UI related fields which were being updated before data was available. Now we'll depend on the actual data to exist before we say the budget has been switched.
