### PR TITLE
Move spending by payee to top of page

### DIFF
--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -179,7 +179,7 @@ export class SpendingByPayeeComponent extends React.Component {
       },
       title: {
         align: 'center',
-        verticalAlign: 'middle',
+        verticalAlign: 'top',
         text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>`,
       },
       series: [


### PR DESCRIPTION
GitHub Issue (if applicable): #1914 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Moved graph to top of page to fix display issues.
