### PR TITLE
Bug Fix: Income Breakdown Render Bug With Duplicate Category and Sub-Category Names

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
@@ -195,8 +195,8 @@ export class IncomeBreakdownComponent extends React.Component {
           return;
         }
         subCategorySeries.push({
-          from: masterCategory.get('name'),
-          to: subCatogory.get('name'),
+          from: masterCategory.get('entityId'),
+          to: subCatogory.get('entityId'),
           weight: absAmount,
           outgoing: true,
         });
@@ -209,7 +209,7 @@ export class IncomeBreakdownComponent extends React.Component {
       categorySeries.push({
         masterEntry: {
           from: 'Budget',
-          to: masterCategory.get('name'),
+          to: masterCategory.get('entityId'),
           weight: masterCategoryTotal,
         },
         subEntries: subCategorySeries.sort((a, b) => b.weight - a.weight),
@@ -232,6 +232,32 @@ export class IncomeBreakdownComponent extends React.Component {
     }
 
     return seriesData;
+  }
+
+  _getNodeData() {
+    const { expenses } = this.state;
+
+    let nodeData = [];
+
+    expenses.forEach((subCategoryMap, masterCategory) => {
+      subCategoryMap.forEach((amount, subCatogory) => {
+        const absAmount = Math.abs(amount);
+        if (absAmount <= 0) {
+          return;
+        }
+        nodeData.push({
+          id: subCatogory.get('entityId'),
+          name: subCatogory.get('name'),
+        });
+      });
+
+      nodeData.push({
+        id: masterCategory.get('entityId'),
+        name: masterCategory.get('name'),
+      });
+    });
+
+    return nodeData;
   }
 
   _renderReport = () => {
@@ -283,6 +309,7 @@ export class IncomeBreakdownComponent extends React.Component {
           keys: ['from', 'to', 'weight'],
           data: this._getSeriesData(),
           type: 'sankey',
+          nodes: this._getNodeData(),
         },
       ],
     });

--- a/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
@@ -177,7 +177,7 @@ export class IncomeBreakdownComponent extends React.Component {
       }
       if (showIncome) {
         seriesData.push({
-          from: payee.get('name'),
+          from: payee.get('entityId'),
           to: 'Budget',
           weight: amount,
         });
@@ -235,16 +235,12 @@ export class IncomeBreakdownComponent extends React.Component {
   }
 
   _getNodeData() {
-    const { expenses } = this.state;
+    const { expenses, incomes } = this.state;
 
     let nodeData = [];
 
     expenses.forEach((subCategoryMap, masterCategory) => {
-      subCategoryMap.forEach((amount, subCatogory) => {
-        const absAmount = Math.abs(amount);
-        if (absAmount <= 0) {
-          return;
-        }
+      subCategoryMap.forEach((_amount, subCatogory) => {
         nodeData.push({
           id: subCatogory.get('entityId'),
           name: subCatogory.get('name'),
@@ -254,6 +250,13 @@ export class IncomeBreakdownComponent extends React.Component {
       nodeData.push({
         id: masterCategory.get('entityId'),
         name: masterCategory.get('name'),
+      });
+    });
+
+    incomes.forEach((_amount, payee) => {
+      nodeData.push({
+        id: payee.get('entityId'),
+        name: payee.get('name'),
       });
     });
 


### PR DESCRIPTION
<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

GitHub Issue (if applicable): #1599

Trello Link (if applicable): N/A

Forum Link (if applicable): N/A

#### Explanation of Bugfix/Feature/Modification:

Use `entityId` as the `to` and `from` keys in the Income Breakdown `sankey` Income Breakdown graph in combination with the `nodes` option to make the graph rendering independent of the names of categories. 

This allows the graph to work as expected even when a category and sub-category have the same name.

Test Budget with "Test" master category and "Test" sub category.

**Before:**
<img width="500" alt="Screen Shot 2019-07-05 at 1 00 05 PM" src="https://user-images.githubusercontent.com/2810519/60743442-79a5e680-9f26-11e9-9a93-ac3a2678451b.png">

**After:**
<img width="500" alt="Screen Shot 2019-07-05 at 1 05 13 PM" src="https://user-images.githubusercontent.com/2810519/60743450-87f40280-9f26-11e9-8120-2f3741e82945.png">