### PR TITLE
Fixed Category Selectors for Goal and Pace Progress Bars

### DIFF
--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -218,7 +218,7 @@ export class BudgetProgressBars extends Feature {
       let budgetedCell;
       if ($(element).hasClass('is-master-category')) {
         masterCategoryName = $(element).find(
-          'div.budget-table-cell-name-row-label-item>div>div[title]'
+            'li.budget-table-cell-name>div:first-child[title]'
         );
         masterCategoryName =
           masterCategoryName !== 'undefined' ? $(masterCategoryName).attr('title') + '_' : '';
@@ -227,7 +227,7 @@ export class BudgetProgressBars extends Feature {
       if ($(element).hasClass('is-sub-category')) {
         const subCategory = getEmberView(element.id, 'category');
         let subCategoryName = $(element)
-          .find('li.budget-table-cell-name>div>div')[0]
+          .find('li.budget-table-cell-name>div')[0]
           .title.match(/.[^\n]*/);
 
         subCategoryName = masterCategoryName + subCategoryName;


### PR DESCRIPTION
GitHub Issue (if applicable): #1901 

Goal and Pace progress bars broke when the markup for both Master Categories and Subcategories changed.
