### PR TITLE
Fixed excessive dimming in Toolkit Report Charts

### DIFF
--- a/src/extension/features/toolkit-reports/pages/balance-over-time/RunningBalanceGraph.jsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/RunningBalanceGraph.jsx
@@ -69,6 +69,11 @@ export const RunningBalanceGraph = ({ series }) => {
               event.preventDefault(); // Prevent toggling via the legend
             },
           },
+          states: {
+            inactive: {
+              enabled: false,
+            },
+          },
         },
       },
       responsive: {

--- a/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
@@ -361,6 +361,13 @@ export class IncomeBreakdownComponent extends React.Component {
             },
           },
         },
+        series: {
+          states: {
+            inactive: {
+              enabled: false,
+            },
+          },
+        },
       },
       series: [
         {

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
@@ -85,6 +85,13 @@ export class InflowOutflowComponent extends React.Component {
         column: {
           grouping: false,
         },
+        series: {
+          states: {
+            inactive: {
+              enabled: false,
+            },
+          },
+        },
       },
       series: [
         {

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -83,6 +83,15 @@ export class NetWorthComponent extends React.Component {
           },
         },
       },
+      plotOptions: {
+        series: {
+          states: {
+            inactive: {
+              enabled: false,
+            },
+          },
+        },
+      },
       series: [
         {
           id: 'debts',

--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -205,6 +205,11 @@ export class SpendingByCategoryComponent extends React.Component {
               )}%)</span>`;
             },
           },
+          states: {
+            inactive: {
+              enabled: false,
+            },
+          },
         },
       },
       tooltip: {

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -174,6 +174,11 @@ export class SpendingByPayeeComponent extends React.Component {
               )}%)</span>`;
             },
           },
+          states: {
+            inactive: {
+              enabled: false,
+            },
+          },
         },
       },
       tooltip: {


### PR DESCRIPTION
GitHub Issue (if applicable): #2155

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.

Toolkit 2.28.1 updated Highcharts from version 7.0.0 to 7.2.2 #2130. For highcharts 7.1.0 https://www.highcharts.com/blog/changelog/#highcharts-v7.1.0, they added "inactive" states by default to dim the other series when user hovers over data or legend. Unfortunately, this is very distracting for the user and makes it hard to read text and see the dimmed charts. 
I disabled this "inactive" state so that the behaviour is the same as Toolkit 2.27.0. Here is the relevant highcharts api: https://api.highcharts.com/highcharts/plotOptions.series.states.inactive.enabled
I fixed this for the following Toolkit charts.

- Net Worth
- Inflow/Outflow
- Spending by Category
- Spending by Payee
- Income Breakdown
- Balance Over Time

This should likely be released a bit faster as it is quite a distracting "bug". Let me know if you see any issues, thanks!
