### PR TITLE
Add debt ratio feature

### DIFF
--- a/src/core/browser/options/index.html
+++ b/src/core/browser/options/index.html
@@ -57,6 +57,11 @@
               <a href="#" id="reportsMenuItem"> <i class="fa fa-bar-chart"></i> Reports Screen</a>
             </li>
             <li>
+              <a href="#" id="toolkitReportsMenuItem">
+                <i class="fa fa-file-text-o"></i> Toolkit Reports</a
+              >
+            </li>
+            <li>
               <a href="#" id="supportMenuItem"> <i class="fa fa-support"></i> Support</a>
             </li>
             <li>
@@ -108,6 +113,9 @@
 
               <!-- ======= REPORTS SETTINGS ======= -->
               <div id="reportsSettingsPage" class="settingsPage"></div>
+
+              <!-- ======= TOOLKIT REPORTS SETTINGS ======= -->
+              <div id="toolkitReportsSettingsPage" class="settingsPage"></div>
 
               <!-- ======= SUPPORT ======= -->
               <div id="supportSettingsPage" class="settingsPage">

--- a/src/core/browser/options/options.js
+++ b/src/core/browser/options/options.js
@@ -164,6 +164,12 @@ jq(() => {
         showActions: true,
       },
       {
+        id: 'toolkitReportsSettingsPage',
+        iconClass: 'fa-file-text-o',
+        title: 'Toolkit Reports Screen Settings',
+        showActions: true,
+      },
+      {
         id: 'reportsSettingsPage',
         iconClass: 'fa-bar-chart',
         title: 'Reports Screen Settings',
@@ -432,6 +438,10 @@ jq(() => {
     });
     jq('#reportsMenuItem').click(function(e) {
       loadPanel('reports');
+      e.preventDefault();
+    });
+    jq('#toolkitReportsMenuItem').click(function(e) {
+      loadPanel('toolkitReports');
       e.preventDefault();
     });
     jq('#supportMenuItem').click(function(e) {

--- a/src/extension/features/toolkit-reports/hide-debt-ratio/index.css
+++ b/src/extension/features/toolkit-reports/hide-debt-ratio/index.css
@@ -1,3 +1,0 @@
-body .tk-debt-ratio {
-  display: none !important;
-}

--- a/src/extension/features/toolkit-reports/hide-debt-ratio/index.css
+++ b/src/extension/features/toolkit-reports/hide-debt-ratio/index.css
@@ -1,0 +1,3 @@
+body .tk-debt-ratio {
+  display: none !important;
+}

--- a/src/extension/features/toolkit-reports/hide-debt-ratio/index.js
+++ b/src/extension/features/toolkit-reports/hide-debt-ratio/index.js
@@ -1,0 +1,7 @@
+import { Feature } from 'toolkit/extension/features/feature';
+
+export class ShowDebtRatio extends Feature {
+  injectCSS() {
+    return require('./index.css');
+  }
+}

--- a/src/extension/features/toolkit-reports/hide-debt-ratio/index.js
+++ b/src/extension/features/toolkit-reports/hide-debt-ratio/index.js
@@ -1,7 +1,3 @@
 import { Feature } from 'toolkit/extension/features/feature';
 
-export class ShowDebtRatio extends Feature {
-  injectCSS() {
-    return require('./index.css');
-  }
-}
+export class HideDebtRatio extends Feature {}

--- a/src/extension/features/toolkit-reports/hide-debt-ratio/settings.js
+++ b/src/extension/features/toolkit-reports/hide-debt-ratio/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'ShowDebtRatio',
+  type: 'checkbox',
+  default: false,
+  section: 'toolkitReports',
+  title: 'Hide Debt Ratio in Toolkit Reports: Net Worth',
+  description: 'Hide debt ratio (debts / assets * 100%) in the Toolkit Reports Net Worth page',
+};

--- a/src/extension/features/toolkit-reports/hide-debt-ratio/settings.js
+++ b/src/extension/features/toolkit-reports/hide-debt-ratio/settings.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: 'ShowDebtRatio',
+  name: 'HideDebtRatio',
   type: 'checkbox',
   default: false,
   section: 'toolkitReports',

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -36,6 +36,7 @@ export class NetWorthComponent extends React.Component {
             <Legend
               assets={this.state.hoveredData.assets}
               debts={this.state.hoveredData.debts}
+              debtRatio={this.state.hoveredData.debtRatio}
               netWorth={this.state.hoveredData.netWorth}
             />
           )}
@@ -47,7 +48,7 @@ export class NetWorthComponent extends React.Component {
 
   _renderReport = () => {
     const _this = this;
-    const { labels, debts, assets, netWorths } = this.state.reportData;
+    const { labels, debts, assets, debtRatios, netWorths } = this.state.reportData;
 
     const pointHover = {
       events: {
@@ -56,6 +57,7 @@ export class NetWorthComponent extends React.Component {
             hoveredData: {
               assets: assets[this.index],
               debts: debts[this.index],
+              debtRatio: debtRatios[this.index],
               netWorth: netWorths[this.index],
             },
           });
@@ -121,7 +123,7 @@ export class NetWorthComponent extends React.Component {
     }
 
     const accounts = new Map();
-    const allReportData = { assets: [], labels: [], debts: [], netWorths: [] };
+    const allReportData = { assets: [], labels: [], debts: [], netWorths: [], debtRatios: [] };
     const transactions = this.props.allReportableTransactions.slice().sort(sortByGettableDate);
 
     let lastMonth = null;
@@ -139,6 +141,8 @@ export class NetWorthComponent extends React.Component {
       allReportData.assets.push(assets);
       allReportData.debts.push(debts);
       allReportData.netWorths.push(assets - debts);
+      // for debtRatio: if any assets are $0, it will safely display 'Infinity'
+      allReportData.debtRatios.push((debts / assets) * 100);
       allReportData.labels.push(localizedMonthAndYear(lastMonth));
     }
 
@@ -191,10 +195,11 @@ export class NetWorthComponent extends React.Component {
         .startOfMonth();
       while (transactionMonth.isBefore(lastFilterMonth)) {
         if (!allReportData.labels.includes(localizedMonthAndYear(transactionMonth))) {
-          const { assets, debts, netWorths, labels } = allReportData;
+          const { assets, debts, debtRatios, netWorths, labels } = allReportData;
           labels.splice(currentIndex, 0, localizedMonthAndYear(transactionMonth));
           assets.splice(currentIndex, 0, assets[currentIndex - 1] || 0);
           debts.splice(currentIndex, 0, debts[currentIndex - 1] || 0);
+          debtRatios.splice(currentIndex, 0, debtRatios[currentIndex - 1] || 0);
           netWorths.splice(currentIndex, 0, netWorths[currentIndex - 1] || 0);
         }
 
@@ -205,7 +210,7 @@ export class NetWorthComponent extends React.Component {
 
     // Net Worth is calculated from the start of time so we need to handle "filters" here
     // rather than using `filteredTransactions` from context.
-    const { labels, assets, debts, netWorths } = allReportData;
+    const { labels, assets, debts, netWorths, debtRatios } = allReportData;
     let startIndex = labels.findIndex(label => label === localizedMonthAndYear(fromDate));
     startIndex = startIndex === -1 ? 0 : startIndex;
     let endIndex = labels.findIndex(label => label === localizedMonthAndYear(toDate));
@@ -214,6 +219,7 @@ export class NetWorthComponent extends React.Component {
     const filteredLabels = labels.slice(startIndex, endIndex);
     const filteredDebts = debts.slice(startIndex, endIndex);
     const filteredAssets = assets.slice(startIndex, endIndex);
+    const filteredDebtRatios = debtRatios.slice(startIndex, endIndex);
     const filteredNetWorths = netWorths.slice(startIndex, endIndex);
 
     this.setState(
@@ -221,6 +227,7 @@ export class NetWorthComponent extends React.Component {
         hoveredData: {
           assets: assets[assets.length - 1] || 0,
           debts: debts[debts.length - 1] || 0,
+          debtRatio: debtRatios[debtRatios.length - 1] || 0,
           netWorth: netWorths[netWorths.length - 1] || 0,
         },
         reportData: {
@@ -228,6 +235,7 @@ export class NetWorthComponent extends React.Component {
           debts: filteredDebts,
           assets: filteredAssets,
           netWorths: filteredNetWorths,
+          debtRatios: filteredDebtRatios,
         },
       },
       this._renderReport

--- a/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
@@ -23,6 +23,14 @@ export const Legend = props => (
         <Currency value={props.assets} />
       </div>
     </div>
+    <div className="tk-debt-ratio">
+      <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
+        <div className="tk-flex tk-mg-b-05 tk-align-items-center">
+          <div className="tk-mg-0">Debt Ratio</div>
+        </div>
+        <div>{Math.round(props.debtRatio)}%</div>
+      </div>
+    </div>
     <div className="tk-mg-05 tk-pd-r-1">
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-net-worth-legend__icon-net-worths" />

--- a/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { Currency } from 'toolkit-reports/common/components/currency';
+import { isFeatureEnabled } from 'toolkit/extension/utils/feature';
 import './styles.scss';
 
 export const Legend = props => (
@@ -23,14 +24,16 @@ export const Legend = props => (
         <Currency value={props.assets} />
       </div>
     </div>
-    <div className="tk-debt-ratio">
-      <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
-        <div className="tk-flex tk-mg-b-05 tk-align-items-center">
-          <div className="tk-mg-0">Debt Ratio</div>
+    {!isFeatureEnabled(window.ynabToolKit.options.HideDebtRatio) && (
+      <div className="tk-debt-ratio">
+        <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
+          <div className="tk-flex tk-mg-b-05 tk-align-items-center">
+            <div className="tk-mg-0">Debt Ratio</div>
+          </div>
+          <div>{Math.round(props.debtRatio)}%</div>
         </div>
-        <div>{Math.round(props.debtRatio)}%</div>
       </div>
-    </div>
+    )}
     <div className="tk-mg-05 tk-pd-r-1">
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-net-worth-legend__icon-net-worths" />


### PR DESCRIPTION
GitHub Issue (if applicable): #2034

Trello Link (if applicable): https://trello.com/c/fljiWdxH

Short reddit discussion: https://www.reddit.com/r/ynab/comments/hs2uet/would_any_of_you_be_interested_in_debt_ratio_in/
Summary: Many people liked the feature, but wanted the ability the turn it off.

**Explanation of Bugfix/Feature/Modification:**
See Github issue and Trello link for details on feature, including screenshots.
Essentially, I would like the Debt Ratio (debt/assets* 100%) to be displayed along the debts, assets, and networth legend of the Toolkit Net Worth page.
I also added a toggle to be able to turn it off and this involved creating a new settings page for Toolkit Reports.

This is the first time I have touched YNAB code and I am new to web development so some extra scrutiny would be appreciated.

**I modified the following files to add the debt ratio feature:**

- src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
- src/extension/features/toolkit-reports/pages/net-worth/component.jsx

**I modified the following files to add the settings page**

- src/core/browser/options/index.html
- src/core/browser/options/options.js

**I created the following files to add the toggle feature "hide-debt-ratio"**

- src/extension/features/toolkit-reports/hide-debt-ratio/index.css
- src/extension/features/toolkit-reports/hide-debt-ratio/index.js
- src/extension/features/toolkit-reports/hide-debt-ratio/settings.js


