### PR TITLE
Feature: Hide Total Available

### DIFF
--- a/src/extension/features/budget/hide-total-available/index.js
+++ b/src/extension/features/budget/hide-total-available/index.js
@@ -1,0 +1,33 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
+import { l10n } from 'toolkit/extension/utils/toolkit';
+
+/**
+ * Hides the "Total Available" section of the budget inspector.
+ */
+export class HideTotalAvailable extends Feature {
+
+  shouldInvoke() {
+    return isCurrentRouteBudgetPage();
+  }
+
+  onRouteChanged() {
+    if (this.shouldInvoke()) {
+      this.invoke();
+    }
+  }
+
+  invoke() {
+    const budgetInspector = $('.budget-inspector');
+
+    // Attempt to target the english string, `TOTAL AVAILABLE`, but if that's not
+    // found, try the localized version of the string.
+    const englishHeading = 'TOTAL AVAILABLE';
+    const localizedHeading = l10n('inspector.totalAvailable', englishHeading);
+    const headingEl =
+      budgetInspector.find(`h3:contains(${englishHeading})`)[0] ||
+      budgetInspector.find(`h3:contains(${localizedHeading})`)[0];
+
+    $(headingEl).nextUntil('h3').andSelf().addClass('hidden');
+  }
+}

--- a/src/extension/features/budget/hide-total-available/index.js
+++ b/src/extension/features/budget/hide-total-available/index.js
@@ -6,7 +6,6 @@ import { l10n } from 'toolkit/extension/utils/toolkit';
  * Hides the "Total Available" section of the budget inspector.
  */
 export class HideTotalAvailable extends Feature {
-
   shouldInvoke() {
     return isCurrentRouteBudgetPage();
   }

--- a/src/extension/features/budget/hide-total-available/settings.js
+++ b/src/extension/features/budget/hide-total-available/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'HideTotalAvailable',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Hide Total Available',
+  description: 'Hides the "Total Available" section in the budget inspector.'
+};

--- a/src/extension/features/budget/resize-inspector/index.js
+++ b/src/extension/features/budget/resize-inspector/index.js
@@ -38,7 +38,6 @@ export class ResizeInspector extends Feature {
         $('.budget-toolbar').append('<div class="toolkit-budget-toolbar-buttons"></div>');
       }
       $('.toolkit-budget-toolbar-buttons').append($button);
-
     }
   }
 


### PR DESCRIPTION
#### Explanation of Feature:

I might be alone in this, but I find the "Total Available" section of the budget inspector super disorienting.  I have a fair bit of cash savings for long term goals in my budget and seeing that amount as "available" throws me off. I've always wanted to hide it. So here we go! 

Hopefully I'm not alone and others will find this useful. 🙏 

