### PR TITLE
Add a divider after the budget quick switch list

### DIFF
--- a/src/extension/features/general/budget-quick-switch/index.js
+++ b/src/extension/features/general/budget-quick-switch/index.js
@@ -12,9 +12,14 @@ export class BudgetQuickSwitch extends Feature {
     ynab.YNABSharedLib.getCatalogViewModel_UserViewModel().then(({ userBudgetDisplayItems }) => {
       userBudgetDisplayItems.filter((budget) => {
         return !budget.get('isTombstone') && budget.get('budgetVersionId') !== activeBudgetVersionId;
-      }).forEach((budget) => {
+      }).forEach((budget, i) => {
         const budgetVersionName = budget.get('budgetVersionName');
         const budgetVersionId = budget.get('budgetVersionId');
+
+        if (i === 0) {
+          componentPrepend((<li><hr /></li>), modalList);
+        }
+
         componentPrepend((
           <BudgetListItem
             key={budget.get('budgetVersionId')}


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:

Tiny UI change that adds a divider between the budget quick switch list and the rest of the items in the account modal list.  Trivial, but it's nicer on the eyes! :D 

#### Before:
<img width="244" alt="screenshot_3_2_19__9_24_am" src="https://user-images.githubusercontent.com/1299305/53683286-f1d87300-3ccc-11e9-807f-22bb796c8597.png">

#### After: 
<img width="240" alt="screenshot_3_2_19__9_25_am" src="https://user-images.githubusercontent.com/1299305/53683294-16cce600-3ccd-11e9-8cda-10223e820c60.png">


