### PR TITLE
Fixed an issue with "Inspector width" menu not displaying when sidebar is collapsed

### DIFF
--- a/src/extension/features/budget/resize-inspector/index.js
+++ b/src/extension/features/budget/resize-inspector/index.js
@@ -50,7 +50,9 @@ export class ResizeInspector extends Feature {
   showResizeModal() {
     let _this = this;
     let btnLeft =
-      $('.budget-toolbar').outerWidth() + $('#toolkitResizeInspector').outerWidth() + 29;
+      $('.budget-toolbar').outerWidth() +
+      $('.sidebar').outerWidth() -
+      $('#toolkitResizeInspector').outerWidth();
     let btnTop = $('.budget-toolbar').outerHeight() + $('.budget-header-flexbox').outerHeight() + 8;
     let $modal = $('<div>', {
       id: 'toolkitInspectorODiv',


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

GitHub Issue (if applicable): #1589 

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:

This uses the current width of the sidebar to calculate the position (left) of the modal. Currently, when the sidebar is collapsed, the modal appears off screen as the calculation is hard coded and ignores the sidebar width.