### PR TITLE
Feature: Change memo fields default behavior on enter

### DIFF
--- a/src/extension/features/accounts/change-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-enter-behavior/index.js
@@ -29,6 +29,8 @@ export class ChangeEnterBehavior extends Feature {
   }
 
   applyNewEnterBehavior(event) {
+    // This check is added so that there is no conflict with ChangeMemoEnterBehavior
+    if ($(this)[0].getAttribute('data-toolkit-memo-behavior')) return;
     if (event.keyCode === 13) {
       event.preventDefault();
       event.stopPropagation();

--- a/src/extension/features/accounts/change-memo-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-memo-enter-behavior/index.js
@@ -1,0 +1,38 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+
+export class ChangeMemoEnterBehavior extends Feature {
+  shouldInvoke() {
+    return (
+      isCurrentRouteAccountsPage() &&
+      $('.ynab-grid-body-row.is-adding, .ynab-grid-body-row.is-editing').length
+    );
+  }
+
+  invoke() {
+    const $addEditRow = $('.ynab-grid-body-row.is-adding, .ynab-grid-body-row.is-editing');
+    const $memoInput = $('.ynab-grid-cell-memo input', $addEditRow);
+
+    if (!$memoInput[0].getAttribute('data-toolkit-memo-behavior')) {
+      $memoInput[0].setAttribute('data-toolkit-memo-behavior', true);
+      $memoInput.keydown(this.applyNewEnterBehavior);
+    }
+  }
+
+  applyNewEnterBehavior(event) {
+    if (event.keyCode === 13) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      $('.ynab-grid-cell-outflow input').focus();
+    }
+  }
+
+  observe(changedNodes) {
+    if (!changedNodes.has('ynab-grid-body')) return;
+
+    if (this.shouldInvoke()) {
+      this.invoke();
+    }
+  }
+}

--- a/src/extension/features/accounts/change-memo-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-memo-enter-behavior/index.js
@@ -24,7 +24,12 @@ export class ChangeMemoEnterBehavior extends Feature {
       event.preventDefault();
       event.stopPropagation();
 
-      $('.ynab-grid-cell-outflow input').focus();
+      const $addEditRow = $('.ynab-grid-body-row.is-adding, .ynab-grid-body-row.is-editing');
+      const $memoColumn = $('.ynab-grid-cell-memo', $addEditRow);
+      const $columns = $addEditRow.children();
+      const $nextColumn = $($columns.get($columns.index($memoColumn) + 1));
+
+      $nextColumn.find('input').focus();
     }
   }
 

--- a/src/extension/features/accounts/change-memo-enter-behavior/settings.js
+++ b/src/extension/features/accounts/change-memo-enter-behavior/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'ChangeMemoEnterBehavior',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Change Behaviour of Enter Key on the Memo field When Adding or Editing Transactions',
+  description:
+    "When you press enter on the memo field while adding or editing a transaction, the default behaviour is 'Save' or 'Save and add another'. This option changes it to move to the next field.",
+};


### PR DESCRIPTION
Trello Link (if applicable): https://trello.com/c/15wGR3sT/177-make-enter-key-function-as-tab-in-memo-field

#### Explanation of Bugfix/Feature/Modification:
Updates the default behaviour of hitting enter on the memo field when adding/editing a transaction. Enter will no tab to the Outflow field. 

