### PR TITLE
issue-1597: Report total days used in DoB calculation

### DIFF
--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -131,10 +131,13 @@ ${l10n('budget.dob.avgOutflow', 'Average daily outflow')}: ~${formatCurrency(ave
     const availableDates = maxDate.diff(minDate, 'days');
 
     let averageDailyOutflow;
+    let totalDays;
     if (this._lookbackDays !== 0) {
       averageDailyOutflow = Math.abs(totalOutflow / this._lookbackDays);
+      totalDays = this._lookbackDays;
     } else {
       averageDailyOutflow = Math.abs(totalOutflow / availableDates);
+      totalDays = availableDates;
     }
 
     let daysOfBuffering = balance / averageDailyOutflow;
@@ -153,7 +156,7 @@ ${l10n('budget.dob.avgOutflow', 'Average daily outflow')}: ~${formatCurrency(ave
       averageDailyOutflow,
       daysOfBuffering,
       notEnoughDates,
-      totalDays: uniqueDates.size,
+      totalDays,
       totalOutflow,
     };
   };


### PR DESCRIPTION
GitHub Issue (if applicable): #1597 

Trello Link (if applicable): N/A (I think?)

**Explanation of Bugfix/Feature/Modification:**
Here, I've updated the "Total Days" value shown in the DoB tooltip to report the actual number of days that the outflow was averaged over, rather than the number of days on which there were transactions (the current value).
