### PR TITLE
Fix POS-style currency entry mode

### DIFF
--- a/src/extension/features/general/pos-style-currency-entry-mode/index.js
+++ b/src/extension/features/general/pos-style-currency-entry-mode/index.js
@@ -34,7 +34,7 @@ export class POSStyleCurrencyEntryMode extends Feature {
 
     const newCurrencyInputComponent = componentLookup(name);
     const originalNewCurrencyInputComponentActions = Object.getPrototypeOf(
-      Object.getPrototypeOf(newCurrencyInputComponent)
+      newCurrencyInputComponent
     ).actions;
     const originalNewCurrencyInputComponentCallback =
       originalNewCurrencyInputComponentActions.commitValue;


### PR DESCRIPTION
In YNAB v1.42309 the `ynab-new-currency-input` callbacks/actions
including `commitValue` are found in direct prototype of Ember component

Verified manually that POS-entry functionality is back to working order