### PR TITLE
Fix collapse sidebar for 6/18/2020 release

### DIFF
--- a/src/extension/features/general/collapse-side-menu/index.css
+++ b/src/extension/features/general/collapse-side-menu/index.css
@@ -6,11 +6,6 @@
   width: 4.6rem;
 }
 
-.layout.collapsed .content,
-.layout.collapsed .budget-header {
-  left: 40px;
-}
-
 .layout.collapsed .content .scroll-wrap,
 .layout.collapsed .content .register-flex-columns {
   width: inherit;

--- a/src/extension/features/general/collapse-side-menu/index.js
+++ b/src/extension/features/general/collapse-side-menu/index.js
@@ -82,12 +82,6 @@ export class CollapseSideMenu extends Feature {
         $('.ynab-u.sidebar')
           .animate({ width: `${SIDEBAR_COLLAPSED_SIZE}` })
           .promise(),
-        $('.ynab-u.content')
-          .animate({ left: `${SIDEBAR_COLLAPSED_SIZE}` })
-          .promise(),
-        $('.budget-header')
-          .animate({ left: `${SIDEBAR_COLLAPSED_SIZE}` })
-          .promise(),
       ]).then(() => {
         $('.layout.user-logged-in').addClass('collapsed');
         $('.ynabtk-navlink-reports-link span').addClass('ynabtk-nav-link-collapsed');
@@ -108,12 +102,6 @@ export class CollapseSideMenu extends Feature {
       Promise.all([
         $('.ynab-u.sidebar')
           .animate({ width: '260px' })
-          .promise(),
-        $('.ynab-u.content')
-          .animate({ left: '260px' })
-          .promise(),
-        $('.budget-header')
-          .animate({ left: '260px' })
           .promise(),
       ]).then(() => {
         $('.layout.user-logged-in').removeClass('collapsed');


### PR DESCRIPTION
Hello! We have some layout and sidebar adjustments going out tomorrow June 18th, 2020 that will break the collapsible sidebar feature. The good news is the layout now more naturally flexes so these custom sizes will no longer be needed.

**Before**
![Screen Shot 2020-06-17 at 12 35 36 PM](https://user-images.githubusercontent.com/99604/84942012-1067a680-b097-11ea-97fc-b7ec7b5a6a5b.png)

**After**
![Screen Shot 2020-06-17 at 12 34 15 PM](https://user-images.githubusercontent.com/99604/84942034-18274b00-b097-11ea-9f65-c3d865390fae.png)

