### PR TITLE
Docs: Add mini-steps for installing the extension locally as a developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ versions are asking for options that are easily implemented in a browser extensi
 Rather than ask the YNAB team to implement these features, let's just do it
 ourselves!
 
-
 ### [List of Features](/docs/feature-list.md)
 You can find a full list of features [here](/docs/feature-list.md) and also on the options
 page of the extension once you have installed it which is where you can configure these
@@ -61,13 +60,15 @@ content scripts) into single files and manages most of the build process.
 
 	- On **macOS** both prerequisites can be setup using `brew`. Ensure command line developer tools (`xcode-select --install`) are also installed.
 	- On **Windows** `node` and `yarn` can be installed via Chocolatey (`choco`) package manager.
-4. Run `yarn install` within the folder you cloned. This will install all the dependencies needed for the project.
-5. Run `yarn build:development` from within the folder you cloned which will build the Toolkit.
+3. Run `yarn install` within the folder you cloned. This will install all the dependencies needed for the project.
+4. Run `yarn build:development` from within the folder you cloned which will build the Toolkit.
   - Whilst developing, you may prefer to run `yarn watch` which will monitor the project
     directory for changes and run `yarn build:development` automatically for you.
-6. The built extension will be available in the `dist/extension` folder. Navigate to `chrome://extensions`
+5. The built extension will be available in the `dist/extension` folder. Navigate to `chrome://extensions`
   and select the `dist/extension` folder as the folder that you would like to load.
-7. You may need to reload the Chrome plugin if it's been already installed. Visit `chrome://extensions` and click the reload icon ![](https://camo.githubusercontent.com/4d41ad79a8241b062ea59fa332b39028c1469703/68747470733a2f2f636c2e6c792f31633167304633443142316f2f496d616765253230323031382d30362d3034253230617425323031362e32302e33342e706e67)
+   - turn on `Developer mode`
+   - click on `Load unpacked`
+6. You may need to reload the Chrome plugin if it's been already installed. Visit `chrome://extensions` and click the reload icon ![](https://camo.githubusercontent.com/4d41ad79a8241b062ea59fa332b39028c1469703/68747470733a2f2f636c2e6c792f31633167304633443142316f2f496d616765253230323031382d30362d3034253230617425323031362e32302e33342e706e67)
 
 # Development Methodology
 


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:

With Hacktoberfest starting today, thought I'd come back to the toolkit and help contribute again.

Step 0: get up to speed with the changes

While doing so, notice some small tweaks in the readMe that would helpful.

P.S. Previous work was under the alias of `TAPE-SPEED`. Did small stuff like:
- small CSS to always show the save/cancel buttons
- Master toggle within the extension so you don't have to enable/disable the extension
- master reset to default

Not sure if those are still in play in some way though...

