### PR TITLE
{Fix} Make Transaction modal show again

### DIFF
--- a/src/extension/features/toolkit-reports/utils/show-transaction-modal.js
+++ b/src/extension/features/toolkit-reports/utils/show-transaction-modal.js
@@ -2,7 +2,7 @@ import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 export function showTransactionModal(title, transactions) {
   const applicationController = controllerLookup('application');
-  const reportsController = controllerLookup('reports');
+  const reportsController = controllerLookup('reports/spending');
   reportsController.set('modalTitle', title);
   reportsController.set('modalTransactions', transactions);
   applicationController.send('openModal', 'modals/reports/transactions', {


### PR DESCRIPTION
The transactions modal was no longer working from the reports.
It was even making YNAB crash
Fixes #1606 
