### PR TITLE
Fixes for toolkit income-vs-expense report

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/styles.scss
@@ -4,6 +4,8 @@
   &__child-row,
   &__child-summary-row,
   &__title-row--collapsed {
+    background: var(--background_primary);
+
     &:hover {
       background-color: var(--table_row_background_selected);
     }
@@ -27,7 +29,7 @@
 
     .tk-monthly-totals-row {
       &__title-cell {
-        background: var(--default_background);
+        background: inherit;
         padding-left: 0.5rem;
       }
     }
@@ -52,7 +54,7 @@
 
     .tk-monthly-totals-row {
       &__title-cell {
-        background: var(--default_background);
+        background: inherit;
         font-weight: normal;
         padding-left: 1rem;
       }
@@ -64,7 +66,7 @@
 
     .tk-monthly-totals-row {
       &__title-cell {
-        background: var(--default_background);
+        background: inherit;
         padding-left: 1rem;
       }
 

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/styles.scss
@@ -7,6 +7,10 @@
     &:hover {
       background-color: var(--table_row_background_selected);
     }
+
+    body.theme-classic &:hover {
+      color: #ffffff;
+    }
   }
 
   &__header-row,

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/styles.scss
@@ -25,6 +25,7 @@ body.theme-dark {
   font-size: 0.85rem;
 
   &__net-income {
+    background: var(--background_primary);
     border-top: 3px solid var(--tk-ive-report-border-color);
     border-bottom: 3px solid var(--tk-ive-report-border-color);
     width: fit-content;


### PR DESCRIPTION
GitHub Issue (if applicable): #2137 and #2131

Trello Link (if applicable): n/a

**Explanation of Bugfix/Feature/Modification:**
Just a couple of style fixes to ensure correct work on report. 

* In classic theme variable `--table_row_background_selected` (used on hover) contains dark color, so additional styles for text required to make it readable 

*  Variable `--default_background` (in all themes) contains fully transparent color, which caused issue with overlap on scrolling. I added `background: var(--background_primary);` to all uncolored rows (all rows except header&footer rows for income and expense) and `background: inherit;` to their children cells, work fine with all themes
