### PR TITLE
Don't toggle balance column on all accounts

### DIFF
--- a/src/extension/features/accounts/auto-enable-running-balance/index.js
+++ b/src/extension/features/accounts/auto-enable-running-balance/index.js
@@ -8,19 +8,24 @@ export class AutoEnableRunningBalance extends Feature {
   }
 
   invoke() {
-    const registerService = controllerLookup('accounts').get('registerGridService');
-    const { balance } = registerService.get('displayColumns');
-    if (!balance) {
+    const accountsController = controllerLookup('accounts');
+    const { registerGridService, selectedAccountId } = accountsController.getProperties(
+      'registerGridService',
+      'selectedAccountId'
+    );
+
+    const { balance } = registerGridService.get('displayColumns');
+    if (selectedAccountId && !balance) {
       try {
         // misspelled -- should remove once/if fixed
-        registerService.toggleVieMenuColumn('balance');
+        registerGridService.toggleVieMenuColumn('balance');
         return;
       } catch {
         /* ignore */
       }
 
       try {
-        registerService.toggleViewMenuColumn('balance');
+        registerGridService.toggleViewMenuColumn('balance');
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
GitHub Issue (if applicable): #1723

**Explanation of Bugfix/Feature/Modification:**
Calling the `toggleViewColumn` on for an account causes YNAB to save column widths which appears to cause issues for the "all accounts" view. This should hopefully resolve those issues.
