### PR TITLE
issue-1920: Fix styling of budget-table-headers for budget row height

### DIFF
--- a/src/extension/features/budget/rows-height/compact.css
+++ b/src/extension/features/budget/rows-height/compact.css
@@ -1,5 +1,9 @@
 .budget-table-header {
-  height: 1.2rem !important;
+  height: auto !important;
+}
+
+.budget-table-header-labels {
+  height: 1.15rem !important;
 }
 
 .budget-table-cell-available-payment {

--- a/src/extension/features/budget/rows-height/slim-fonts.css
+++ b/src/extension/features/budget/rows-height/slim-fonts.css
@@ -1,4 +1,8 @@
 .budget-table-header {
+  height: auto !important;
+}
+
+.budget-table-header-labels {
   height: 1.3rem !important;
 }
 

--- a/src/extension/features/budget/rows-height/slim.css
+++ b/src/extension/features/budget/rows-height/slim.css
@@ -1,4 +1,8 @@
 .budget-table-header {
+  height: auto !important;
+}
+
+.budget-table-header-labels {
   height: 1.5rem !important;
 }
 


### PR DESCRIPTION
GitHub Issue (if applicable): #1920

**Explanation of Bugfix/Feature/Modification:**
YNAB changed up the dom for budget table headers.
