### PR TITLE
Feature: Link to Inflows

### DIFF
--- a/src/extension/features/budget/link-to-inflows/index.css
+++ b/src/extension/features/budget/link-to-inflows/index.css
@@ -1,0 +1,4 @@
+.toolkit-total-inflows:hover {
+    cursor: pointer;
+    text-decoration: underline;
+}

--- a/src/extension/features/budget/link-to-inflows/index.js
+++ b/src/extension/features/budget/link-to-inflows/index.js
@@ -4,14 +4,13 @@ import { l10n } from 'toolkit/extension/utils/toolkit';
 import {
   getSelectedMonth,
   isCurrentRouteBudgetPage,
-  transitionTo,
+  transitionTo
 } from 'toolkit/extension/utils/ynab';
 
 /**
  * Adds a click handler to the "TOTAL INFLOW" inspector area.
  */
 export class LinkToInflows extends Feature {
-
   injectCSS() {
     return require('./index.css');
   }

--- a/src/extension/features/budget/link-to-inflows/index.js
+++ b/src/extension/features/budget/link-to-inflows/index.js
@@ -30,11 +30,17 @@ export class LinkToInflows extends Feature {
    * Add the wrapper element to the TOTAL INFLOWS inspector area.
    */
   invoke() {
-    $('.budget-inspector')
-      .find(`h3:contains("${l10n('inspector.totalIncome', 'TOTAL INFLOWS')}")`)
-      .next()
-      .andSelf()
-      .wrapAll('<span class="toolkit-total-inflows" />');
+    const budgetInspector = $('.budget-inspector');
+
+    // Attempt to target the english string, `TOTAL INFLOWS`, but if that's not
+    // found, try the localized version of the string.
+    const englishHeading = 'TOTAL INFLOWS';
+    const localizedHeading = l10n('inspector.totalIncome', englishHeading);
+    const inflowsHeadingEl =
+      budgetInspector.find(`h3:contains(${englishHeading})`)[0] ||
+      budgetInspector.find(`h3:contains(${localizedHeading})`)[0];
+
+    $(inflowsHeadingEl).next().andSelf().wrapAll('<span class="toolkit-total-inflows" />');
 
     $('.toolkit-total-inflows').click(this.onClick);
   }
@@ -51,10 +57,7 @@ export class LinkToInflows extends Feature {
       controller.filters.resetFilters();
     }
 
-    controller.set(
-      'searchText',
-      `${l10n('search.income', 'Income')}: ${month.format('MMMM YYYY')}`
-    );
+    controller.set('searchText', `Income: ${month.format('MMMM YYYY')}`);
     transitionTo('accounts');
   }
 }

--- a/src/extension/features/budget/link-to-inflows/index.js
+++ b/src/extension/features/budget/link-to-inflows/index.js
@@ -1,0 +1,58 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
+import {
+  getSelectedMonth,
+  isCurrentRouteBudgetPage,
+  transitionTo,
+} from 'toolkit/extension/utils/ynab';
+
+/**
+ * Adds a click handler to the "TOTAL INFLOW" inspector area.
+ */
+export class LinkToInflows extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteBudgetPage();
+  }
+
+  onRouteChanged() {
+    if (this.shouldInvoke()) {
+      this.invoke();
+    }
+  }
+
+  /**
+   * Add the wrapper element to the TOTAL INFLOWS inspector area.
+   */
+  invoke() {
+    $('.budget-inspector')
+      .find(`h3:contains("${Ember.I18n.t('inspector.totalIncome')}")`)
+      .next()
+      .andSelf()
+      .wrapAll('<span class="toolkit-total-inflows" />');
+
+    $('.toolkit-total-inflows').click(this.onClick);
+  }
+
+  /**
+   * Handle the click on TOTAL INFLOWS. Set the search field and navigate
+   * to the accounts route.
+   */
+  onClick() {
+    const month = getSelectedMonth();
+    const controller = controllerLookup('accounts');
+
+    if (controller.filters) {
+      controller.filters.resetFilters();
+    }
+
+    controller.set(
+      'searchText',
+      `${Ember.I18n.t('search.income')}: ${month.format('MMMM YYYY')}`
+    );
+    transitionTo('accounts');
+  }
+
+  injectCSS() {
+    return require('./index.css');
+  }
+}

--- a/src/extension/features/budget/link-to-inflows/index.js
+++ b/src/extension/features/budget/link-to-inflows/index.js
@@ -1,5 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { l10n } from 'toolkit/extension/utils/toolkit';
 import {
   getSelectedMonth,
   isCurrentRouteBudgetPage,
@@ -10,6 +11,11 @@ import {
  * Adds a click handler to the "TOTAL INFLOW" inspector area.
  */
 export class LinkToInflows extends Feature {
+
+  injectCSS() {
+    return require('./index.css');
+  }
+
   shouldInvoke() {
     return isCurrentRouteBudgetPage();
   }
@@ -25,7 +31,7 @@ export class LinkToInflows extends Feature {
    */
   invoke() {
     $('.budget-inspector')
-      .find(`h3:contains("${Ember.I18n.t('inspector.totalIncome')}")`)
+      .find(`h3:contains("${l10n('inspector.totalIncome', 'TOTAL INFLOWS')}")`)
       .next()
       .andSelf()
       .wrapAll('<span class="toolkit-total-inflows" />');
@@ -47,12 +53,8 @@ export class LinkToInflows extends Feature {
 
     controller.set(
       'searchText',
-      `${Ember.I18n.t('search.income')}: ${month.format('MMMM YYYY')}`
+      `${l10n('search.income', 'Income')}: ${month.format('MMMM YYYY')}`
     );
     transitionTo('accounts');
-  }
-
-  injectCSS() {
-    return require('./index.css');
   }
 }

--- a/src/extension/features/budget/link-to-inflows/settings.js
+++ b/src/extension/features/budget/link-to-inflows/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'LinkToInflows',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Link to Inflows',
+  description: 'Clicking on the "Total Inflows" section of the budget inspector will link to the inflow transactions for that month.'
+};

--- a/src/extension/features/budget/resize-inspector/index.js
+++ b/src/extension/features/budget/resize-inspector/index.js
@@ -38,7 +38,6 @@ export class ResizeInspector extends Feature {
         $('.budget-toolbar').append('<div class="toolkit-budget-toolbar-buttons"></div>');
       }
       $('.toolkit-budget-toolbar-buttons').append($button);
-
     }
   }
 


### PR DESCRIPTION
#### Explanation of Feature

This adds a link to the "Total Inflows" section of the budget inspector such that clicking on it will navigate to the inflow transactions for that month. 🎉 

This is my first attempt at a new feature and it involved lots of poking around in the YNAB app code. Please school me if there are better and/or preferred ways to do things! 🙏 

PS - I've been knocking off things on my personal want list for YNAB, but if there are roadmap items I could help out with, please let me know! 
