### PR TITLE
Update hide-referral-banner

### DIFF
--- a/src/extension/features/general/hide-referral-banner/index.css
+++ b/src/extension/features/general/hide-referral-banner/index.css
@@ -1,3 +1,3 @@
-div.referral-program {
+div.sidebar-bottom {
   display: none !important;
 }


### PR DESCRIPTION
Hide sidebar-bottom instead of referral-program.

**Explanation of Bugfix/Feature/Modification:**
The "referral-program" div is in a "sidebar-bottom" div that create the space for the the referral banner at the bottom of the sidebar.
Hide the bottom-sidebar instead of the referral-program to gain some space.
[NOT TESTED] (I can't test for the moment)
