### PR TITLE
Fix title and amount overlapping in "Income vs Expense" report

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/styles.scss
@@ -1,8 +1,9 @@
 .tk-ive {
   flex: 1;
-  font-size: .85rem;
+  font-size: 0.85rem;
 
   &__net-income {
+    background-color: white;
     border-top: 2px solid #000000;
     border-bottom: 2px solid #000000;
     width: fit-content;
@@ -20,7 +21,7 @@
         }
 
         &--negative {
-          color: #d33c2d
+          color: #d33c2d;
         }
       }
     }


### PR DESCRIPTION
The "Net Income" and amounts would overlap if you scroll sideways

was: 
<img width="390" alt="Screenshot 2019-05-27 at 10 09 26" src="https://user-images.githubusercontent.com/10436899/58405398-9d445a00-8067-11e9-9d2a-1b304d08b512.png">
to be:
<img width="351" alt="Screenshot 2019-05-27 at 10 09 50" src="https://user-images.githubusercontent.com/10436899/58405414-a59c9500-8067-11e9-908c-5e7539b3df95.png">

