### PR TITLE
Respond properly to themes for striped rows

### DIFF
--- a/src/extension/features/accounts/striped-rows/index.css
+++ b/src/extension/features/accounts/striped-rows/index.css
@@ -1,4 +1,14 @@
-/* Maybe this should play better with reconciled rows that don't have a background-color */
-.ynab-grid .ynab-grid-body-row:nth-of-type(even):not(.is-scheduled):not(.is-checked):not(.is-editing):not(.ynab-grid-body-empty):not(.ynab-grid-actions) {
-	background-color: #fafafa;
+body,
+body.theme-new-default,
+body.theme-classic {
+  --tk-striped-transaction-row-color: #fafafa;
+}
+
+body.theme-dark {
+  --tk-striped-transaction-row-color: #1e1e1f;
+}
+
+.ynab-grid
+  .ynab-grid-body-row:nth-of-type(even):not(.is-scheduled):not(.is-checked):not(.is-editing):not(.ynab-grid-body-empty):not(.ynab-grid-actions) {
+  background-color: var(--tk-striped-transaction-row-color);
 }

--- a/src/extension/features/budget/striped-budget-rows/index.css
+++ b/src/extension/features/budget/striped-budget-rows/index.css
@@ -1,3 +1,13 @@
+body,
+body.theme-new-default,
+body.theme-classic {
+  --tk-striped-budget-row-color: #fafafa;
+}
+
+body.theme-dark {
+  --tk-striped-budget-row-color: #2b2b2d;
+}
+
 .budget-table-row.is-sub-category:nth-of-type(even):not(.is-checked):not(.is-editing):not(.ynab-grid-body-empty):not(.ynab-grid-actions) {
-  background-color: #fafafa;
+  background-color: var(--tk-striped-budget-row-color);
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #1933

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Adds support for the dark theme (other themes look fine).
