### PR TITLE
Fixed Auto-Distribute not parsing amount correctly

### DIFF
--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -1,5 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+import { stripCurrency, formatCurrency } from 'toolkit/extension/utils/currency';
 
 const DISTRIBUTE_BUTTON_ID = 'toolkit-auto-distribute-splits-button';
 
@@ -78,7 +79,7 @@ export class AutoDistributeSplits extends Feature {
 
   getCellsAndValues() {
     const cells = $('.is-editing .ynab-grid-cell-outflow input').toArray();
-    const values = cells.map(node => parseFloat(node.value.trim()));
+    const values = cells.map(node => stripCurrency(node.value));
     return [cells, values];
   }
 
@@ -126,8 +127,9 @@ export class AutoDistributeSplits extends Feature {
 
   adjustValues(subCells, newSubValues) {
     subCells.forEach((cell, i) => {
-      $(cell).val(actualNumber(newSubValues[i]) ? newSubValues[i].toFixed(2) : '');
+      $(cell).val(actualNumber(newSubValues[i]) ? formatCurrency(newSubValues[i], true) : '');
       $(cell).trigger('change');
+      $(cell).trigger('blur');
     });
   }
 }

--- a/src/extension/utils/currency.js
+++ b/src/extension/utils/currency.js
@@ -1,10 +1,13 @@
-export function formatCurrency(value) {
+export function formatCurrency(value, hideSymbol) {
   const {
     currencyFormatter,
   } = ynab.YNABSharedLibWebInstance.firstInstanceCreated.formattingManager;
   const userCurrency = currencyFormatter.getCurrency();
 
   let formattedCurrency = currencyFormatter.format(value).toString();
+
+  if (hideSymbol === true) return formattedCurrency;
+
   if (userCurrency.display_symbol) {
     if (userCurrency.symbol_first) {
       if (formattedCurrency.charAt(0) === '-') {
@@ -18,4 +21,11 @@ export function formatCurrency(value) {
   }
 
   return formattedCurrency;
+}
+
+export function stripCurrency(text) {
+  const {
+    currencyFormatter,
+  } = ynab.YNABSharedLibWebInstance.firstInstanceCreated.formattingManager;
+  return Number(currencyFormatter.unformat(text) + '000');
 }


### PR DESCRIPTION
Fixed the issue with Auto-Distribute splits not calculating correctly.

<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

GitHub Issue (if applicable): #1402

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
The existing splits were being parsed with parseFloat which doesn't work with currency. I created a stripCurrency function in utils/currency that uses the YNAB formattingManager to correctly parse the amount from currency value. I also added an optional parameter to formatCurrency so the correct value could be inserted into the field without the currency symbol, and a blur after inserting the new split so the "Amount remaining to assign:" would be updated.

