### PR TITLE
fix: use ynab-new-icon class for edit context menu icons

### DIFF
--- a/src/extension/features/accounts/bulk-manage-payees/index.js
+++ b/src/extension/features/accounts/bulk-manage-payees/index.js
@@ -25,7 +25,7 @@ export class BulkManagePayees extends Feature {
     $('.modal-account-edit-transaction-move').before(
       $(`<li>
             <button class="toolkit-modal-select-budget-manage-payees">
-            <i class="ember-view flaticon stroke group"><!----></i>${menuText}
+            <i class="ynab-new-icon ember-view flaticon stroke group"><!----></i>${menuText}
             </button>
           </li>
           <li><hr /><li>`).click(() => {

--- a/src/extension/features/accounts/clear-selection/index.js
+++ b/src/extension/features/accounts/clear-selection/index.js
@@ -39,7 +39,7 @@ export class ClearSelection extends Feature {
     $('.modal-account-edit-transaction-list .modal-list').prepend(
       $(`<li>
             <button class="button-list ynab-toolkit-clear-selection">
-              <i class="flaticon stroke minus-2"></i>${menuText}
+              <i class="ynab-new-icon flaticon stroke minus-2"></i>${menuText}
             </button>
           </li>
           <li><hr /><li>`).click(() => {

--- a/src/extension/features/accounts/set-multiple-flags/index.css
+++ b/src/extension/features/accounts/set-multiple-flags/index.css
@@ -1,7 +1,3 @@
-.tk-multi-flags__icon {
-  margin: 0 .5em;
-}
-
 .tk-multi-flags__button {
   display: flex;
   align-items: center;

--- a/src/extension/features/accounts/set-multiple-flags/index.js
+++ b/src/extension/features/accounts/set-multiple-flags/index.js
@@ -54,7 +54,7 @@ export class SetMultipleFlags extends Feature {
           $(`
         <li id="tk-add-flags">
           <button class="button-list tk-multi-flags__button">
-            <svg class="ynab-flag ynab-flag-header tk-multi-flags__icon">
+            <svg class="ynab-flag ynab-flag-header ynab-new-icon">
               <g>
                 <path d="M 0,4 16,4 12,9 16,14 0,14 z"></path>
               </g>
@@ -73,7 +73,7 @@ export class SetMultipleFlags extends Feature {
           <button class="button-list tk-multi-flags__button ${
             !this._isAnyCheckedTransactionFlagged ? 'button-disabled' : ''
           }">
-            <svg class="ynab-flag ynab-flag-none tk-multi-flags__icon">
+            <svg class="ynab-flag ynab-flag-none ynab-new-icon">
               <g>
                 <path d="M 0,4 16,4 12,9 16,14 0,14 z"></path>
               </g>


### PR DESCRIPTION
GitHub Issue (if applicable): #2007

**Explanation of Bugfix/Feature/Modification:**
The styling of the edit menu has changed, just using the same class on our icons that ynab uses on theirs.
