### PR TITLE
Resolves #2080 (description of the location of the privacy lock)

### DIFF
--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -66,7 +66,7 @@ Changes print styles so budget and account sections can be easily printed. Due t
 
 ## Privacy Mode
 
-Obscures dollar amounts everywhere until hovered. In toggle mode, a lock icon will appear to the right of your budget name in the top left corner of YNAB. Click to enable or disable privacy mode.
+Obscures dollar amounts everywhere until hovered. In toggle mode, a lock icon will appear in the lower left corner of YNAB. Click to enable or disable privacy mode.
 
 ## Show Import Notifications in Navigation Sidebar
 

--- a/src/extension/features/general/privacy-mode/settings.js
+++ b/src/extension/features/general/privacy-mode/settings.js
@@ -5,7 +5,7 @@ module.exports = {
   section: 'general',
   title: 'Privacy Mode',
   description:
-    'Obscures dollar amounts everywhere until hovered. In toggle mode, a lock icon will appear to the right of your budget name in the top left corner of YNAB. Click to enable or disable privacy mode.',
+    'Obscures dollar amounts everywhere until hovered. In toggle mode, a lock icon will appear in the lower left corner of YNAB. Click to enable or disable privacy mode.',
   options: [
     { name: 'Disabled', value: '0' },
     { name: 'Always On', value: '1' },


### PR DESCRIPTION
GitHub Issue (if applicable): Resolves #2080 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Changed the description of the location of the lock from "next to budget name at the top left" to "in the lower left corner of YNAB" as requested in the issue
