### PR TITLE
Fixed an issue where the sidebar would be collapsed or resized when you navigated to the "Select Budget" page.

### DIFF
--- a/src/extension/features/general/collapse-side-menu/index.js
+++ b/src/extension/features/general/collapse-side-menu/index.js
@@ -1,4 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
+import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
 import { getToolkitStorageKey, l10n, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 
 export class CollapseSideMenu extends Feature {
@@ -7,7 +8,7 @@ export class CollapseSideMenu extends Feature {
   }
 
   shouldInvoke() {
-    return true;
+    return getCurrentRouteName() !== 'users.budgets';
   }
 
   invoke() {

--- a/src/extension/features/general/resize-sidebar/index.js
+++ b/src/extension/features/general/resize-sidebar/index.js
@@ -1,4 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
+import { getCurrentRouteName } from 'toolkit/extension/utils/ynab';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 
 const RESIZER_CLASS = 'tk-sidebar-resizer';
@@ -15,7 +16,7 @@ export class ResizeSidebar extends Feature {
   isMouseDown = false;
 
   shouldInvoke() {
-    return true;
+    return getCurrentRouteName() !== 'users.budgets';
   }
 
   invoke() {


### PR DESCRIPTION
GitHub Issue (if applicable): #1591 

#### Explanation of Bugfix/Feature/Modification:
These features were always invoking. Just make sure they don't invoke on the initial load if the page is the select budget page.
