### PR TITLE
Feature: Native browser search keypress override on accounts page

### DIFF
--- a/src/extension/features/accounts/capture-native-search-shortcuts/index.js
+++ b/src/extension/features/accounts/capture-native-search-shortcuts/index.js
@@ -1,0 +1,93 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+import { isPlatformMac } from 'toolkit/extension/utils/platform';
+
+export class CaptureNativeSearchShortcuts extends Feature {
+  constructor() {
+    super();
+
+    this.previousActiveElement = null;
+    this.searchInput = null;
+    this.windowKeydownHandlerAdded = false;
+  }
+
+  onRouteChanged() {
+    this.searchInput = null;
+
+    if (!this.shouldInvoke()) return;
+
+    this.invoke();
+  }
+
+  shouldInvoke() {
+    if (!isCurrentRouteAccountsPage()) return false;
+
+    return this.$detectSearchInput().length > 0;
+  }
+
+  invoke() {
+    if (this.windowKeydownHandlerAdded === false) {
+      this.addGlobalKeydownHandler();
+      this.windowKeydownHandlerAdded = true;
+    }
+
+    this.addSearchInputHandlers();
+  }
+
+  addGlobalKeydownHandler() {
+    const self = this;
+
+    $(window).on('keydown', e => {
+      if (!self.searchInput) return;
+      if (!self.isSearchKeyComboPressed(e)) return;
+
+      e.preventDefault();
+      self.previousActiveElement = document.activeElement;
+
+      return self
+        .$searchInput()
+        .focus()
+        .trigger('focusin');
+    });
+  }
+
+  addSearchInputHandlers() {
+    const self = this;
+    const searchBlurKeyboardEventCode = 'Escape';
+
+    this.$searchInput().on('keydown', e => {
+      if (self.isSearchKeyComboPressed(e)) {
+        e.preventDefault();
+        e.stopPropagation();
+      } else if (e.code === searchBlurKeyboardEventCode) {
+        let $previousElement = $(this.previousActiveElement);
+
+        e.preventDefault();
+        self.$searchInput().trigger('focusout');
+
+        return $previousElement.length ? $previousElement.focus() : true;
+      }
+    });
+  }
+
+  isSearchKeyComboPressed(e) {
+    const searchFocusKeyboardEventCode = 'KeyF';
+
+    return e.code === searchFocusKeyboardEventCode && this.isSearchModifierKeyPressed(e);
+  }
+
+  isSearchModifierKeyPressed(e) {
+    return isPlatformMac() ? e.metaKey : e.ctrlKey;
+  }
+
+  $searchInput() {
+    if (this.searchInput) return this.searchInput;
+
+    this.searchInput = this.$detectSearchInput();
+    return this.searchInput;
+  }
+
+  $detectSearchInput() {
+    return $('.transaction-search');
+  }
+}

--- a/src/extension/features/accounts/capture-native-search-shortcuts/settings.js
+++ b/src/extension/features/accounts/capture-native-search-shortcuts/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'CaptureNativeSearchShortcuts',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Capture native search shortcuts',
+  description:
+    "Make pressing default browser search shortcuts (Ctrl+F/Cmd+F) focus in YNAB's account transaction input field. Restoring focus back to previously active element or field can be done by pressing Escape",
+};

--- a/src/extension/utils/platform.js
+++ b/src/extension/utils/platform.js
@@ -1,0 +1,10 @@
+export function userAgent() {
+  return window.navigator.userAgent;
+}
+
+export function isPlatformMac() {
+  // Matchers adapted from https://github.com/bestiejs/platform.js/blob/efa9ac0e4f4aec19f10280c90fcf8dd47fa67a2f/platform.js#L483-L485
+  const macRegexp = /\b(?:Mac OS X|Macintosh|Mac)\b/gi;
+
+  return userAgent().match(macRegexp).length > 0;
+}


### PR DESCRIPTION
Add Ctrl+F/Cmd+F keypress override to focus in YNAB account transaction search field

**Explanation of Bugfix/Feature/Modification:**

This PR adds a new _Account_-scope feature to enable a faster lookup of previous transactions, without mouse movement (e.g., when need to cross check previous amounts or categories).

Standard combinations of `Ctrl+F` (Win/Linux/*) and `Cmd+F` (macOS) are handled with blurring back to input _previous to search_ input is done by `Escape` listener.

**Example:**

![Apr-11-2020 22-27-18](https://user-images.githubusercontent.com/2079110/79053158-ca7c0580-7c43-11ea-808d-334a747ce7dd.gif)
