### PR TITLE
jQuery deprecated and removed addSelf for addBack

### DIFF
--- a/src/extension/features/budget/hide-total-available/index.js
+++ b/src/extension/features/budget/hide-total-available/index.js
@@ -37,7 +37,7 @@ export class HideTotalAvailable extends Feature {
 
     $(headingEl)
       .nextUntil('h3')
-      .andSelf()
+      .addBack()
       .addClass('hidden');
   }
 }

--- a/src/extension/features/budget/link-to-inflows/index.js
+++ b/src/extension/features/budget/link-to-inflows/index.js
@@ -41,7 +41,7 @@ export class LinkToInflows extends Feature {
 
     $(inflowsHeadingEl)
       .next()
-      .andSelf()
+      .addBack()
       .wrapAll('<span class="toolkit-total-inflows" />');
 
     $('.toolkit-total-inflows').click(this.onClick);


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
I think maybe the version of jQuery in YNAB got updated, this got removed in 3.0 but we just started getting errors.
