### PR TITLE
Fix pacing styles

### DIFF
--- a/src/extension/features/budget/pacing/index.css
+++ b/src/extension/features/budget/pacing/index.css
@@ -1,5 +1,5 @@
 .budget-table-header .toolkit-cell-pacing {
-  font-size: .75em;
+  font-size: 0.75em;
 }
 .toolkit-cell-pacing {
   width: 10%;
@@ -15,23 +15,29 @@
 
 .toolkit-cell-pacing-display {
   border-radius: 1em;
-  padding: .125em .5em .175em .5em !important;
-  color: #fff !important;
+  padding: 0.125em 0.5em 0.175em 0.5em !important;
+  color: #fff;
   font-weight: normal !important;
   cursor: pointer;
 }
 
 .toolkit-cell-pacing-display.positive {
-	background-color: #16a336 !important;
+  background-color: #16a336;
+  background-color: var(--budget_balance_positive_background);
+  color: var(--budget_balance_positive_text);
 }
 .toolkit-cell-pacing-display.positive:hover {
-	background-color: #138b2e !important;
+  background-color: #138b2e;
+  background-color: var(--budget_balance_positive_background_active);
 }
 .toolkit-cell-pacing-display.cautious {
-	background-color: #e59100 !important;
+  background-color: #e59100;
+  background-color: var(--budget_balance_warning_background);
+  color: var(--budget_balance_warning_text);
 }
 .toolkit-cell-pacing-display.cautious:hover {
-	background-color: #c37b00 !important;
+  background-color: #c37b00;
+  background-color: var(--budget_balance_warning_background_active);
 }
 
 .toolkit-cell-pacing-display.deemphasized,
@@ -41,10 +47,10 @@
 }
 
 .toolkit-cell-pacing-display.indicator {
-  border-radius: .5em;
+  border-radius: 0.5em;
   height: 1em;
   width: 1em;
-  margin-right: .5em;
+  margin-right: 0.5em;
   overflow: hidden;
   text-indent: -9999px;
   text-align: left;

--- a/src/extension/features/budget/pacing/index.js
+++ b/src/extension/features/budget/pacing/index.js
@@ -116,7 +116,7 @@ export class Pacing extends Feature {
       <li class="budget-table-cell-available toolkit-cell-pacing">
         <span
           title="${tooltip}"
-          class="toolkit-cell-pacing-display currency ${temperatureClass} ${deemphasizedClass} ${indicatorClass}"
+          class="ynab-new-budget-available-number toolkit-cell-pacing-display currency ${temperatureClass} ${deemphasizedClass} ${indicatorClass}"
           data-sub-category-id="${subCategoryId}"
         />
       </li>


### PR DESCRIPTION
Before this change, pacing cell was always colored with old colors and
disrespected height of budget rows feature. Now, both of this problems
fixed. Colors are calculated using YNAB CSS variable, with fallback
to old hardcoded ones, and height is fixed by adding correct class to
cell.

For example, for Compact height:
Before: ![](https://i.imgur.com/tAhc44z.png), after: ![](https://i.imgur.com/6i6K4ko.png)