### PR TITLE
Fix: Calendar-first-week feature

### DIFF
--- a/src/extension/features/accounts/calendar-first-day/index.css
+++ b/src/extension/features/accounts/calendar-first-day/index.css
@@ -1,0 +1,4 @@
+.modal-account-calendar
+  .accounts-calendar-grid:not(.accounts-calendar-grid--toolkit-calendar-first-day-managed) {
+  display: none;
+}

--- a/src/extension/features/accounts/calendar-first-day/index.js
+++ b/src/extension/features/accounts/calendar-first-day/index.js
@@ -6,6 +6,10 @@ export class CalendarFirstDay extends Feature {
 
   isReRendering = false;
 
+  injectCSS() {
+    return require('./index.css');
+  }
+
   shouldInvoke() {
     return false;
   }
@@ -27,25 +31,40 @@ export class CalendarFirstDay extends Feature {
 
   reRenderWeekdays() {
     let shiftDays = this.shiftDays();
+    let $originalAccountsCalendarGrid = $(
+      '.accounts-calendar-grid:not(.accounts-calendar-grid--toolkit-calendar-first-day-managed)'
+    );
 
     // Remove all previously added shift elements
-    $('.accounts-calendar-grid')
-      .find('.shift')
-      .remove();
+    $originalAccountsCalendarGrid.find('.shift').remove();
 
-    if ($('.accounts-calendar-empty').length >= shiftDays) {
+    if ($('.accounts-calendar-empty', $originalAccountsCalendarGrid).length >= shiftDays) {
       // Remove specific # of empty elements
-      $('.accounts-calendar-empty')
+      $('.accounts-calendar-empty', $originalAccountsCalendarGrid)
         .slice(-shiftDays)
         .remove();
     } else {
       // Add 'shift' empty elements
       for (var j = 0; j < 7 - shiftDays; j++) {
-        $('.accounts-calendar-grid').prepend(
+        $originalAccountsCalendarGrid.prepend(
           '<li class="accounts-calendar-empty shift">&nbsp;</li>'
         );
       }
     }
+
+    // Duplication of calendar days to Toolkit managed area is necessary
+    // to avoid ugly re-styling flash/jumping numbers when selecting date
+    // which doesn't auto-close the calendar modal
+    if ($('.accounts-calendar-grid--toolkit-calendar-first-day-managed').length === 0) {
+      $originalAccountsCalendarGrid.after(
+        '<ul class="accounts-calendar-grid accounts-calendar-grid--toolkit-calendar-first-day-managed"></ul>'
+      );
+    }
+
+    let $managedAccountsCalendarGrid = $(
+      '.accounts-calendar-grid--toolkit-calendar-first-day-managed'
+    );
+    $managedAccountsCalendarGrid.html($originalAccountsCalendarGrid.html());
   }
 
   shiftDays() {
@@ -55,14 +74,15 @@ export class CalendarFirstDay extends Feature {
   observe(changedNodes) {
     if (
       changedNodes.has(
-        'ynab-u modal-account-calendar modal-account-dropdown ember-view modal-overlay active'
-      ) ||
-      changedNodes.has('ynab-u modal-account-calendar ember-view modal-overlay active')
+        'modal-account-calendar js-ynab-new-calendar-overlay ember-view modal-overlay active'
+      )
     ) {
       this.isCalendarOpen = true;
       this.reRenderHeader();
     } else if (
-      changedNodes.has('ynab-u modal-account-calendar ember-view modal-overlay active closing')
+      changedNodes.has(
+        'modal-account-calendar js-ynab-new-calendar-overlay ember-view modal-overlay active closing'
+      )
     ) {
       this.isCalendarOpen = false;
     } else if (


### PR DESCRIPTION
Stopped working due to introduction of new classes at YNAB's side
This change also includes fix for styling flash/jumping numbers that was
observed to happen when selecting future date (i.e., which don't
auto-close calendar)

Closes https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/1732

**Explanation of Bugfix/Feature/Modification:**

1. Updated observed `changedNodes` to match new YNAB situation (`v1.41626`);
2. Introduced cloned `account-calendar-grid` handler to avoid styling flashes
