### PR TITLE
Respond properly to themes for release modal

### DIFF
--- a/src/core/browser/content-scripts/init.js
+++ b/src/core/browser/content-scripts/init.js
@@ -51,7 +51,7 @@ function sendToolkitBootstrap(options) {
       type: 'ynab-toolkit-bootstrap',
       ynabToolKit: {
         assets: {
-          logo: browser.runtime.getURL('assets/images/logos/toolkitforynab-logo-400.png'),
+          logo: browser.runtime.getURL('assets/images/logos/toolkitforynab-logo-200.png'),
         },
         environment,
         extensionId: browser.runtime.id,

--- a/src/core/components/toolkit-release-modal/component.jsx
+++ b/src/core/components/toolkit-release-modal/component.jsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import './styles.scss';
+
+export function ToolkitReleaseModal({ onClose }) {
+  const { assets, name, version } = ynabToolKit;
+
+  return (
+    <div className="tk-release-modal">
+      <div className="tk-release-modal__logo">
+        <img src={assets.logo} />
+      </div>
+      <div className="tk-release-modal__content">
+        <h1 className="tk-release-modal__header">{name} has been updated!</h1>
+        <p className="tk-release-modal__message--centered">
+          You are now using version{' '}
+          <a
+            href="https://github.com/toolkit-for-ynab/toolkit-for-ynab/releases"
+            rel="noopener noreferrer"
+          >
+            {version}
+          </a>
+          .
+        </p>
+        <p className="tk-release-modal__message">
+          <strong>{name} is completely separate, and in no way affiliated with YNAB itself.</strong>{' '}
+          If you discover a bug, please disable the Toolkit to identify whether the issue is with
+          the extension or with YNAB itself and report the issue accordingly.
+        </p>
+        <p className="tk-release-modal__message">
+          Issues with {name} can be reported to the Toolkit team by submitting an issue on our{' '}
+          <a
+            href="https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub Issues
+          </a>{' '}
+          page. Please ensure the issue has not already been reported before submitting.
+        </p>
+        <p className="tk-release-modal__message">
+          Finally, if you have the time and the ability, new contributors to the Toolkit are always
+          welcome!
+        </p>
+      </div>
+      <div className="tk-release-modal__actions">
+        <button className="button button-primary" onClick={onClose}>
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}
+
+ToolkitReleaseModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/core/components/toolkit-release-modal/index.js
+++ b/src/core/components/toolkit-release-modal/index.js
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/core/components/toolkit-release-modal/styles.scss
+++ b/src/core/components/toolkit-release-modal/styles.scss
@@ -1,0 +1,30 @@
+.tk-release-modal {
+  background-color: var(--tk-default-background-color);
+  color: var(--tk-default-font-color);
+  border-radius: 10px;
+  width: 60%;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+
+  &__logo {
+    text-align: center;
+  }
+
+  &__header {
+    font-size: 1.5rem;
+    text-align: center;
+  }
+
+  &__message {
+    line-height: 1.75rem;
+
+    &--centered {
+      text-align: center;
+    }
+  }
+
+  &__actions {
+    text-align: center;
+  }
+}

--- a/src/extension/legacy/features/shared/main.js
+++ b/src/extension/legacy/features/shared/main.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-nested-ternary, one-var-declaration-per-line, one-var */
 
 ynabToolKit.shared = (function() {
-  let storageKeyPrefix = 'ynab-toolkit-';
   return {
     parseSelectedMonth() {
       // TODO: There's probably a better way to reference this view, but this works better than DOM scraping which seems to fail in Firefox
@@ -21,96 +20,6 @@ ynabToolKit.shared = (function() {
 
     getEmberViewRegistry() {
       return __ynabapp__.__container__.lookup('-view-registry:main');
-    },
-
-    showNewReleaseModal() {
-      const { assets, environment, name, version } = ynabToolKit;
-      // beta concatenates the TRAVIS_BUILD_NUMBER so we do this to strip it for
-      // the URL that points to diffs on master for beta/development builds
-      const githubVersion = version
-        .split('.')
-        .slice(0, 3)
-        .join('.');
-      const githubIssuesLink =
-        '<a href="https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues" target="_blank">GitHub Issues</a>';
-
-      const releaseNotes =
-        ynabToolKit.environment === 'production'
-          ? 'View the <a href="https://github.com/toolkit-for-ynab/toolkit-for-ynab/releases" target="_blank">release notes</a>.'
-          : `<br><br><div class="message">(Release notes are currently only available for production releases. However,
-        ${githubIssuesLink} should be tagged with "beta" if they have made it into the beta build. It may also be helpful
-        to see what changed by checking the raw commit log: <a href="https://github.com/toolkit-for-ynab/toolkit-for-ynab/compare/v${githubVersion}...master" target="_blank">here</a>.)
-        </div>`;
-
-      const $modal = $(
-        `<div class="toolkit-modal">
-                      <div class="toolkit-modal-outer"><div class="toolkit-modal-inner"><div class="toolkit-modal-content">
-
-                        <header class="toolkit-modal-header">
-                          <img src="` +
-          assets.logo +
-          `" id="toolkit-modal-logo" />
-                        </header>
-
-                        <div class="toolkit-modal-message">
-                          <h1>The ${name} extension has been updated!</h1>
-                          <span class="version">
-                            You are now using version ${version}. ${releaseNotes}
-                          </span>
-                          <div class="message">
-                            <p>
-                              <strong>It is important to note that the ${name} extension is completely separate,
-                              and in no way affiliated with YNAB itself.</strong> If you discover a bug, please first disable
-                              the Toolkit to identify whether the issue is with the extension, or with YNAB itself.
-                            </p>
-                            <p>
-                              Issues with ${name} can be reported to the Toolkit team by submitting an issue on our
-                              ${githubIssuesLink} page. Please ensure the issue has not already been reported before
-                              submitting${
-                                environment !== 'production'
-                                  ? ' and mark issue titles with [BETA].'
-                                  : '.'
-                              }
-                            </p>
-                            <p>
-                              Finally, if you have the time and the ability, new contributors to the Toolkit are always welcome!
-                            </p>
-                          </div>
-                        </div>
-
-                        <footer class="toolkit-modal-actions">
-                          <button class="toolkit-modal-action-close">Continue</button>
-                        </footer>
-
-                      </div></div></div>
-                    </div>`
-      );
-
-      $('.toolkit-modal-action-close', $modal).on('click', () => {
-        $('.layout .toolkit-modal').remove();
-      });
-
-      if (!$('.modal-error').length) {
-        $('.layout').append($modal);
-      }
-    },
-
-    getToolkitStorageKey(key) {
-      const value = localStorage.getItem(storageKeyPrefix + key);
-
-      try {
-        return JSON.parse(value);
-      } catch (e) {
-        return value;
-      }
-    },
-
-    setToolkitStorageKey(key, value) {
-      return localStorage.setItem(storageKeyPrefix + key, value);
-    },
-
-    removeToolkitStorageKey(key, value) {
-      return localStorage.removeItem(storageKeyPrefix + key, value);
     },
 
     monthsShort: [
@@ -160,23 +69,6 @@ ynabToolKit.shared = (function() {
 
   if (isYNABReady()) {
     ynabToolKit.pageReady = true;
-
-    const latestVersionKey = `latest-version-${ynabToolKit.environment}`;
-    let latestVersion = ynabToolKit.shared.getToolkitStorageKey(latestVersionKey);
-    if (latestVersion) {
-      if (latestVersion !== ynabToolKit.version) {
-        ynabToolKit.shared.showNewReleaseModal();
-        ynabToolKit.shared.setToolkitStorageKey(latestVersionKey, ynabToolKit.version);
-      }
-    } else {
-      ynabToolKit.shared.setToolkitStorageKey(latestVersionKey, ynabToolKit.version);
-    }
-
-    const deprecatedLatestVersion = ynabToolKit.shared.getToolkitStorageKey('latest-version');
-    if (deprecatedLatestVersion && deprecatedLatestVersion !== ynabToolKit.version) {
-      ynabToolKit.shared.removeToolkitStorageKey('latest-version');
-      ynabToolKit.shared.showNewReleaseModal();
-    }
   } else if (typeof Ember !== 'undefined') {
     Ember.run.next(poll, 250);
   } else {

--- a/src/extension/utils/helpers.js
+++ b/src/extension/utils/helpers.js
@@ -6,3 +6,32 @@ export function mapToArray(map) {
 
   return array;
 }
+
+export function compareSemanticVersion(left, right) {
+  const leftSplit = left.split('.').map(val => parseInt(val, 10));
+  const rightSplit = right.split('.').map(val => parseInt(val, 10));
+
+  while (leftSplit.length < rightSplit.length) {
+    leftSplit.push(0);
+  }
+
+  while (rightSplit.length < leftSplit.length) {
+    rightSplit.push(0);
+  }
+
+  for (let x = 0; x < leftSplit.length; x++) {
+    if (leftSplit[x] === rightSplit[x]) {
+      continue; // eslint-disable-line no-continue
+    }
+
+    if (leftSplit[x] > rightSplit[x]) {
+      return 1;
+    }
+
+    if (leftSplit[x] < rightSplit[x]) {
+      return -1;
+    }
+  }
+
+  return 0;
+}

--- a/src/extension/utils/helpers.test.js
+++ b/src/extension/utils/helpers.test.js
@@ -1,0 +1,22 @@
+const { compareSemanticVersion } = require('./helpers');
+
+describe('compareSemanticVersion', () => {
+  it('true if the right version is greater than the left', () => {
+    expect(compareSemanticVersion('1.0.0', '1.0.1')).toEqual(true);
+    expect(compareSemanticVersion('1.0.0', '1.2.0')).toEqual(true);
+    expect(compareSemanticVersion('1.0.0', '2.0.0')).toEqual(true);
+    expect(compareSemanticVersion('1.0.0', '1.0.0.1001')).toEqual(true);
+    expect(compareSemanticVersion('1.0.0', '10.0.0')).toEqual(true);
+    expect(compareSemanticVersion('1.1.0', '1.10.0')).toEqual(true);
+  });
+
+  it('returns false if the right is equal to left', () => {
+    expect(compareSemanticVersion('2.0.0', '2.0.0')).toEqual(false);
+    expect(compareSemanticVersion('1.0.1', '1.0.1')).toEqual(false);
+  });
+
+  it('returns false if right is less than left', () => {
+    expect(compareSemanticVersion('2.0.0', '1.0.0')).toEqual(false);
+    expect(compareSemanticVersion('1.3.1', '1.2.1')).toEqual(false);
+  });
+});

--- a/src/extension/ynab-toolkit.css
+++ b/src/extension/ynab-toolkit.css
@@ -1,10 +1,20 @@
-/* global reusable colors */
-:root {
-  --tk-color-black: #000000;
-  --tk-color-gray: #cfd5d8;
-  --tk-color-positive: #16a336;
-  --tk-color-positive--hover: #138b2e;
-  --tk-color-white: #ffffff;
+body,
+body.theme-new-default {
+  --tk-modal-backdrop: rgba(99, 99, 99, 0.5);
+  --tk-default-background-color: #ffffff;
+  --tk-default-font-color: #000000;
+}
+
+body.theme-classic {
+  --tk-modal-backdrop: rgba(99, 99, 99, 0.5);
+  --tk-default-background-color: #ffffff;
+  --tk-default-font-color: #000000;
+}
+
+body.theme-dark {
+  --tk-modal-backdrop: rgba(99, 99, 99, 0.5);
+  --tk-default-background-color: #909090;
+  --tk-default-font-color: #000000;
 }
 
 .tk-navlink i {
@@ -15,4 +25,17 @@
 .budget-toolbar {
   padding: 0px 10px;
   align-items: center;
+}
+
+#tk-modal-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  background-color: var(--tk-modal-backdrop);
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #1933

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Updates the release modal to be readable when dark theme is selected.
