### PR TITLE
Fixed the hiding of the "Total Available" entry in the budget inspector

### DIFF
--- a/src/extension/features/budget/hide-total-available/index.js
+++ b/src/extension/features/budget/hide-total-available/index.js
@@ -16,6 +16,14 @@ export class HideTotalAvailable extends Feature {
     }
   }
 
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (changedNodes.has('budget-inspector')) {
+      this.invoke();
+    }
+  }
+
   invoke() {
     const budgetInspector = $('.budget-inspector');
 


### PR DESCRIPTION
The total available amount was readded after deselecting a category. (#1570)
This fix resolves this.

