### PR TITLE
Don't invoke Running Balance if available natively

### DIFF
--- a/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
+++ b/src/extension/features/accounts/transaction-grid-features/running-balance/index.js
@@ -22,6 +22,7 @@ export class RunningBalance extends TransactionGridFeature {
 
   shouldInvoke() {
     return (
+      !YNABFEATURES['view-menu'] &&
       isCurrentRouteAccountsPage() &&
       controllerLookup('application').get('selectedAccountId') !== null
     );


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
Native YNAB Running Balance is coming. This makes the toolkit feature not invoke when it's enabled.
