### PR TITLE
Fix toolkit-for-ynab/toolkit-for-ynab#1469

### DIFF
--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -133,7 +133,7 @@ ${l10n('budget.dob.avgOutflow', 'Average daily outflow')}: ~${formatCurrency(ave
     let averageDailyOutflow;
     let totalDays;
     if (this._lookbackDays !== 0) {
-      averageDailyOutflow = Math.abs(totalOutflow / this._lookbackDays);
+      averageDailyOutflow = Math.abs(totalOutflow / Math.min(this._lookbackDays, availableDates));
       totalDays = this._lookbackDays;
     } else {
       averageDailyOutflow = Math.abs(totalOutflow / availableDates);

--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -128,17 +128,12 @@ ${l10n('budget.dob.avgOutflow', 'Average daily outflow')}: ~${formatCurrency(ave
 
     const minDate = moment.min(dates);
     const maxDate = moment.max(dates);
-    const availableDates = maxDate.diff(minDate, 'days');
+    const availableDates =
+      this._lookbackDays !== 0
+        ? Math.min(this._lookbackDays, maxDate.diff(minDate, 'days'))
+        : maxDate.diff(minDate, 'days');
 
-    let averageDailyOutflow;
-    let totalDays;
-    if (this._lookbackDays !== 0) {
-      averageDailyOutflow = Math.abs(totalOutflow / Math.min(this._lookbackDays, availableDates));
-      totalDays = this._lookbackDays;
-    } else {
-      averageDailyOutflow = Math.abs(totalOutflow / availableDates);
-      totalDays = availableDates;
-    }
+    let averageDailyOutflow = Math.abs(totalOutflow / availableDates);
 
     let daysOfBuffering = balance / averageDailyOutflow;
     if (daysOfBuffering < 10) {
@@ -156,7 +151,7 @@ ${l10n('budget.dob.avgOutflow', 'Average daily outflow')}: ~${formatCurrency(ave
       averageDailyOutflow,
       daysOfBuffering,
       notEnoughDates,
-      totalDays,
+      availableDates,
       totalOutflow,
     };
   };


### PR DESCRIPTION
GitHub Issue: #1469 

**Explanation of Bugfix/Feature/Modification:**
Say I have only used YNAB for 50 days and in the settings I set the `Days of Buffering History Lookup` to 6 months. I think the correct behavior would be to use 50 days to calculate my `averageDailyOutflow ` instead of 180 days.