### PR TITLE
adds striped rows to categories on the budget section

### DIFF
--- a/src/extension/features/budget/striped-budget-rows/index.css
+++ b/src/extension/features/budget/striped-budget-rows/index.css
@@ -1,0 +1,3 @@
+.budget-table-row.is-sub-category:nth-of-type(even):not(.is-checked):not(.is-editing):not(.ynab-grid-body-empty):not(.ynab-grid-actions) {
+  background-color: #fafafa;
+}

--- a/src/extension/features/budget/striped-budget-rows/index.js
+++ b/src/extension/features/budget/striped-budget-rows/index.js
@@ -1,0 +1,7 @@
+import { Feature } from 'toolkit/extension/features/feature';
+
+export class StripedBudgetRows extends Feature {
+  injectCSS() {
+    return require('./index.css');
+  }
+}

--- a/src/extension/features/budget/striped-budget-rows/settings.js
+++ b/src/extension/features/budget/striped-budget-rows/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'StripedBudgetRows',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Stripped Budget Rows',
+  description: 'Shows a light gray background on alternating category rows.',
+};


### PR DESCRIPTION
GitHub Issue (if applicable): #1749

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Adds a light grey background colour to alternate categories on the budget screen, similar to how you can do this in the accounts section. 