### PR TITLE
Fix first-render issues with addToolkitEmberHook

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -83,13 +83,11 @@ export class DisplayTotalMonthlyGoals extends Feature {
   }
 
   invoke() {
-    const inspectorComponents = [
+    addToolkitEmberHook(
+      this,
       'budget/inspector/default-inspector',
-      'budget/inspector/multi-select-inspector',
-    ];
-
-    inspectorComponents.forEach(key =>
-      addToolkitEmberHook(this, key, 'didRender', this.addTotalMonthlyGoals)
+      'didRender',
+      this.addTotalMonthlyGoals
     );
   }
 }

--- a/src/extension/features/budget/hide-total-available/index.js
+++ b/src/extension/features/budget/hide-total-available/index.js
@@ -1,46 +1,41 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 import { l10n } from 'toolkit/extension/utils/toolkit';
+import { addToolkitEmberHook } from 'toolkit/extension/utils/toolkit';
 
 /**
  * Hides the "Total Available" section of the budget inspector.
  */
 export class HideTotalAvailable extends Feature {
   shouldInvoke() {
-    return isCurrentRouteBudgetPage();
-  }
-
-  onRouteChanged() {
-    if (this.shouldInvoke()) {
-      this.invoke();
-    }
-  }
-
-  observe(changedNodes) {
-    if (!this.shouldInvoke()) return;
-
-    if (changedNodes.has('budget-inspector')) {
-      this.invoke();
-    }
+    return true;
   }
 
   invoke() {
-    const budgetInspector = $('.budget-inspector');
+    addToolkitEmberHook(
+      this,
+      'budget/inspector/default-inspector',
+      'didRender',
+      this.hideTotalAvailable
+    );
+  }
 
+  hideTotalAvailable(element) {
     // Attempt to target the english string, `TOTAL AVAILABLE`, but if that's not
     // found, try the localized version of the string.
     const englishHeading = 'TOTAL AVAILABLE';
     const localizedHeading = l10n('inspector.totalAvailable', englishHeading);
     const headingEl =
-      budgetInspector.find(`h3:contains(${englishHeading})`)[0] ||
-      budgetInspector.find(`h3:contains(${localizedHeading})`)[0];
+      $(element).find(`h3:contains(${englishHeading})`)[0] ||
+      $(element).find(`h3:contains(${localizedHeading})`)[0];
 
     if ($(headingEl).hasClass('hidden')) {
       return;
     }
 
     $(headingEl)
-      .nextUntil('h3, .inspector-quick-budget')
+      .nextUntil('hr')
+      .addBack()
+      .next()
       .addBack()
       .addClass('hidden');
   }

--- a/src/extension/utils/ember.js
+++ b/src/extension/utils/ember.js
@@ -19,6 +19,14 @@ export function componentLookup(componentName) {
   return containerLookup(`component:${componentName}`);
 }
 
+export function forEachRenderedComponent(key, fn) {
+  return Object.values(getViewRegistry()).forEach(view => {
+    if (view._debugContainerKey === `component:${key}`) {
+      fn(view);
+    }
+  });
+}
+
 export function lookupForReopen(name) {
   const appContainer = __ynabapp__.__container__;
 

--- a/src/extension/utils/toolkit.js
+++ b/src/extension/utils/toolkit.js
@@ -2,7 +2,7 @@ import {
   EMBER_COMPONENT_TOOLKIT_HOOKS,
   emberComponentToolkitHookKey,
 } from 'toolkit/extension/ynab-toolkit';
-import { componentLookup } from 'toolkit/extension/utils/ember';
+import { componentLookup, forEachRenderedComponent } from 'toolkit/extension/utils/ember';
 
 const MONTHS_SHORT = [
   'Jan',
@@ -87,5 +87,5 @@ export function addToolkitEmberHook(context, componentKey, lifecycleHook, fn) {
     hooks.push({ context, fn });
   }
 
-  componentLookup(componentKey).rerender();
+  forEachRenderedComponent(componentKey, view => view.rerender());
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #1797

**Explanation of Bugfix/Feature/Modification:**
Likely related to the upgrade of Ember, `addToolkitEmberHook` wasn't actually triggering re-renders on the first load. This new approach seems to fix it but it's definitely not the best approach in the world. Memoization should be added to the `rerender` call.
