### PR TITLE
Add confirmation of keyboard-initiated transaction change cancelation

### DIFF
--- a/src/extension/features/accounts/confirm-keyboard-cancelation-of-transaction-changes/index.js
+++ b/src/extension/features/accounts/confirm-keyboard-cancelation-of-transaction-changes/index.js
@@ -1,0 +1,34 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+import { l10n } from 'toolkit/extension/utils/toolkit';
+
+export class ConfirmKeyboardCancelationOfTransactionChanges extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage() && $('.ynab-grid-body-row .is-editing').length > 0;
+  }
+
+  invoke() {
+    const $cancelButton = $('.ynab-grid-actions-buttons .button.button-cancel');
+    const confirmationText = l10n(
+      'toolkit.confirmCancelationOfTransactionChanges',
+      'Discard changes to this transaction?'
+    );
+    const guardedKeydownEventCode = 'Enter';
+
+    $cancelButton.on('keydown', e => {
+      if (e.code !== guardedKeydownEventCode) return;
+      if (window.confirm(confirmationText)) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+    });
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (changedNodes.has('button button-cancel')) {
+      this.invoke();
+    }
+  }
+}

--- a/src/extension/features/accounts/confirm-keyboard-cancelation-of-transaction-changes/settings.js
+++ b/src/extension/features/accounts/confirm-keyboard-cancelation-of-transaction-changes/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'ConfirmKeyboardCancelationOfTransactionChanges',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Confirm keyboard-initiated transaction cancelation',
+  description:
+    'Displays a pop-up confirmation prompt when transaction row\'s "Cancel" action is triggered by keyboard press ("Enter"). This guards against inadvertent discarding of complex split transaction entries in keyboard driven entry workflows.',
+};


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**

When using YNAB in keyboard-driven way (e.g., using `<Tab>` to switch between rows/buttons and running "Add another split" action) there is a good chance that one extra/few `<Tab>` hit can move active element selection past "Add another split"/before "Save" button and **land on "Cancel"**.  Hitting an `<Enter>` key in such situation make whole transaction changeset to be discarded.

This feature makes a JS `window.confirm` (Ok/Cancel) prompt appear in situations when "Cancel" button in transaction row is being pressed by keyboard hit (i.e., `<Enter>`), thus allowing user to re-confirm "cancelation event" and possibly guard against an unsaved data loss.
