### PR TITLE
Fixes privacy mode toggle and toolkit report button on new sidebar

### DIFF
--- a/src/extension/features/general/privacy-mode/index.css
+++ b/src/extension/features/general/privacy-mode/index.css
@@ -1,47 +1,47 @@
-.toolkit-privacyMode .currency,          /* global .currency handler */
-.toolkit-privacyMode .button-prefs-user  /* user e-mail */
-{
+.tk-privacy-mode .currency,          /* global .currency handler */
+.tk-privacy-mode .button-prefs-user  /* user e-mail */
+ {
   filter: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg"><filter id="filter"><feGaussianBlur stdDeviation="3" /></filter></svg>#filter');
   -webkit-filter: blur(10px);
   filter: blur(10px);
 }
 
-.toolkit-privacyMode *:hover > .currency,            /* global .currency handler */
-.toolkit-privacyMode *:hover > * > .currency,        /* global .currency handler */
-.toolkit-privacyMode .currency:hover,                /* global .currency handler */
-.toolkit-privacyMode .button-prefs-user:hover,       /* user e-mail */
-.toolkit-privacyMode .c3-tooltip-container .currency /* ynab report tooltips */
-{
+.tk-privacy-mode *:hover > .currency,            /* global .currency handler */
+.tk-privacy-mode *:hover > * > .currency,        /* global .currency handler */
+.tk-privacy-mode .currency:hover,                /* global .currency handler */
+.tk-privacy-mode .button-prefs-user:hover,       /* user e-mail */
+.tk-privacy-mode .c3-tooltip-container .currency /* ynab report tooltips */
+ {
   -webkit-filter: initial;
   filter: initial;
 }
 
 /* YNAB Reports don't use .currency class so we gotta do special stuff for those. */
-.toolkit-privacyMode .c3-chart-arcs .c3-chart-arcs-title tspan:last-child,
-.toolkit-privacyMode .c3-axis-y text tspan {
+.tk-privacy-mode .c3-chart-arcs .c3-chart-arcs-title tspan:last-child,
+.tk-privacy-mode .c3-axis-y text tspan {
   fill: #ffffff !important;
   color: #ffffff !important;
 }
 
-.toolkit-privacyMode .c3-chart-arcs .c3-chart-arcs-title:hover tspan:last-child,
-.toolkit-privacyMode .c3-axis-y:hover text tspan {
+.tk-privacy-mode .c3-chart-arcs .c3-chart-arcs-title:hover tspan:last-child,
+.tk-privacy-mode .c3-axis-y:hover text tspan {
   color: #0d233a !important;
   fill: #0d233a !important;
 }
 
 /* Higcharts doesn't seem to like `filters` so we need to special stuff for those too */
-.toolkit-privacyMode .highcharts-yaxis-labels text tspan,          /* net-worth */
-.toolkit-privacyMode .highcharts-title tspan:last-child,           /* spending */
-.toolkit-privacyMode .highcharts-data-labels text tspan:last-child /* spending */
-{
+.tk-privacy-mode .highcharts-yaxis-labels text tspan,          /* net-worth */
+.tk-privacy-mode .highcharts-title tspan:last-child,           /* spending */
+.tk-privacy-mode .highcharts-data-labels text tspan:last-child /* spending */
+ {
   fill: #ffffff !important;
   color: #ffffff !important;
 }
 
-.toolkit-privacyMode .highcharts-yaxis-labels:hover text tspan,          /* net-worth */
-.toolkit-privacyMode .highcharts-title:hover tspan:last-child,           /* spending */
-.toolkit-privacyMode .highcharts-data-labels text:hover tspan:last-child /* spending */
-{
+.tk-privacy-mode .highcharts-yaxis-labels:hover text tspan,          /* net-worth */
+.tk-privacy-mode .highcharts-title:hover tspan:last-child,           /* spending */
+.tk-privacy-mode .highcharts-data-labels text:hover tspan:last-child /* spending */
+ {
   fill: #606060 !important;
   color: #606060 !important;
 }

--- a/src/extension/features/general/privacy-mode/index.js
+++ b/src/extension/features/general/privacy-mode/index.js
@@ -22,21 +22,28 @@ export class PrivacyMode extends Feature {
   }
 
   invoke() {
+    const self = this;
     let toggle = getToolkitStorageKey('privacy-mode');
     if (typeof toggle === 'undefined') {
       setToolkitStorageKey('privacy-mode', false);
     }
 
     if (ynabToolKit.options.PrivacyMode === Settings.Toggle) {
-      if (!$('#toolkit-togglePrivacy').length) {
-        $('nav.sidebar.logged-in .sidebar-contents').after(
-          '<button id="toolkit-togglePrivacy"><i class="ember-view flaticon stroke lock-1"></i></button>'
+      if (!$('#tk-toggle-privacy').length) {
+        $('.sidebar-bottom').prepend(
+          $('<button>', {
+            id: 'tk-toggle-privacy',
+            class: 'tk-toggle-privacy',
+          })
+            .append(
+              $('<i>', {
+                class: 'tk-toggle-privacy__icon flaticon stroke lock-1',
+              })
+            )
+            .click(() => {
+              self.togglePrivacyMode();
+            })
         );
-
-        let parent = this;
-        $('body').on('click', 'button#toolkit-togglePrivacy', function() {
-          parent.togglePrivacyMode();
-        });
       }
     } else if (ynabToolKit.options.PrivacyMode === Settings.AlwaysOn) {
       setToolkitStorageKey('privacy-mode', true);
@@ -46,7 +53,7 @@ export class PrivacyMode extends Feature {
   }
 
   togglePrivacyMode() {
-    $('button#toolkit-togglePrivacy').toggleClass('active');
+    $('#tk-toggle-privacy').toggleClass('active');
 
     let toggle = getToolkitStorageKey('privacy-mode');
     setToolkitStorageKey('privacy-mode', !toggle);
@@ -57,13 +64,13 @@ export class PrivacyMode extends Feature {
     let toggle = getToolkitStorageKey('privacy-mode');
 
     if (toggle) {
-      $('body').addClass('toolkit-privacyMode');
-      $('#toolkit-togglePrivacy i')
+      $('body').addClass('tk-privacyMode');
+      $('#tk-toggle-privacy i')
         .removeClass('unlock-1')
         .addClass('lock-1');
     } else {
-      $('body').removeClass('toolkit-privacyMode');
-      $('#toolkit-togglePrivacy i')
+      $('body').removeClass('tk-privacyMode');
+      $('#tk-toggle-privacy i')
         .removeClass('lock-1')
         .addClass('unlock-1');
     }

--- a/src/extension/features/general/privacy-mode/toggle.css
+++ b/src/extension/features/general/privacy-mode/toggle.css
@@ -1,15 +1,21 @@
 .collapsed-buttons {
-	margin-top: 42px;
+  margin-top: 42px;
 }
 
-#toolkit-togglePrivacy {
-  color: #bee6ef;
-  top: 12px;
-  right: 32px;
-  position: absolute;
-  padding: 10px;
+.tk-toggle-privacy {
+  color: var(--sidebar_text_default);
+  padding: 1rem;
 }
 
-#toolkit-togglePrivacy.active {
-	color: #fff;
+.tk-toggle-privacy__icon {
+  font-size: 1rem;
+}
+
+.sidebar.sidebar-resized-collapsed .sidebar-bottom {
+  height: auto;
+  flex-direction: column;
+}
+
+.sidebar.sidebar-resized-collapsed .sidebar-bottom .tk-toggle-privacy {
+  padding: 0.5rem;
 }

--- a/src/extension/features/toolkit-reports/index.js
+++ b/src/extension/features/toolkit-reports/index.js
@@ -41,7 +41,11 @@ export class ToolkitReports extends Feature {
       }).append(
         $('<a>', { class: 'tk-navlink' })
           .append($('<i>', { class: 'flaticon stroke document-4' }))
-          .append($('<div>').text(l10n('toolkit.reports') || 'Toolkit Reports'))
+          .append(
+            $('<div>', { class: 'tk-navlink__label' }).text(
+              l10n('toolkit.reports') || 'Toolkit Reports'
+            )
+          )
       );
 
       $('.nav-main > li:eq(1)').after(toolkitReportsLink);

--- a/src/extension/ynab-toolkit.css
+++ b/src/extension/ynab-toolkit.css
@@ -22,6 +22,15 @@ body.theme-dark {
   padding-left: 20px;
 }
 
+.sidebar.sidebar-resized-collapsed .tk-navlink__label {
+  display: none;
+}
+
+.sidebar.sidebar-resized-collapsed .tk-navlink i {
+  margin-right: 0px;
+  padding-left: 0px;
+}
+
 .budget-toolbar {
   padding: 0px 10px;
   align-items: center;


### PR DESCRIPTION
GitHub Issue (if applicable): #1959 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Moves privacy mode toggle into the `sidebar-bottom` container, adds some changes to the toolkit reports navlink to prepare for YNAB's collapsible sidebar.
