### PR TITLE
Update Toolkit Reports not showing

### DIFF
--- a/src/extension/features/toolkit-reports/index.js
+++ b/src/extension/features/toolkit-reports/index.js
@@ -81,7 +81,7 @@ export class ToolkitReports extends Feature {
       .first()
       .show();
 
-    // Display the toolkit's report
+    // Unmount and hide the toolkit's report
     const container = document.getElementById(TOOLKIT_REPORTS_CONTAINER_ID);
     if (container) {
       ReactDOM.unmountComponentAtNode(container);

--- a/src/extension/features/toolkit-reports/index.js
+++ b/src/extension/features/toolkit-reports/index.js
@@ -9,8 +9,10 @@ const TOOLKIT_REPORTS_CONTAINER_ID = 'toolkit-reports';
 const TOOLKIT_REPORTS_NAVLINK_CLASS = 'tk-react-reports-link';
 const TOOLKIT_REPORTS_NAVLINK_SELECTOR = `.${TOOLKIT_REPORTS_NAVLINK_CLASS}`;
 
+// Note: YNAB_CONTENT_CONTAINER SELECTOR will contain two elements when this is rendered
+//       The current nav's report and then a element containing toolkit reports
+//       When toolkit reports is selected, show the toolkit report element and hide the current ynabs element
 const YNAB_CONTENT_CONTAINER_SELECTOR = '.ynab-u.content';
-const YNAB_APPLICATION_CONTENT_SELECTOR = `${YNAB_CONTENT_CONTAINER_SELECTOR} .scroll-wrap,.register-flex-columns`;
 const YNAB_NAVLINK_CLASSES = ['navlink-budget', 'navlink-accounts', 'navlink-reports'];
 const YNAB_NAVLINK_SELECTOR = `.${YNAB_NAVLINK_CLASSES.join(', .')}`;
 const YNAB_NAVACCOUNT_CLASS = 'nav-account-row';
@@ -72,13 +74,20 @@ export class ToolkitReports extends Feature {
 
   _removeToolkitReports(event) {
     $(TOOLKIT_REPORTS_NAVLINK_SELECTOR).removeClass('active');
-    $(YNAB_APPLICATION_CONTENT_SELECTOR).show();
 
+    // Show the current ynab report
+    $(YNAB_CONTENT_CONTAINER_SELECTOR)
+      .children()
+      .first()
+      .show();
+
+    // Display the toolkit's report
     const container = document.getElementById(TOOLKIT_REPORTS_CONTAINER_ID);
     if (container) {
       ReactDOM.unmountComponentAtNode(container);
     }
 
+    // Update the nav with the active indicator
     const $currentTarget = $(event.currentTarget);
     if (YNAB_NAVLINK_CLASSES.some(className => $currentTarget.hasClass(className))) {
       $currentTarget.addClass('active');
@@ -89,8 +98,13 @@ export class ToolkitReports extends Feature {
 
   _renderToolkitReports() {
     setTimeout(() => {
-      $(YNAB_APPLICATION_CONTENT_SELECTOR).hide();
+      // Hide the ynab report
+      $(YNAB_CONTENT_CONTAINER_SELECTOR)
+        .children()
+        .first()
+        .hide();
 
+      // Display the toolkit's report
       const container = document.getElementById(TOOLKIT_REPORTS_CONTAINER_ID);
       if (container) {
         ReactDOM.render(React.createElement(Root), container);


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2023
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2020
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2017

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.

There was an update to some of the css selectors in ynabs container that displayed the body when on specific nav links.
From any accounts or the 'All Accounts', we were able to hide the current container, but on others, there was no matching one and so we couldn't hide.

Instead of grabbing a specific selector to find the child element of the container. We'll just grab the first div which indicates the current ynab report.

```
container (.ynab-u.content)
   - ynab report
   - toolkit report
```

Then on update, we'll show and hide the corresponding div accordingly.

