### PR TITLE
Use isImmediateIncomeCategory instead of removed isIncomeCategory

### DIFF
--- a/src/extension/features/budget/income-from-last-month/index.js
+++ b/src/extension/features/budget/income-from-last-month/index.js
@@ -37,7 +37,7 @@ export class IncomeFromLastMonth extends Feature {
           return reduced;
         }
 
-        if (transactionSubCategory.isIncomeCategory()) {
+        if (transactionSubCategory.isImmediateIncomeCategory()) {
           return reduced + transactionAmount;
         }
         if (isSplit) {
@@ -50,7 +50,7 @@ export class IncomeFromLastMonth extends Feature {
               return;
             }
 
-            if (subTransactionSubCategory.isIncomeCategory()) {
+            if (subTransactionSubCategory.isImmediateIncomeCategory()) {
               subTransactionIncomes += subTransactionAmount;
             }
           });

--- a/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
@@ -131,7 +131,7 @@ export class IncomeBreakdownComponent extends React.Component {
         return;
       }
 
-      if (transactionSubCategory.isIncomeCategory()) {
+      if (transactionSubCategory.isImmediateIncomeCategory()) {
         const transactionPayeeId =
           transaction.get('payeeId') || transaction.get('parentTransaction.payeeId');
         if (!transactionPayeeId) {

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/component.jsx
@@ -161,7 +161,7 @@ export class IncomeVsExpenseComponent extends React.Component {
         return;
       }
 
-      if (transactionSubCategory.isIncomeCategory()) {
+      if (transactionSubCategory.isImmediateIncomeCategory()) {
         const transactionPayeeId =
           transaction.get('payeeId') || transaction.get('parentTransaction.payeeId');
         if (!transactionPayeeId) {

--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -82,7 +82,7 @@ export class SpendingByCategoryComponent extends React.Component {
       const transactionSubCategory = this._subCategoriesCollection.findItemByEntityId(
         transactionSubCategoryId
       );
-      if (!transactionSubCategory || transactionSubCategory.isIncomeCategory()) {
+      if (!transactionSubCategory || transactionSubCategory.isImmediateIncomeCategory()) {
         return;
       }
 

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -68,7 +68,7 @@ export class SpendingByPayeeComponent extends React.Component {
       const transactionSubCategory = this._subCategoriesCollection.findItemByEntityId(
         transactionSubCategoryId
       );
-      if (!transactionSubCategory || transactionSubCategory.isIncomeCategory()) {
+      if (!transactionSubCategory || transactionSubCategory.isImmediateIncomeCategory()) {
         return;
       }
 


### PR DESCRIPTION
We noticed a new error after the last deploy: `TypeError: transactionSubCategory.isIncomeCategory is not a function`

That method has been removed in favor of using `isImmediateIncomeCategory()` instead.