### PR TITLE
Fixed the problem with the Budget Quick Switch  feature not opening the selected budget

### DIFF
--- a/src/extension/features/general/budget-quick-switch/components/budget-list-item.jsx
+++ b/src/extension/features/general/budget-quick-switch/components/budget-list-item.jsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { getRouter } from 'toolkit/extension/utils/ember';
+// import { getRouter } from 'toolkit/extension/utils/ember';
+import { getApplicationService } from 'toolkit/extension/utils/ynab';
 
 export const BudgetListItem = props => {
   const handleClick = () => {
-    const router = getRouter();
-    router.send('openBudget', props.budgetVersionId, props.budgetVersionName);
+    const appService = getApplicationService();
+    appService.loadBudget(props.budgetVersionId, props.budgetVersionName);
   };
 
   return (

--- a/src/extension/utils/ynab.js
+++ b/src/extension/utils/ynab.js
@@ -56,6 +56,10 @@ export function getSidebarViewModel() {
   return controllerLookup('application').get('sidebarViewModel');
 }
 
+export function getApplicationService() {
+  return controllerLookup('application').get('applicationService');
+}
+
 export function isCurrentMonthSelected() {
   const today = new ynab.utilities.DateWithoutTime();
   const selectedMonth = getSelectedMonth();


### PR DESCRIPTION

<!--Thank you for your contribution! Please note that Pull Request titles are used
to generate release notes. So rather than having a "technical" title, it's
preferred that you have a title which is descriptive to a normal user.

Example:
  Instead of:
    - "Changed the selector to use new YNAB className"
  Use:
    - "Fixed an issue with account rows height introduced by YNAB's latest update.

Starting titles in the following way is also really useful for release notes to have
a consistent feeling:

Bug Fix (ie: YNAB changed a class name we depend on):
  - "Fixed an issue..."
Modification (ie: Removed starting balances from reports):
  - "Changed the way..."
Feature (ie: adding a feature that didn't already exist):
  - "Feature: Name of New Feature"

Finally, after properly titling your Pull Request, please fill out the following
information to provide context to the reviewer and more technical information
to interested users since this Pull Request will be linked in the release notes.-->

GitHub Issue (if applicable): #1697

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Modification:
Due to a recent YNAB change, we should use the application service to load the budget. Now we are.
