### PR TITLE
Only insert copy transactions button into activity modal

### DIFF
--- a/src/extension/features/budget/category-activity-copy/index.js
+++ b/src/extension/features/budget/category-activity-copy/index.js
@@ -8,7 +8,7 @@ export class CategoryActivityCopy extends Feature {
   }
 
   invoke() {
-    $('.modal-actions > .button-primary')
+    $('.modal-budget-activity .modal-actions > .button-primary')
       .clone()
       .attr('id', 'toolkit-copy-button')
       .insertAfter('.modal-actions > .button-primary')


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
If YNAB opens the "YNAB Just Got Better" modal while you are opening an activity modal, it will accidentally add the Copy Transactions button to it:

![Screen Shot 2020-05-05 at 12 19 15 PM](https://user-images.githubusercontent.com/99604/81116093-a5448500-8ed9-11ea-954b-405874107ab1.png)

This specifically targets the `.modal-budget-activity` modal.
