### PR TITLE
Changed the way positive categories are displayed in "Income Breakdown"

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
@@ -269,11 +269,14 @@ export class IncomeBreakdownComponent extends React.Component {
     }
 
     if (showLossGain && (showExpense || showIncome) && totalExpense !== totalIncome) {
-      seriesData.push({
+      const lossGainData = {
         from: totalExpense > totalIncome ? 'NET LOSS' : 'Budget',
         to: totalExpense > totalIncome ? 'Budget' : 'NET GAIN',
         weight: Math.abs(totalIncome - totalExpense),
-      });
+      };
+      totalExpense > totalIncome && totalIncome === 0
+        ? seriesData.unshift(lossGainData)
+        : seriesData.push(lossGainData);
     }
 
     return seriesData;


### PR DESCRIPTION
By default positive categories will now show ungrouped with the ability to group them in a single "fake" category