### PR TITLE
New(?) Feature: Spending Report transactions copy to clipboard

### DIFF
--- a/src/extension/features/reports/spending-activity-copy/index.js
+++ b/src/extension/features/reports/spending-activity-copy/index.js
@@ -1,0 +1,82 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { getCurrentRouteName, getEntityManager } from 'toolkit/extension/utils/ynab';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
+
+export class SpendingActivityCopy extends Feature {
+  shouldInvoke() {
+    return getCurrentRouteName().includes('reports.spending.totals');
+  }
+
+  invoke() {
+    $('.modal-actions > .button-primary')
+      .clone()
+      .attr('id', 'toolkit-copy-button')
+      .insertAfter('.modal-actions > .button-primary')
+      .on('click', this.categoryActivityCopy);
+
+    var childCache = $('#toolkit-copy-button').children();
+    $('#toolkit-copy-button')
+      .text('Copy Transactions')
+      .append(childCache);
+    $('#toolkit-copy-button > .flaticon')
+      .toggleClass('checkmark-2 copy')
+      .css('margin-left', '3px');
+  }
+
+  categoryActivityCopy() {
+    const activityTransactions = controllerLookup('reports/spending').get('modalTransactions');
+    if (!activityTransactions) {
+      return;
+    }
+
+    const entityManager = getEntityManager();
+    const activities = activityTransactions.map(transaction => {
+      const parentEntityId = transaction.get('parentEntityId');
+      let payeeId = transaction.get('payeeId');
+
+      if (parentEntityId) {
+        payeeId = entityManager.transactionsCollection
+          .findItemByEntityId(parentEntityId)
+          .get('payeeId');
+      }
+
+      const payee = entityManager.payeesCollection.findItemByEntityId(payeeId);
+
+      return {
+        Account: transaction.get('accountName'),
+        Date: ynab.formatDateLong(transaction.get('date').toNativeDate()),
+        Payee: payee && payee.get('name') ? payee.get('name') : 'Unknown',
+        Category: transaction.get('subCategoryNameWrapped'),
+        Memo: transaction.get('memo'),
+        Amount: ynab.formatCurrency(transaction.get('amount')),
+      };
+    });
+
+    const replacer = (key, value) => (value === null ? '' : value);
+    const header = Object.keys(activities[0]);
+    let csv = activities.map(row =>
+      header.map(fieldName => JSON.stringify(row[fieldName], replacer)).join('\t')
+    );
+    csv.unshift(header.join('\t'));
+    csv = csv.join('\r\n');
+    let $temp = $('<textarea style="position:absolute; left: -9999px; top: 50px;"/>');
+    $('body').append($temp);
+    $temp.val(csv).select();
+    document.execCommand('copy');
+    $temp.remove();
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+    if (
+      changedNodes.has('pure-u modal-popup modal-budget-activity ember-view modal-overlay active')
+    ) {
+      this.invoke();
+    }
+  }
+
+  onRouteChanged() {
+    if (!this.shouldInvoke()) return;
+    this.invoke();
+  }
+}

--- a/src/extension/features/reports/spending-activity-copy/settings.js
+++ b/src/extension/features/reports/spending-activity-copy/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'SpendingActivityCopy',
+  type: 'checkbox',
+  default: false,
+  section: 'reports',
+  title: 'Add Copy Transactions button to the Spending Report Activity Popup',
+  description:
+    'Adds a button to the spending report activity popup to allow you to copy the transactions to the clipboard (able to be pasted into a spreadsheet app).',
+};


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
Adds an optional button to transaction inspect modal on Reports/Spending (and toolkit-reports/spending) to copy the transactions to the clipboard. 

Could be considered duplicate of #780, happy to move both to a General option and make the code conditional based on routes with the modal present.