### PR TITLE
Modification: Add 0% width option to the resize-inspector feature

### DIFF
--- a/src/extension/features/budget/resize-inspector/index.css
+++ b/src/extension/features/budget/resize-inspector/index.css
@@ -10,6 +10,7 @@ section.budget-table-container {
 .budget-inspector {
   min-width: var(--toolkit-inspector-minwidth, inherit) !important;
   width: var(--toolkit-inspector-width, 25%) !important; /* default to our widest width */
+  visibility: var(--toolkit-inspector-visibility);
 }
 
 .toolkit-modal-item-hide-image {

--- a/src/extension/features/budget/resize-inspector/index.js
+++ b/src/extension/features/budget/resize-inspector/index.js
@@ -73,7 +73,14 @@ export class ResizeInspector extends Feature {
                   _this.setProperties($(this).data('inspector-size'));
                 })
                 .append($('<i>', { class: IMAGECLASSES }))
-                .append('15% '))))
+                .append('15% ')))
+            .append($('<li>')
+              .append($('<button>', { 'data-inspector-size': '4', class: 'button-list' })
+                .click(function () {
+                  _this.setProperties($(this).data('inspector-size'));
+                })
+                .append($('<i>', { class: IMAGECLASSES }))
+                .append('0% '))))
           .append($('<div>', { class: 'modal-arrow', style: 'position:absolute;width: 0;height: 0;bottom: 100%;left: 37px;border: solid transparent;border-color: transparent;border-width: 15px;border-bottom-color: #fff' }))));
 
     // Handle dismissal of modal via the ESC key
@@ -114,6 +121,7 @@ export class ResizeInspector extends Feature {
     if ($(ele).length) {
       let contentWidth = '67%';
       let inspectorWidth = '33%';
+      let inspectorVisibility = 'visible';
 
       if (width === 1) {
         contentWidth = '75%';
@@ -124,10 +132,14 @@ export class ResizeInspector extends Feature {
       } else if (width === 3) {
         contentWidth = '85%';
         inspectorWidth = '15%';
+      } else if (width === 4) {
+        contentWidth = '100%';
+        inspectorVisibility = 'hidden';
       }
 
       $(ele)[0].style.setProperty('--toolkit-content-width', contentWidth);
       $('.budget-inspector')[0].style.setProperty('--toolkit-inspector-width', inspectorWidth);
+      $('.budget-inspector')[0].style.setProperty('--toolkit-inspector-visibility', inspectorVisibility);
 
       // Save the users current selection for future page loads.
       setToolkitStorageKey('inspector-width', width);

--- a/src/extension/features/budget/resize-inspector/settings.js
+++ b/src/extension/features/budget/resize-inspector/settings.js
@@ -4,5 +4,5 @@ module.exports = {
   default: false,
   section: 'budget',
   title: 'Allow Resizing of Inspector',
-  description: 'Adds a button to the Budget Toolbar that allows resizing the Budget Inspector to predetermined widths of 33% (YNAB default), 25%, 20% or 15%. Note that smaller values maybe not be suitable on small screens.'
+  description: 'Adds a button to the Budget Toolbar that allows resizing the Budget Inspector to predetermined widths of 33% (YNAB default), 25%, 20%, 15%, or 0%. Note that smaller values maybe not be suitable on small screens.'
 };


### PR DESCRIPTION
Github Issue (if applicable): #1511

#### Explanation of Bugfix/Feature/Modification: 

Adds a 0% width option to the resize-inspector feature in order to completely hide the inspector as requested in #1511. 

Alternatively, instead of modifying resize-inspector, we could add a new "Toggle Inspector" feature that handles visibility separately from width. But that felt redundant to me and this was much quicker to do. :) But I defer to the project owners! Lemme know if that would be a better approach and I'll close this and take a whack at it. 

Also: hello! 👋 This is my first contribution. I'm a big fan of YNAB and found the toolkit extension recently. It's awesome and I look forward to helping out. 

