### PR TITLE
Feature: Hide Closed Accounts

### DIFF
--- a/src/extension/features/general/hide-closed-accounts/components/hide-closed-button.jsx
+++ b/src/extension/features/general/hide-closed-accounts/components/hide-closed-button.jsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { l10n, getToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+
+export const HideClosedButton = ({ toggleHiddenState }) => {
+  const isHidden = getToolkitStorageKey('hide-closed', true);
+  const label = isHidden ? l10n('app.show', 'Show') : l10n('app.hide', 'Hide');
+
+  const toggleHidden = () => {
+    toggleHiddenState(!isHidden);
+    controllerLookup('application').send('closeModal');
+  };
+
+  return (
+    <li onClick={toggleHidden}>
+      <button>
+        <i className="flaticon stroke help-2" />
+        {` ${label}`} Closed Accounts
+      </button>
+    </li>
+  );
+};
+
+HideClosedButton.propTypes = {
+  toggleHiddenState: PropTypes.func.isRequired,
+};

--- a/src/extension/features/general/hide-closed-accounts/index.css
+++ b/src/extension/features/general/hide-closed-accounts/index.css
@@ -1,0 +1,3 @@
+body.toolkit-hide-closed .sidebar .nav-accounts .nav-account.closed {
+  display: none !important;
+}

--- a/src/extension/features/general/hide-closed-accounts/index.js
+++ b/src/extension/features/general/hide-closed-accounts/index.js
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { componentAppend } from 'toolkit/extension/utils/react';
+import { HideClosedButton } from './components/hide-closed-button';
+import { Feature } from 'toolkit/extension/features/feature';
+import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+
+export class HideClosedAccounts extends Feature {
+  injectCSS() {
+    return require('./index.css');
+  }
+
+  shouldInvoke() {
+    return true;
+  }
+
+  observe(changedNodes) {
+    if (changedNodes.has('ynab-u modal-popup modal-sidebar-menu ember-view modal-overlay active')) {
+      componentAppend(
+        <HideClosedButton toggleHiddenState={this.setHiddenState} />,
+        document.getElementsByClassName('modal-list')[0]
+      );
+    }
+  }
+
+  invoke() {
+    const initialState = getToolkitStorageKey('hide-closed', true);
+    this.setHiddenState(initialState);
+  }
+
+  setHiddenState = state => {
+    setToolkitStorageKey('hide-closed', state);
+    if (state) {
+      $('body').addClass('toolkit-hide-closed');
+    } else {
+      $('body').removeClass('toolkit-hide-closed');
+    }
+  };
+}

--- a/src/extension/features/general/hide-closed-accounts/settings.js
+++ b/src/extension/features/general/hide-closed-accounts/settings.js
@@ -5,5 +5,5 @@ module.exports = {
   section: 'general',
   title: 'Hide Closed Accounts',
   description:
-    'This feature hides the closed accounts section in the side menu. View the account-options popup (click your e-mail in the bottom left) to show or hide the closed accounts.',
+    'This feature hides the closed accounts section in the side menu. View the account-options popup (click your e-mail) to show or hide the closed accounts.',
 };

--- a/src/extension/features/general/hide-closed-accounts/settings.js
+++ b/src/extension/features/general/hide-closed-accounts/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'HideClosedAccounts',
+  type: 'checkbox',
+  default: false,
+  section: 'general',
+  title: 'Hide Closed Accounts',
+  description:
+    'This feature hides the closed accounts section in the side menu. View the account-options popup (click your e-mail in the bottom left) to show or hide the closed accounts.',
+};

--- a/src/extension/features/general/hide-help/settings.js
+++ b/src/extension/features/general/hide-help/settings.js
@@ -5,5 +5,5 @@ module.exports = {
   section: 'general',
   title: 'Hide Help (?) Button',
   description:
-    'This feature hides the blue help (?) button in the bottom right corner of the screen. View the account-options popup (click your e-mail in the bottom left) to show or hide the help button.',
+    'This feature hides the blue help (?) button in the bottom right corner of the screen. View the account-options popup (click your e-mail) to show or hide the help button.',
 };


### PR DESCRIPTION
Trello Link (if applicable): https://trello.com/c/JT2CtHpZ/508-hide-closed-accounts

Forum Link (if applicable): https://forum.youneedabudget.com/discussion/56350/toolkit-feature-request-hide-closed-accounts#latest

#### Explanation of Bugfix/Feature/Modification: This feature adds the ability for the user to hide or show the closed accounts section in the side menu based on a toggle.

