### PR TITLE
Fix Privacy Mode body class

### DIFF
--- a/src/extension/features/general/privacy-mode/index.js
+++ b/src/extension/features/general/privacy-mode/index.js
@@ -64,12 +64,12 @@ export class PrivacyMode extends Feature {
     let toggle = getToolkitStorageKey('privacy-mode');
 
     if (toggle) {
-      $('body').addClass('tk-privacyMode');
+      $('body').addClass('tk-privacy-mode');
       $('#tk-toggle-privacy i')
         .removeClass('unlock-1')
         .addClass('lock-1');
     } else {
-      $('body').removeClass('tk-privacyMode');
+      $('body').removeClass('tk-privacy-mode');
       $('#tk-toggle-privacy i')
         .removeClass('lock-1')
         .addClass('unlock-1');


### PR DESCRIPTION
In 02a00f738a60e7e6563cc210d9f09858d419b484 , class name was changed in CSS to `tk-privacy-mode`, but JS was updated to add `tk-privacyMode` class.

Fixes #1959
