### PR TITLE
Feature: Add an option to Edit menu to Manage Payees for selected transactions.

### DIFF
--- a/src/extension/features/accounts/bulk-manage-payees/index.js
+++ b/src/extension/features/accounts/bulk-manage-payees/index.js
@@ -1,0 +1,37 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
+
+export class BulkManagePayees extends Feature {
+  observe = changedNodes => {
+    if (
+      changedNodes.has(
+        'ynab-u modal-popup modal-account-edit-transaction-list ember-view modal-overlay active'
+      )
+    ) {
+      this.invoke();
+    }
+  };
+
+  invoke() {
+    const menuText =
+      (ynabToolKit.l10nData && ynabToolKit.l10nData['toolkit.accountsBulkManagePayees']) ||
+      'Manage Payees';
+
+    // Note that ${menuText} was intentionally placed on the same line as the <i> tag to
+    // prevent the leading space that occurs as a result of using a multi-line string.
+    // Using a dedent function would allow it to be placed on its own line which would be
+    // more natural.
+    //
+    // The second <li> functions as a separator on the menu after the feature menu item.
+    $('.modal-account-edit-transaction-move').before(
+      $(`<li>
+            <button class="toolkit-modal-select-budget-manage-payees">
+            <i class="ember-view flaticon stroke group"><!----></i>${menuText}
+            </button>
+          </li>
+          <li><hr /><li>`).click(() => {
+        controllerLookup('accounts').send('openPayeeModal');
+      })
+    );
+  }
+}

--- a/src/extension/features/accounts/bulk-manage-payees/settings.js
+++ b/src/extension/features/accounts/bulk-manage-payees/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'BulkManagePayees',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Bulk Manage Payees',
+  description:
+    'Adds an option to the transaction edit drop-down menu to manage payees for the current selection.',
+};


### PR DESCRIPTION
GitHub Issue (if applicable): #1644

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:

This currently is a very hacky way of opening the Manage Payees dialog from a set of selected transactions using the Edit menu rather than the main account menu, which when combined with [Show Menu When Right Clicking On Transaction](https://github.com/toolkit-for-ynab/toolkit-for-ynab/blob/master/docs/feature-list.md#show-menu-when-right-clicking-on-transaction), allows for easy recategorization of transaction payees.

I just copied the "Clear Selection" feature and modified it for these purposes, so I'm sure there's a better way to do it. I'm very unfamiliar with the inner workings of Ember, so please don't merge this until we figure out the "right" way to launch the modal.