### PR TITLE
Enable Date Of Money and Date of Buffering as Default

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
     "ShowIntercom",
     "SplitKeyboardShortcut",
     "ToolkitReports",
-    "FilterCategories"
+    "FilterCategories",
+    "DateOfMoney",
+    "DaysOfBufferingDate"
   ],
   "husky": {
     "hooks": {

--- a/src/extension/features/budget/date-of-money/settings.js
+++ b/src/extension/features/budget/date-of-money/settings.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: 'DateOfMoney',
   type: 'checkbox',
-  default: false,
+  default: true,
   section: 'budget',
   title: 'Date Of Money',
   description:

--- a/src/extension/features/budget/days-of-buffering/settings.js
+++ b/src/extension/features/budget/days-of-buffering/settings.js
@@ -26,7 +26,7 @@ module.exports = [
   {
     name: 'DaysOfBufferingDate',
     type: 'checkbox',
-    default: false,
+    default: true,
     section: 'budget',
     title: 'Days Of Buffering Metric - Date',
     description:


### PR DESCRIPTION
Enable these features by default. They're relatively unobtrusive and this will improve feature discovery (I should have enabled as default in the first place!)

Note: Date of Buffering will only display once Days of Buffering has been enabled (as the div must be visible on the screen)
