### PR TITLE
make step graph and fix x-axis labeling

### DIFF
--- a/src/extension/features/toolkit-reports/pages/balance-over-time/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/component.jsx
@@ -177,7 +177,7 @@ export class BalanceOverTimeComponent extends React.Component {
         dateTimeLabelFormats: {
           day: '%b %d',
           week: '%b %d, %y',
-          month: '%b %y',
+          month: '%b %Y',
         },
       },
       legend: {

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/component.jsx
@@ -174,7 +174,11 @@ export class BalanceOverTimeComponent extends React.Component {
       xAxis: {
         title: { text: 'Time' },
         type: 'datetime',
-        dateTimeLabelFormats: { day: '%d %b %Y' },
+        dateTimeLabelFormats: {
+          day: '%b %d',
+          week: '%b %d, %y',
+          month: '%b %y',
+        },
       },
       legend: {
         layout: 'vertical',
@@ -199,6 +203,7 @@ export class BalanceOverTimeComponent extends React.Component {
           marker: { enabled: false },
         },
         series: {
+          step: true,
           cursor: 'pointer',
           events: {
             click: event => {


### PR DESCRIPTION
GitHub Issue (if applicable): NA

Trello Link (if applicable): NA

**Explanation of Bugfix/Feature/Modification:**
Making the balance over time graph a step graph.
- When there are two points, the money is technically still the same until it reaches the second point date. This is more realistic view of our accounts rather than trying to connect them directly.

Fixed some formatting on the x-axis
- The axis looked very cluttered for the month view.
  - Day will look like: Nov 1
  - Week will look like: Nov 1, 19
  - Month will look like: Nov 2019
  - https://api.highcharts.com/highcharts/xAxis.dateTimeLabelFormats

Happy Thanksgiving!