### PR TITLE
Exclude unapproved transactions from days of buffering calculation

### DIFF
--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -172,7 +172,8 @@ ${l10n('toolkit.dob.avgOutflow', 'Average daily outflow')}: ~${formatCurrency(av
       !transaction.get('payee.isInternal') &&
       !transaction.isTransferTransaction() &&
       transaction.get('account.onBudget') &&
-      transaction.get('amount') < 0
+      transaction.get('amount') < 0 &&
+      transaction.get('accepted')
     );
   };
 


### PR DESCRIPTION
GitHub Issue (if applicable): #2148

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
See issue #2148 for more info. A summary of the fix is below. 

Past rejected (and current pending approval) imported transactions are being included in the DoB calculation, even though they don't show in the account ledgers. This skews the DoB, sometimes significantly.
