### PR TITLE
Fix Auto-Distribute for split transactions with fractional values

### DIFF
--- a/src/extension/utils/currency.js
+++ b/src/extension/utils/currency.js
@@ -1,10 +1,10 @@
-export function formatCurrency(value, hideSymbol) {
+export function formatCurrency(valueInMilliDollars, hideSymbol) {
   const {
     currencyFormatter,
   } = ynab.YNABSharedLibWebInstance.firstInstanceCreated.formattingManager;
   const userCurrency = currencyFormatter.getCurrency();
 
-  let formattedCurrency = currencyFormatter.format(value).toString();
+  let formattedCurrency = currencyFormatter.format(valueInMilliDollars).toString();
 
   if (hideSymbol === true) return formattedCurrency;
 
@@ -23,10 +23,10 @@ export function formatCurrency(value, hideSymbol) {
   return formattedCurrency;
 }
 
-export function stripCurrency(text) {
+export function stripCurrency(formattedCurrencyText) {
   const {
     currencyFormatter,
   } = ynab.YNABSharedLibWebInstance.firstInstanceCreated.formattingManager;
-  const numberInDollars = currencyFormatter.unformat(text);
+  const numberInDollars = currencyFormatter.unformat(formattedCurrencyText);
   return currencyFormatter.convertToMilliDollars(numberInDollars);
 }

--- a/src/extension/utils/currency.js
+++ b/src/extension/utils/currency.js
@@ -27,5 +27,6 @@ export function stripCurrency(text) {
   const {
     currencyFormatter,
   } = ynab.YNABSharedLibWebInstance.firstInstanceCreated.formattingManager;
-  return Number(currencyFormatter.unformat(text) + '000');
+  const numberInDollars = currencyFormatter.unformat(text);
+  return currencyFormatter.convertToMilliDollars(numberInDollars);
 }

--- a/src/extension/utils/currency.test.js
+++ b/src/extension/utils/currency.test.js
@@ -1,0 +1,34 @@
+import { stripCurrency } from './currency';
+
+describe('stripCurrency', () => {
+  const currencyFormatter = {
+    unformat: jest.fn(),
+    convertToMilliDollars: jest.fn(),
+  };
+  beforeEach(() => defineYnabSharedLib(currencyFormatter));
+  afterEach(() => delete global.ynab);
+
+  it('should handle fractional values correctly', () => {
+    currencyFormatter.unformat.mockReturnValue(0.5);
+    currencyFormatter.convertToMilliDollars.mockReturnValue(500);
+    expect(stripCurrency('0.50')).toBe(500);
+  });
+
+  it('should handle integer values correctly', () => {
+    currencyFormatter.unformat.mockReturnValue(1);
+    currencyFormatter.convertToMilliDollars.mockReturnValue(1000);
+    expect(stripCurrency('1.00')).toBe(1000);
+  });
+});
+
+function defineYnabSharedLib(currencyFormatter) {
+  global.ynab = {
+    YNABSharedLibWebInstance: {
+      firstInstanceCreated: {
+        formattingManager: {
+          currencyFormatter,
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
GitHub Issue: #1640

#### Explanation of Bugfix:

This PR fixes a subtle bug in the number-parsing logic for the Auto-Distribute feature.

This parsing logic was updated by #1665 to correctly use YNAB's internal `format()` and `unformat()` functions for converting dollar values to and from formatted currency strings, respectively.

One of the subtleties of `format()` is that it expects its argument to be in "millidollars" (e.g. where $1 == 1000 millidollars). This enables the rest of the business logic within YNAB and the YNAB Toolkit to manipulate dollars and cents using whole numbers, rather than dealing with the nuances of floating-point arithmetic. Once we're ready to display a calculated value, we simply pass the millidollars value to `format()` to generate a formatted currency string for display in the UI.

`unformat()` performs the opposite operation, taking a formatted currency string and returning a number. The number it returns, however, is in _dollars_, not _millidollars_.

To summarize:
```
  format(): Number In Millidollars => String
unformat():                 String => Number in Dollars
```

The lack of symmetry in the signatures of these two functions means we need an extra step to convert the return value from `unformat()` to millidollars whenever we try to parse formatted currency values from the UI (such as, for example, when we read the values of split transactions for the Auto-Distribute feature).

#1665 implemented that conversion by appending `000` to the number. This works as expected for whole numbers (e.g. `2 + "000" === 2000`), but not for fractional numbers (e.g. `1.5 + "000" === "1.5000"`).

It turns out we don't have to implement this conversion ourselves, since YNAB's internal library includes a dedicated function for this purpose: `convertToMilliDollars()`.

This PR updates our `stripCurrency()` function to call `convertToMilliDollars()` appropriately. It also includes a few tests for good measure, and renames the parameters of our `formatCurrency()` and `stripCurrency()` functions to highlight the distinction between dollars and millidollars explained above.