### PR TITLE
Fixed an issue with "Hide Total Available" hiding other things when switching months 

### DIFF
--- a/src/extension/features/budget/hide-total-available/index.js
+++ b/src/extension/features/budget/hide-total-available/index.js
@@ -35,6 +35,10 @@ export class HideTotalAvailable extends Feature {
       budgetInspector.find(`h3:contains(${englishHeading})`)[0] ||
       budgetInspector.find(`h3:contains(${localizedHeading})`)[0];
 
+    if ($(headingEl).hasClass('hidden')) {
+      return;
+    }
+
     $(headingEl)
       .nextUntil('h3')
       .addBack()


### PR DESCRIPTION
GitHub Issue (if applicable): n/a

Trello Link (if applicable): n/a

Forum Link (if applicable): n/a

#### Explanation of Bugfix/Feature/Modification:
There's currently a bug (my bug! 🙀) in the "Hide Total Available" feature where other things would be hidden in the budget inspector after you change budget months. This is because the "Total Available" heading is _already_ hidden when we go to apply the hidden class name. 

So this just returns early if the heading is already hidden. 👍  
