### PR TITLE
Subcategory propertly `targetBalance` renamed to `goalTargetAmount`

### DIFF
--- a/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.js
+++ b/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.js
@@ -52,9 +52,9 @@ export class DisplayTargetGoalAmount extends Feature {
         return;
       }
 
-      const { monthlyFunding, targetBalance } = subCategory.getProperties(
+      const { monthlyFunding, goalTargetAmount } = subCategory.getProperties(
         'monthlyFunding',
-        'targetBalance'
+        'goalTargetAmount'
       );
       const targetBalanceDate = monthlySubCategoryBudgetCalculation.get('goalTarget');
       const budgeted = monthlySubCategoryBudget.get('budgeted');
@@ -71,10 +71,13 @@ export class DisplayTargetGoalAmount extends Feature {
           }
           break;
         case ynab.constants.SubCategoryGoalType.TargetBalance:
-          goalAmount = targetBalance;
-          if (userSetting === Settings.WarnBudgetOverTarget && budgeted > targetBalance) {
+          goalAmount = goalTargetAmount;
+          if (userSetting === Settings.WarnBudgetOverTarget && budgeted > goalTargetAmount) {
             applyEmphasis = true;
-          } else if (userSetting === Settings.GreenBudgetOverTarget && budgeted >= targetBalance) {
+          } else if (
+            userSetting === Settings.GreenBudgetOverTarget &&
+            budgeted >= goalTargetAmount
+          ) {
             applyEmphasis = true;
           }
           break;

--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -59,7 +59,7 @@ export class BudgetProgressBars extends Feature {
       /**
        * Add a few values from the subCat object to the calculation object.
        */
-      calculation.targetBalance = subCat.getTargetBalance();
+      calculation.targetBalance = subCat.getGoalTargetAmount();
       calculation.goalType = subCat.getGoalType();
       calculation.goalCreationMonth = subCat.goalCreationMonth
         ? subCat.goalCreationMonth.toString().substr(0, 7)


### PR DESCRIPTION
GitHub Issue (if applicable): #1558

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
A property name on sub categories got renamed.