### PR TITLE
Fixed that 'Total days of budgeting' is shown as undefined after #1936

### DIFF
--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -47,7 +47,7 @@ export class DaysOfBuffering extends Feature {
   }
 
   _updateDisplay(calculation) {
-    const { averageDailyOutflow, daysOfBuffering, totalDays, totalOutflow } = calculation;
+    const { averageDailyOutflow, daysOfBuffering, availableDates, totalOutflow } = calculation;
     const daysOfBufferingContainer = document.querySelector('.toolkit-days-of-buffering');
     let $displayElement = $(daysOfBufferingContainer);
     if (!daysOfBufferingContainer) {
@@ -89,7 +89,7 @@ export class DaysOfBuffering extends Feature {
       $('.budget-header-days-age', $displayElement).attr(
         'title',
         `${l10n('budget.dob.outflow', 'Total outflow')}: ${formatCurrency(totalOutflow)}
-${l10n('budget.dob.days', 'Total days of budgeting')}: ${totalDays}
+${l10n('budget.dob.days', 'Total days of budgeting')}: ${availableDates}
 ${l10n('budget.dob.avgOutflow', 'Average daily outflow')}: ~${formatCurrency(averageDailyOutflow)}`
       );
 


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
After #1936 is merged, the tooltip ___Total days of budgeting___ is showing `undefined` as the name of the field changed.
This PR is to fix that.

---

Besides that, I think the tooltip ___Total outflow___ and ___Total days of budgeting___ are inaccurate descriptions of what it actually is. However that's up to you to decide and I will not include it in this PR. 
