### PR TITLE
Fixed an issue where the "Compact Income vs Expense Report" feature would disable the sticky first-column in the native YNAB Reports.

### DIFF
--- a/src/extension/features/reports/compact-income-vs-expense/index.js
+++ b/src/extension/features/reports/compact-income-vs-expense/index.js
@@ -40,7 +40,8 @@ export class CompactIncomeVsExpense extends Feature {
             $(
               '.income-expense-level2 .income-expense-row .income-expense-column:first-child'
             ).outerWidth() || 200,
-          left: e.scrollLeft - parseFloat($('.reports-content').css('padding-left') || 0),
+          left:
+            e.currentTarget.scrollLeft - parseFloat($('.reports-content').css('padding-left') || 0),
           borderRight: '1px solid #dfe4e9',
         });
         $('.income-expense-h1 .income-expense-first-column').css('borderRight', 'none');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const BUILD_ROOT = './dist';
 const BUILD_PATH = `${BUILD_ROOT}/extension`;
 const CODE_SOURCE_DIR = './src';
 
-module.exports = function (env) {
+module.exports = function(env) {
   const validBuildTypes = ['beta', 'development', 'production'];
   if (!env || !validBuildTypes.includes(env.buildType)) {
     console.log(`Invalid --env.buildType provided. Must be one of: [${validBuildTypes.join('|')}]`);
@@ -18,46 +18,53 @@ module.exports = function (env) {
       'background/background': path.resolve(`${CODE_SOURCE_DIR}/core/browser/background/index.js`),
       'options/options': path.resolve(`${CODE_SOURCE_DIR}/core/browser/options/options.js`),
       'popup/popup': path.resolve(`${CODE_SOURCE_DIR}/core/browser/popup/index.js`),
-      'content-scripts/init': path.resolve(`${CODE_SOURCE_DIR}/core/browser/content-scripts/init.js`),
-      'web-accessibles/ynab-toolkit': path.resolve(`${CODE_SOURCE_DIR}/extension/index.js`)
+      'content-scripts/init': path.resolve(
+        `${CODE_SOURCE_DIR}/core/browser/content-scripts/init.js`
+      ),
+      'web-accessibles/ynab-toolkit': path.resolve(`${CODE_SOURCE_DIR}/extension/index.js`),
     },
 
-    devtool: 'source-map',
+    devtool: 'inline-source-map',
 
     output: {
       path: path.join(__dirname, BUILD_PATH),
-      filename: '[name].js'
+      filename: '[name].js',
     },
 
     resolve: {
       alias: {
         toolkit: path.resolve(__dirname, CODE_SOURCE_DIR),
-        'toolkit-reports': path.resolve(__dirname, path.join(CODE_SOURCE_DIR, 'extension', 'features', 'toolkit-reports'))
+        'toolkit-reports': path.resolve(
+          __dirname,
+          path.join(CODE_SOURCE_DIR, 'extension', 'features', 'toolkit-reports')
+        ),
       },
       extensions: ['.js', '.jsx'],
-      modules: ['node_modules']
+      modules: ['node_modules'],
     },
 
     module: {
-      rules: [{
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        include: [
-          path.resolve(__dirname, CODE_SOURCE_DIR)
-        ],
-        use: [{
-          loader: 'babel-loader'
-        }]
-      }, {
-        test: /\.css$/,
-        include: [
-          path.resolve(__dirname, CODE_SOURCE_DIR)
-        ],
-        use: ['to-string-loader', 'css-loader']
-      }, {
-        test: /\.scss$/,
-        use: ['style-loader', 'css-loader', 'sass-loader']
-      }]
+      rules: [
+        {
+          test: /\.jsx?$/,
+          exclude: /node_modules/,
+          include: [path.resolve(__dirname, CODE_SOURCE_DIR)],
+          use: [
+            {
+              loader: 'babel-loader',
+            },
+          ],
+        },
+        {
+          test: /\.css$/,
+          include: [path.resolve(__dirname, CODE_SOURCE_DIR)],
+          use: ['to-string-loader', 'css-loader'],
+        },
+        {
+          test: /\.scss$/,
+          use: ['style-loader', 'css-loader', 'sass-loader'],
+        },
+      ],
     },
 
     plugins: [
@@ -65,22 +72,47 @@ module.exports = function (env) {
       new CopyWebpackPlugin([
         {
           from: path.join(__dirname, `${CODE_SOURCE_DIR}/assets/common`),
-          to: path.join(__dirname, `${BUILD_PATH}/assets`)
+          to: path.join(__dirname, `${BUILD_PATH}/assets`),
         },
         {
           from: path.join(__dirname, `${CODE_SOURCE_DIR}/assets/environment/${env.buildType}`),
-          to: path.join(__dirname, `${BUILD_PATH}/assets`)
+          to: path.join(__dirname, `${BUILD_PATH}/assets`),
         },
-        { from: path.join(__dirname, `${CODE_SOURCE_DIR}/manifest.json`), to: path.join(__dirname, `${BUILD_PATH}`) },
-        { from: path.join(__dirname, `${CODE_SOURCE_DIR}/core/browser/background`), to: path.join(__dirname, `${BUILD_PATH}/background`), ignore: '**/*.js' },
-        { from: path.join(__dirname, `${CODE_SOURCE_DIR}/core/browser/options`), to: path.join(__dirname, `${BUILD_PATH}/options`), ignore: '**/*.js' },
-        { from: path.join(__dirname, `${CODE_SOURCE_DIR}/core/browser/popup`), to: path.join(__dirname, `${BUILD_PATH}/popup`), ignore: '**/*.js' },
-        { from: path.join(__dirname, `${CODE_SOURCE_DIR}/extension/legacy/**/*.css`), to: path.join(__dirname, `${BUILD_PATH}/web-accessibles`), context: 'src/extension' },
-        { from: path.join(__dirname, `${CODE_SOURCE_DIR}/extension/legacy/features/l10n/locales/*.js`), to: path.join(__dirname, `${BUILD_PATH}/web-accessibles`), context: 'src/extension' }
-      ])
-    ]
+        {
+          from: path.join(__dirname, `${CODE_SOURCE_DIR}/manifest.json`),
+          to: path.join(__dirname, `${BUILD_PATH}`),
+        },
+        {
+          from: path.join(__dirname, `${CODE_SOURCE_DIR}/core/browser/background`),
+          to: path.join(__dirname, `${BUILD_PATH}/background`),
+          ignore: '**/*.js',
+        },
+        {
+          from: path.join(__dirname, `${CODE_SOURCE_DIR}/core/browser/options`),
+          to: path.join(__dirname, `${BUILD_PATH}/options`),
+          ignore: '**/*.js',
+        },
+        {
+          from: path.join(__dirname, `${CODE_SOURCE_DIR}/core/browser/popup`),
+          to: path.join(__dirname, `${BUILD_PATH}/popup`),
+          ignore: '**/*.js',
+        },
+        {
+          from: path.join(__dirname, `${CODE_SOURCE_DIR}/extension/legacy/**/*.css`),
+          to: path.join(__dirname, `${BUILD_PATH}/web-accessibles`),
+          context: 'src/extension',
+        },
+        {
+          from: path.join(
+            __dirname,
+            `${CODE_SOURCE_DIR}/extension/legacy/features/l10n/locales/*.js`
+          ),
+          to: path.join(__dirname, `${BUILD_PATH}/web-accessibles`),
+          context: 'src/extension',
+        },
+      ]),
+    ],
   };
-
 
   return config;
 };


### PR DESCRIPTION
GitHub Issue (if applicable): #1636 

#### Explanation of Bugfix/Feature/Modification:
Likely an issue with the upgrade to JQuery. We need access scrollLeft from the currentTarget rather than the event itself.
