### PR TITLE
Add auto-enable running balance feature for native running balance

### DIFF
--- a/scripts/generateSettings.js
+++ b/scripts/generateSettings.js
@@ -18,6 +18,14 @@ const settingMigrationMap = {
       true: 'cat-toggle-all',
     },
   },
+  AutoEnableRunningBalance: {
+    oldSettingName: 'RunningBalance',
+    settingMapping: {
+      0: false,
+      1: true,
+      2: true,
+    },
+  },
 };
 
 let previousSettings;

--- a/src/core/settings/index.js
+++ b/src/core/settings/index.js
@@ -29,11 +29,16 @@ export function getUserSettings() {
         const migrationSetting = settingMigrationMap[setting.name];
         if (migrationSetting && storedFeatureSettings.includes(migrationSetting.oldSettingName)) {
           const { oldSettingName, settingMapping } = migrationSetting;
-          return storage
-            .getFeatureSetting(oldSettingName)
-            .then(oldPersistedValue =>
-              ensureSettingIsValid(setting.name, settingMapping[oldPersistedValue])
-            );
+          return storage.getFeatureSetting(oldSettingName).then(oldPersistedValue => {
+            let newSetting = oldPersistedValue;
+            if (settingMapping) {
+              newSetting = settingMapping[oldPersistedValue];
+            }
+
+            return storage
+              .setFeatureSetting(setting.name, newSetting)
+              .then(() => ensureSettingIsValid(setting.name, newSetting));
+          });
         }
 
         return storage

--- a/src/extension/features/accounts/auto-enable-running-balance/index.js
+++ b/src/extension/features/accounts/auto-enable-running-balance/index.js
@@ -1,0 +1,35 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
+
+export class AutoEnableRunningBalance extends Feature {
+  shouldInvoke() {
+    return YNABFEATURES['view-menu'] && isCurrentRouteAccountsPage();
+  }
+
+  invoke() {
+    const registerService = controllerLookup('accounts').get('registerGridService');
+    const { balance } = registerService.get('displayColumns');
+    if (!balance) {
+      try {
+        // misspelled -- should remove once/if fixed
+        registerService.toggleVieMenuColumn('balance');
+        return;
+      } catch {
+        /* ignore */
+      }
+
+      try {
+        registerService.toggleViewMenuColumn('balance');
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  onRouteChanged() {
+    if (this.shouldInvoke()) {
+      this.invoke();
+    }
+  }
+}

--- a/src/extension/features/accounts/auto-enable-running-balance/settings.js
+++ b/src/extension/features/accounts/auto-enable-running-balance/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'AutoEnableRunningBalance',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Automatically Enable Running Balance',
+  description: `Enables YNAB's native "Running Balance" by default for each account register.`,
+};

--- a/src/extension/features/accounts/transaction-grid-features/running-balance/settings.js
+++ b/src/extension/features/accounts/transaction-grid-features/running-balance/settings.js
@@ -5,7 +5,7 @@ module.exports = {
   section: 'accounts',
   title: 'Show Running Balance',
   description:
-    'Adds a running balance column to the accounts page (does not appear on All Accounts View)',
+    'Adds a running balance column to the accounts page (does not appear on All Accounts View). YNAB recently implemented their own native version of Running Balance. If that has been enabled for your account, this setting is ignored.',
   options: [
     { name: 'Off', value: '0' },
     { name: 'On: Style any negative running balances red', value: '1' },


### PR DESCRIPTION
#### Explanation of Bugfix/Feature/Modification:
This feature should stop some of our bug reports that running balance is missing. Defaults the running balance column to be on if they previously had toolkit's Running Balance enabled. Added a tidbit to the old running balance feature that it should be ignored if they're in that feature group.
