### PR TITLE
Bump node-sass version to 4.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "jest": "^24.9.0",
     "jest-dot-reporter": "^1.0.3",
     "jest-localstorage-mock": "^2.1.0",
-    "node-sass": "^4.9.3",
+    "node-sass": "^4.9.4",
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
     "sass-loader": "^8.0.0",


### PR DESCRIPTION
Solve an error message during "yarn install" on Windows when python3 is installed instead of python2:
python2 missing :
gyp verb check python checking for Python executable "python2" in the PATH
gyp verb `which` failed Error: not found: python2

python3 error:
gyp verb check python checking for Python executable "python" in the PATH
gyp verb `which` succeeded python C:\Python38\python.EXE
gyp ERR! configure error
gyp ERR! stack Error: Command failed: C:\Python38\python.EXE -c import sys; print "%s.%s.%s" % sys.version_info[:3];
gyp ERR! stack   File "<string>", line 1
gyp ERR! stack     import sys; print "%s.%s.%s" % sys.version_info[:3];

Simply change the version of node-sass from v4.9.3 to v4.9.4 solved the issue.

GitHub Issue (if applicable): #XXX

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
