### PR TITLE
Fix progress bar gap in category group

### DIFF
--- a/src/extension/features/budget/budget-progress-bars/index.css
+++ b/src/extension/features/budget/budget-progress-bars/index.css
@@ -9,13 +9,12 @@
 
 /* Fix position of head monthly progress indicator by moving the bg slightly to the right and making it shorter. Also move the text back */
 .budget-table-row.is-master-category .budget-table-cell-name {
-  margin-left: 0.5rem;
+  padding-left: 0.5rem;
   width: 39%;
 }
 .budget-table-cell-name-static-width {
   margin-left: -0.4rem;
 }
-
 
 .budget-table-row.is-checked,
 .budget-table-row.is-checked .budget-table-cell-name,


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
With a progress bar, there would be a slight gap in the category group header, as seen here

![image](https://user-images.githubusercontent.com/5141851/83966594-f09eda00-a86f-11ea-9ca1-22c0481bd07c.png)

Using padding fixes this as border will now extend over the padding as well. 

With progress bar off:
![image](https://user-images.githubusercontent.com/5141851/83966634-204de200-a870-11ea-9b96-311abdfccdae.png)

Goals progress
![image](https://user-images.githubusercontent.com/5141851/83966644-2e036780-a870-11ea-833a-e4e44f576d15.png)

Pacing progress
![image](https://user-images.githubusercontent.com/5141851/83966666-43789180-a870-11ea-8acf-a6cf31592414.png)

Pacing on name goals on progress
![image](https://user-images.githubusercontent.com/5141851/83966680-699e3180-a870-11ea-9a85-57c511b310e4.png)
