### PR TITLE
Fixed an issue with the change enter features not invoking

### DIFF
--- a/src/extension/features/accounts/change-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-enter-behavior/index.js
@@ -43,7 +43,7 @@ export class ChangeEnterBehavior extends Feature {
   }
 
   observe(changedNodes) {
-    if (!changedNodes.has('ynab-grid-body')) return;
+    if (!changedNodes.has('ynab-grid-add-rows')) return;
 
     if (this.shouldInvoke()) {
       this.invoke();

--- a/src/extension/features/accounts/change-memo-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-memo-enter-behavior/index.js
@@ -36,7 +36,11 @@ export class ChangeMemoEnterBehavior extends Feature {
   }
 
   observe(changedNodes) {
-    if (!changedNodes.has('ynab-grid-body')) return;
+    if (
+      !changedNodes.has('ynab-grid-body-row is-editing') &&
+      !changedNodes.has('ynab-grid-add-rows')
+    )
+      return;
 
     if (this.shouldInvoke()) {
       this.invoke();

--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -14,16 +14,26 @@ export class ObserveListener {
     let observer = new _MutationObserver(mutations => {
       this.changedNodes = new Set();
 
-      mutations.forEach(mutation => {
-        let newNodes = mutation.target;
-        let $nodes = $(newNodes);
-
-        $nodes.each((index, element) => {
+      const addChangedNodes = nodes => {
+        nodes.each((index, element) => {
           var nodeClass = $(element).attr('class');
           if (nodeClass) {
             this.changedNodes.add(nodeClass.replace(/^ember-view /, ''));
           }
         });
+      };
+
+      mutations.forEach(mutation => {
+        let newNodes = mutation.target;
+        let addedNodes = mutation.addedNodes;
+        let $nodes = $(newNodes);
+
+        addChangedNodes($nodes);
+
+        if (addedNodes) {
+          let $addedNodes = $(addedNodes);
+          addChangedNodes($addedNodes);
+        }
       });
 
       // Now we are ready to feed the change digest to the


### PR DESCRIPTION
GitHub Issue (if applicable): #1710 

#### Explanation of Bugfix/Feature/Modification:
The issue appeared to be when you clicked to add a transaction, the `ynab-grid-body` was not in the `changedNodes` which is checked in the observe method. I checked, maybe someone else can as well, if there was another node that could be checked in the observe, but I didn't see one that was best. 

To solve this, I modified the observer to also listen for `addedNodes` on the mutation and then add them to the `changedNodes`. This made some new nodes available to check for changes. For the save change on enter, I made it check for the `ynab-grid-add-rows` and for the memo enter change I had to modify it to listen for the `ynab-grid-add-rows` and the `ynab-grid-body-row is-editing` as the memo function is there on edit as well. 
