### PR TITLE
Added system fonts option

### DIFF
--- a/src/extension/features/general/google-fonts-selector/index.js
+++ b/src/extension/features/general/google-fonts-selector/index.js
@@ -12,6 +12,8 @@ export class GoogleFontsSelector extends Feature {
       return require('./droid-sans.css');
     } else if (this.settings.enabled === '5') {
       return require('./inconsolata.css');
+    } else if (this.settings.enabled === '6') {
+      return require('./system-ui.css');
     }
   }
 }

--- a/src/extension/features/general/google-fonts-selector/settings.js
+++ b/src/extension/features/general/google-fonts-selector/settings.js
@@ -4,7 +4,7 @@ module.exports = {
   default: '0',
   section: 'general',
   title: 'Interface Font',
-  description: 'Select a font from the Google Fonts library.',
+  description: 'Select a font from the Google Fonts library or choose to use your system font.',
   options: [
     { name: 'Default', value: '0' },
     { name: 'Open Sans', value: '1' },
@@ -12,5 +12,6 @@ module.exports = {
     { name: 'Roboto Condensed', value: '3' },
     { name: 'Droid Sans', value: '4' },
     { name: 'Inconsolata', value: '5' },
+    { name: 'System font', value: '6' },
   ],
 };

--- a/src/extension/features/general/google-fonts-selector/system-ui.css
+++ b/src/extension/features/general/google-fonts-selector/system-ui.css
@@ -1,0 +1,109 @@
+@import url('https://fonts.googleapis.com/css?family=Roboto:400,700,400italic');
+@import url('./shared.css');
+
+.ember-view {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.nav-account-block .nav-account-name-button {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.budget-header-calendar .budget-header-calendar-date-button {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.budget-inspector-button {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.budget-inspector-goals .link-button {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.inspector-category-edit {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+  top: 3px;
+  font-size: 1em;
+}
+
+.nav-account-block .nav-account-name-button {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.budget-content ul,
+.budget-table-row.is-dragging {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.modal-popup .modal-actions .button {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.modal-generic .modal-actions .button {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.modal-generic .modal-header {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.modal-popup .modal-content {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.modal-account-filters .modal-header {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.modal-account-filters .date-range-dates li.active button,
+.modal-account-filters .date-range-dates li:hover button {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.modal-popup ul.modal-list button {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.modal-account-approve-reject.modal-account-dropdown .modal,
+.modal-account-match-transaction.modal-account-dropdown .modal {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.edit-direct-connect-toggle {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+.account-modal .modal-content dt,
+.account-modal .modal-content dd {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+/* if reports stuff is enabled */
+.reports-inspector-detail {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif;
+}
+
+#reports-header {
+  font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Noto Sans', 'Ubuntu', 'Cantarell',
+    sans-serif !important;
+}


### PR DESCRIPTION
GitHub Issue (if applicable): #1595

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:

Adds the `system-ui` font stack, including a fallback for older browsers (credits for that to the PostCSS system-ui-font-family plugin)