### PR TITLE
Fix Rectify Difference button

### DIFF
--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -220,7 +220,7 @@ export class CheckCreditBalances extends Feature {
 
     $(debtPaymentCategories).each(function() {
       let accountName = $(this)
-        .find('.budget-table-cell-name div.button-truncate')
+        .find('.budget-table-cell-name div.button')
         .prop('title')
         .match(/.[^\n]*/)[0];
       if (accountName === name) {

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -5,6 +5,7 @@ import {
   isCurrentRouteBudgetPage,
 } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
+import { getEmberView } from 'toolkit/extension/utils/ember';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 
 export class CheckCreditBalances extends Feature {
@@ -218,12 +219,12 @@ export class CheckCreditBalances extends Feature {
     let difference = $(this).data('difference');
     let debtPaymentCategories = $('.is-debt-payment-category.is-sub-category');
 
-    $(debtPaymentCategories).each(function() {
-      let accountName = $(this)
-        .find('.budget-table-cell-name div.button')
-        .prop('title')
-        .match(/.[^\n]*/)[0];
-      if (accountName === name) {
+    $(debtPaymentCategories).each((_, el) => {
+      const { category } = getEmberView(el.id);
+      if (!category) {
+        return;
+      }
+      if (category.displayName === name) {
         let input = $(this)
           .find('.budget-table-cell-budgeted div.ynab-new-currency-input')
           .click()

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -225,19 +225,12 @@ export class CheckCreditBalances extends Feature {
         return;
       }
       if (category.displayName === name) {
-        let input = $(this)
+        let input = $(el)
           .find('.budget-table-cell-budgeted div.ynab-new-currency-input')
           .click()
           .find('input');
 
-        let oldValue = input.val();
-
-        // If nothing is budgeted, the input will be empty
-        oldValue = oldValue || 0;
-
-        // YNAB stores values *1000 for decimal places, so just
-        // multiple by 1000 to get the actual amount.
-        let newValue = ynab.unformat(oldValue) * 1000 + difference;
+        let newValue = category.budgeted + difference;
 
         // format the calculated value back to selected number format
         input.val(ynab.formatCurrency(newValue));


### PR DESCRIPTION
GitHub Issue (if applicable): #1924 

Trello Link (if applicable): `N/A`

**Explanation of Bugfix/Feature/Modification:**
It looks as if YNAB changed the button class here from `button-truncate` to just `button`.  Using `getEmberView` also helps clean up some logic.
