### PR TITLE
Fixed an issue with the memo enter behavior on split transactions

### DIFF
--- a/src/extension/features/accounts/change-memo-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-memo-enter-behavior/index.js
@@ -24,9 +24,11 @@ export class ChangeMemoEnterBehavior extends Feature {
       event.preventDefault();
       event.stopPropagation();
 
-      const $addEditRow = $('.ynab-grid-body-row.is-adding, .ynab-grid-body-row.is-editing');
-      const $memoColumn = $('.ynab-grid-cell-memo', $addEditRow);
-      const $columns = $addEditRow.children();
+      const $closestAddEditRow = $(this).closest(
+        $('.ynab-grid-body-row.is-adding, .ynab-grid-body-row.is-editing')
+      );
+      const $memoColumn = $('.ynab-grid-cell-memo', $closestAddEditRow);
+      const $columns = $closestAddEditRow.children();
       const $nextColumn = $($columns.get($columns.index($memoColumn) + 1));
 
       $nextColumn.find('input').focus();


### PR DESCRIPTION
GitHub Issue (if applicable): #1680 

#### Explanation of Bugfix/Feature/Modification:

Fixes issue #1680. The code was previously retrieving the first row with `is-editing` and now it will grab the closest row.
