### PR TITLE
Bulk edit memo

### DIFF
--- a/src/extension/features/accounts/bulk-edit-memo/index.css
+++ b/src/extension/features/accounts/bulk-edit-memo/index.css
@@ -1,0 +1,17 @@
+.ynab-grid-actions.tk-grid-actions {
+  text-align: right;
+  background-color: inherit;
+}
+
+.tk-bulk-edit-memo .tk-memo-cancel {
+  display: inline !important;
+  width: auto !important;
+  border: 1px solid var(--primary_button_background) !important;
+  padding: 0.2rem 1.1rem !important;
+}
+
+.tk-bulk-edit-memo .tk-memo-save {
+  display: inline !important;
+  width: auto !important;
+  padding: 0.2rem 1.1rem !important;
+}

--- a/src/extension/features/accounts/bulk-edit-memo/index.jsx
+++ b/src/extension/features/accounts/bulk-edit-memo/index.jsx
@@ -12,7 +12,7 @@ const EditMemo = () => {
   const handleConfirm = e => {
     const checkedRows = controllerLookup('accounts').get('areChecked');
     const { transactionsCollection } = getEntityManager();
-    getEntityManager().batchChangeProperties(() => {
+    getEntityManager().performAsSingleChangeSet(() => {
       checkedRows.forEach(transaction => {
         const entity = transactionsCollection.findItemByEntityId(transaction.get('entityId'));
         if (entity) {

--- a/src/extension/features/accounts/bulk-edit-memo/index.jsx
+++ b/src/extension/features/accounts/bulk-edit-memo/index.jsx
@@ -10,10 +10,6 @@ const EditMemo = () => {
   const [memoInputValue, setMemoInputValue] = useState('');
 
   const handleConfirm = e => {
-    if (!memoInputValue) {
-      return;
-    }
-
     const checkedRows = controllerLookup('accounts').get('areChecked');
     const { transactionsCollection } = getEntityManager();
     getEntityManager().batchChangeProperties(() => {
@@ -24,19 +20,45 @@ const EditMemo = () => {
         }
       });
     });
+    setIsEditMode(false);
   };
 
   return (
-    <li>
-      {isEditMode && (
-        <>
-          <input value={memoInputValue} onChange={e => setMemoInputValue(e.target.value)} />
-          <button onClick={handleConfirm}>Okay</button>
-          <button onClick={() => setIsEditMode(false)}>Cancel</button>
-        </>
-      )}
-      {!isEditMode && <button onClick={() => setIsEditMode(true)}>Edit Memo</button>}
-    </li>
+    <>
+      <li className="tk-bulk-edit-memo">
+        <div className="button-list">
+          {isEditMode && (
+            <>
+              <input
+                autoFocus
+                className="accounts-text-field"
+                value={memoInputValue}
+                onChange={e => setMemoInputValue(e.target.value)}
+              />
+              <div className="ynab-grid-actions tk-grid-actions">
+                <button
+                  className="button button-cancel tk-memo-cancel"
+                  onClick={() => setIsEditMode(false)}
+                >
+                  Cancel
+                </button>
+                <button className="button button-primary tk-memo-save" onClick={handleConfirm}>
+                  Save
+                </button>
+              </div>
+            </>
+          )}
+          {!isEditMode && (
+            <button onClick={() => setIsEditMode(true)}>
+              <i className="flaticon stroke document-1 ynab-new-icon"></i>Edit Memo
+            </button>
+          )}
+        </div>
+      </li>
+      <li>
+        <hr />
+      </li>
+    </>
   );
 };
 
@@ -56,7 +78,11 @@ export class BulkEditMemo extends Feature {
   }
 
   invoke() {
-    const categorizeRow = $('.modal-account-edit-transaction-list li:contains("Categorize")');
-    componentBefore(<EditMemo />, categorizeRow);
+    const approveRow = $('.modal-account-edit-transaction-list li:contains("Approve")');
+    componentBefore(<EditMemo />, approveRow);
+  }
+
+  injectCSS() {
+    return require('./index.css');
   }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX

Trello Link (if applicable):
https://trello.com/c/GyXyE3jo/343-edit-multiple-memo-fields-at-once

**Explanation of Bugfix/Feature/Modification:**
This allows a user to select multiple transactions and edit the memo for all of them.

![2020-08-15_16-47-21](https://user-images.githubusercontent.com/1242212/90323522-66ca5780-df17-11ea-9888-95aa77274242.gif)

