### PR TITLE
Add inflow/outflow report

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types';
 import { ReportKeys, REPORT_TYPES } from 'toolkit-reports/common/constants/report-types';
 import { IncomeVsExpense } from 'toolkit-reports/pages/income-vs-expense';
 import { NetWorth } from 'toolkit-reports/pages/net-worth';
+import { InflowOutflow } from 'toolkit-reports/pages/inflow-outflow';
 import { BalanceOverTime } from 'toolkit-reports/pages/balance-over-time';
 import { SpendingByPayee } from 'toolkit-reports/pages/spending-by-payee';
 import { SpendingByCategory } from 'toolkit-reports/pages/spending-by-category';
@@ -50,6 +51,14 @@ const REPORT_COMPONENTS = [
     key: ReportKeys.NetWorth,
     filterSettings: {
       disableCategoryFilter: true,
+      includeTrackingAccounts: true,
+    },
+  },
+  {
+    component: InflowOutflow,
+    key: ReportKeys.InflowOutflow,
+    filterSettings: {
+      disableCategoryFilter: false,
       includeTrackingAccounts: true,
     },
   },

--- a/src/extension/features/toolkit-reports/common/constants/report-types.js
+++ b/src/extension/features/toolkit-reports/common/constants/report-types.js
@@ -1,5 +1,6 @@
 export const ReportKeys = {
   NetWorth: 'net-worth',
+  InflowOutflow: 'inflow-outflow',
   SpendingByCategory: 'spending-by-category',
   SpendingByPayee: 'spending-by-payee',
   IncomeVsExpense: 'income-vs-expense',
@@ -9,6 +10,7 @@ export const ReportKeys = {
 
 export const ReportNames = {
   NetWorth: 'Net Worth',
+  InflowOutflow: 'Inflow/Outflow',
   SpendingByCategory: 'Spending By Category',
   SpendingByPayee: 'Spending By Payee',
   IncomeVsExpense: 'Income vs. Expense',
@@ -20,6 +22,10 @@ export const REPORT_TYPES = [
   {
     key: ReportKeys.NetWorth,
     name: ReportNames.NetWorth,
+  },
+  {
+    key: ReportKeys.InflowOutflow,
+    name: ReportNames.InflowOutflow,
   },
   {
     key: ReportKeys.SpendingByCategory,

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
@@ -1,0 +1,246 @@
+import Highcharts from 'highcharts';
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { formatCurrency } from 'toolkit/extension/utils/currency';
+import { localizedMonthAndYear, sortByGettableDate } from 'toolkit/extension/utils/date';
+import { l10n } from 'toolkit/extension/utils/toolkit';
+import { FiltersPropType } from 'toolkit-reports/common/components/report-context/component';
+import { Legend } from './components/legend';
+
+export class InflowOutflowComponent extends React.Component {
+  static propTypes = {
+    filters: PropTypes.shape(FiltersPropType),
+    filteredTransactions: PropTypes.array.isRequired,
+  };
+
+  state = {};
+
+  componentDidMount() {
+    this._calculateData();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.filters !== prevProps.filters ||
+      this.props.filteredTransactions !== prevProps.filteredTransactions
+    ) {
+      this._calculateData();
+    }
+  }
+
+  render() {
+    return (
+      <div className="tk-flex tk-flex-column tk-flex-grow">
+        <div className="tk-flex tk-justify-content-end">
+          {this.state.hoveredData && (
+            <Legend
+              inflows={this.state.hoveredData.inflows}
+              outflows={this.state.hoveredData.outflows}
+              diffs={this.state.hoveredData.diffs}
+            />
+          )}
+        </div>
+        <div className="tk-highcharts-report-container" id="tk-net-worth-chart" />
+      </div>
+    );
+  }
+
+  _renderReport = () => {
+    const _this = this;
+    const { inflows, outflows, diffs, labels } = this.state.reportData;
+
+    const pointHover = {
+      events: {
+        mouseOver: function() {
+          _this.setState({
+            hoveredData: {
+              inflows: inflows[this.index],
+              outflows: outflows[this.index],
+              diffs: diffs[this.index],
+            },
+          });
+        },
+      },
+    };
+
+    const chart = new Highcharts.Chart({
+      credits: false,
+      chart: { renderTo: 'tk-net-worth-chart' },
+      legend: { enabled: false },
+      title: { text: '' },
+      tooltip: { enabled: false },
+      xAxis: { categories: labels },
+      yAxis: {
+        title: { text: '' },
+        labels: {
+          formatter: function() {
+            return formatCurrency(this.value);
+          },
+        },
+      },
+      plotOptions: {
+        column: {
+          grouping: false,
+        },
+      },
+      series: [
+        {
+          id: 'inflows',
+          type: 'column',
+          name: l10n('toolkit.inflows', 'Inflows'),
+          color: 'rgba(142,208,223,1)',
+          data: inflows,
+          pointPadding: 0,
+          point: pointHover,
+        },
+        {
+          id: 'outflows',
+          type: 'column',
+          name: l10n('toolkit.outflows', 'Outflows'),
+          color: 'rgba(234,106,81,1)',
+          data: outflows,
+          pointPadding: 0,
+          point: pointHover,
+        },
+        {
+          id: 'diffs',
+          type: 'area',
+          name: l10n('toolkit.diff', 'Difference'),
+          fillColor: 'rgba(244,248,226,0.5)',
+          negativeFillColor: 'rgba(247, 220, 218, 0.5)',
+          data: diffs,
+          point: pointHover,
+        },
+      ],
+    });
+
+    this.setState({ chart });
+  };
+
+  _calculateData() {
+    if (!this.props.filters) {
+      return;
+    }
+
+    let accountInflows = new Map();
+    let accountOutflows = new Map();
+    const allReportData = { inflows: [], outflows: [], labels: [] };
+    const transactions = this.props.filteredTransactions.slice().sort(sortByGettableDate);
+
+    let lastMonth = null;
+    function pushCurrentAccountData() {
+      let inflows = 0;
+      let outflows = 0;
+      accountInflows.forEach(total => {
+        inflows += total;
+      });
+      accountOutflows.forEach(total => {
+        outflows += total;
+      });
+
+      allReportData.inflows.push(inflows);
+      allReportData.outflows.push(outflows);
+      allReportData.labels.push(localizedMonthAndYear(lastMonth));
+
+      accountInflows = new Map();
+      accountOutflows = new Map();
+    }
+
+    transactions.forEach(transaction => {
+      const transactionMonth = transaction
+        .get('date')
+        .clone()
+        .startOfMonth();
+      if (lastMonth === null) {
+        lastMonth = transactionMonth;
+      }
+
+      // we're on a new month
+      if (transactionMonth.toISOString() !== lastMonth.toISOString()) {
+        pushCurrentAccountData();
+        lastMonth = transactionMonth;
+      }
+
+      const transactionAccountId = transaction.get('accountId');
+
+      if (transaction.getIsOnBudgetTransfer()) {
+        return;
+      }
+
+      const transactionAmount = transaction.get('amount');
+      let prevInflow = accountInflows.has(transactionAccountId)
+        ? accountInflows.get(transactionAccountId)
+        : 0;
+      let prevOutflow = accountOutflows.has(transactionAccountId)
+        ? accountOutflows.get(transactionAccountId)
+        : 0;
+      if (transactionAmount > 0) {
+        accountInflows.set(transactionAccountId, prevInflow + transactionAmount);
+      } else {
+        accountOutflows.set(transactionAccountId, prevOutflow + transactionAmount);
+      }
+    });
+
+    if (
+      lastMonth &&
+      allReportData.labels[allReportData.labels.length - 1] !== localizedMonthAndYear(lastMonth)
+    ) {
+      pushCurrentAccountData();
+    }
+
+    // make sure we have a label for any months which have empty data
+    const { fromDate, toDate } = this.props.filters.dateFilter;
+    if (transactions.length) {
+      let currentIndex = 0;
+      const transactionMonth = transactions[0]
+        .get('date')
+        .clone()
+        .startOfMonth();
+      const lastFilterMonth = toDate
+        .clone()
+        .addMonths(1)
+        .startOfMonth();
+      while (transactionMonth.isBefore(lastFilterMonth)) {
+        if (!allReportData.labels.includes(localizedMonthAndYear(transactionMonth))) {
+          const { inflows, outflows, labels } = allReportData;
+          labels.splice(currentIndex, 0, localizedMonthAndYear(transactionMonth));
+          inflows.splice(currentIndex, 0, inflows[currentIndex - 1] || 0);
+          outflows.splice(currentIndex, 0, outflows[currentIndex - 1] || 0);
+        }
+
+        currentIndex++;
+        transactionMonth.addMonths(1);
+      }
+    }
+
+    // Net Worth is calculated from the start of time so we need to handle "filters" here
+    // rather than using `filteredTransactions` from context.
+    const { labels, inflows, outflows } = allReportData;
+    let startIndex = labels.findIndex(label => label === localizedMonthAndYear(fromDate));
+    startIndex = startIndex === -1 ? 0 : startIndex;
+    let endIndex = labels.findIndex(label => label === localizedMonthAndYear(toDate));
+    endIndex = endIndex === -1 ? labels.length + 1 : endIndex + 1;
+
+    const filteredLabels = labels.slice(startIndex, endIndex);
+    const filteredOutflows = outflows.slice(startIndex, endIndex);
+    const filteredInflows = inflows.slice(startIndex, endIndex);
+    const filteredDiffs = filteredOutflows.map((outflow, idx) => filteredInflows[idx] + outflow);
+
+    this.setState(
+      {
+        hoveredData: {
+          inflows: filteredInflows[inflows.length - 1] || 0,
+          outflows: filteredOutflows[outflows.length - 1] || 0,
+          diffs: filteredDiffs[outflows.length - 1] || 0,
+        },
+        reportData: {
+          labels: filteredLabels,
+          outflows: filteredOutflows,
+          inflows: filteredInflows,
+          diffs: filteredDiffs,
+        },
+      },
+      this._renderReport
+    );
+  }
+}

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/component.jsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { Currency } from 'toolkit-reports/common/components/currency';
+import './styles.scss';
+
+export const Legend = props => (
+  <React.Fragment>
+    <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
+      <div className="tk-flex tk-mg-b-05 tk-align-items-center">
+        <div className="tk-inflow-outflow-legend__icon-outflows" />
+        <div className="tk-mg-l-05">Outflows</div>
+      </div>
+      <div>
+        <Currency value={props.outflows} />
+      </div>
+    </div>
+    <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
+      <div className="tk-flex tk-mg-b-05 tk-align-items-center">
+        <div className="tk-inflow-outflow-legend__icon-inflows" />
+        <div className="tk-mg-l-05">Inflows</div>
+      </div>
+      <div>
+        <Currency value={props.inflows} />
+      </div>
+    </div>
+    <div className="tk-mg-05 tk-pd-r-1">
+      <div className="tk-flex tk-mg-b-05 tk-align-items-center">
+        <div className="tk-inflow-outflow-legend__icon-inflow-outflows" />
+        <div className="tk-mg-l-05">Difference</div>
+      </div>
+      <div>
+        <Currency value={props.diffs} />
+      </div>
+    </div>
+  </React.Fragment>
+);
+
+Legend.propTypes = {
+  inflows: PropTypes.number.isRequired,
+  outflows: PropTypes.number.isRequired,
+  diffs: PropTypes.number.isRequired,
+};

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/index.js
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/index.js
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/styles.scss
@@ -1,0 +1,13 @@
+.tk-inflow-outflow-legend {
+  &__icon-inflows {
+    width: 16px;
+    height: 16px;
+    background-color: #8ed0df;
+  }
+
+  &__icon-outflows {
+    width: 16px;
+    height: 16px;
+    background-color: #ea6a51;
+  }
+}

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/container.js
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/container.js
@@ -1,0 +1,11 @@
+import { withReportContext } from 'toolkit-reports/common/components/report-context';
+import { InflowOutflowComponent } from './component';
+
+function mapReportContextToProps(context) {
+  return {
+    filteredTransactions: context.filteredTransactions,
+    filters: context.filters,
+  };
+}
+
+export const InflowOutflow = withReportContext(mapReportContextToProps)(InflowOutflowComponent);

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/index.js
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/index.js
@@ -1,0 +1,1 @@
+export * from './container';


### PR DESCRIPTION
GitHub Issue (if applicable): (none)

Trello Link (if applicable): maybe similar to https://trello.com/c/aFcsAC0S/304-reports-income-vs-expense-vs-debts-bar-graph

**Explanation of Bugfix/Feature/Modification:**
This adds an *inflow/outflow* report, which shows total inflows and total outflows per month, as well as the difference. It allows filtering by account and by category.

A sample (with fake data):

![Screenshot 2020-05-02 at 12 24 45](https://user-images.githubusercontent.com/6269/80861641-1a148680-8c70-11ea-9179-3bec892d84b1.png)

* * *

I threw this together fairly quickly this morning. I don’t have experience with YNAB Toolkit development. This extension works for me, but I have not tested it thoroughly.