### PR TITLE
Use YNAB's header variable for progress bar colors

### DIFF
--- a/src/extension/features/budget/budget-progress-bars/index.css
+++ b/src/extension/features/budget/budget-progress-bars/index.css
@@ -1,10 +1,18 @@
-:root {
+body.theme-new-default,
+body.theme-dark,
+body.theme-classic {
+  --tk-color-progress-bar-pacing-master-spacing: var(--table_header_background_default),
+}
+body:not(.theme-dark, .theme-new-default, .theme-classic) {
+  --tk-color-progress-bar-pacing-master-spacing: rgb(229, 245, 249);
+}
+
+body {
   --tk-color-progress-bar-goal: rgba(22, 163, 54, 0.3);
   --tk-color-progress-bar-goal-spacing: rgba(0, 0, 0, 0);
   --tk-color-progress-bar-pacing: rgb(192, 226, 233);
   --tk-color-progress-bar-pacing-month-progress-indicator: rgb(207, 213, 216);
   --tk-color-progress-bar-pacing-spacing: rgba(0, 0, 0, 0);
-  --tk-color-progress-bar-pacing-master-spacing: rgb(229, 245, 249);
 }
 
 /* Fix position of head monthly progress indicator by moving the bg slightly to the right and making it shorter. Also move the text back */

--- a/src/extension/features/budget/budget-progress-bars/index.css
+++ b/src/extension/features/budget/budget-progress-bars/index.css
@@ -1,18 +1,10 @@
-body.theme-new-default,
-body.theme-dark,
-body.theme-classic {
-  --tk-color-progress-bar-pacing-master-spacing: var(--table_header_background_default),
-}
-body:not(.theme-dark, .theme-new-default, .theme-classic) {
-  --tk-color-progress-bar-pacing-master-spacing: rgb(229, 245, 249);
-}
-
-body {
+:root {
   --tk-color-progress-bar-goal: rgba(22, 163, 54, 0.3);
   --tk-color-progress-bar-goal-spacing: rgba(0, 0, 0, 0);
   --tk-color-progress-bar-pacing: rgb(192, 226, 233);
   --tk-color-progress-bar-pacing-month-progress-indicator: rgb(207, 213, 216);
   --tk-color-progress-bar-pacing-spacing: rgba(0, 0, 0, 0);
+  --tk-color-progress-bar-pacing-master-spacing: var(--table_header_background_default);
 }
 
 /* Fix position of head monthly progress indicator by moving the bg slightly to the right and making it shorter. Also move the text back */


### PR DESCRIPTION
GitHub Issue (if applicable): #2039

**Explanation of Bugfix/Feature/Modification:**
The new YNAB theme engine exposes variables for the application colors, including the budget category headers. This changes the color from a static color (the classic theme's rgb value), to the CSS var.

The existing color looks _ok_ on the classic and new themes, but in the dark theme the category header becomes unreadable.

I think that colors for the category progress should change based on the theme too, but I don't know how the initial colorings were settled upon.
