### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Finally, after properly titling your Pull Request, please fill out the following
 information to provide context to the reviewer and more technical information
 to interested users since this Pull Request will be linked in the release notes.-->
 
-Github Issue (if applicable): #XXX
+GitHub Issue (if applicable): #XXX
 
 Trello Link (if applicable):
 

--- a/src/extension/legacy/features/shared/main.js
+++ b/src/extension/legacy/features/shared/main.js
@@ -28,7 +28,7 @@ ynabToolKit.shared = (function () {
       // beta concatenates the TRAVIS_BUILD_NUMBER so we do this to strip it for
       // the URL that points to diffs on master for beta/development builds
       const githubVersion = version.split('.').slice(0, 3).join('.');
-      const githubIssuesLink = '<a href="https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues" target="_blank">Github Issues</a>';
+      const githubIssuesLink = '<a href="https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues" target="_blank">GitHub Issues</a>';
 
       const releaseNotes = ynabToolKit.environment === 'production'
         ? 'View the <a href="https://github.com/toolkit-for-ynab/toolkit-for-ynab/releases" target="_blank">release notes</a>.'


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

Github Issue (if applicable): #XXX

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:

GitHub is not capitalized as "Github". This fixes it.