### PR TITLE
Add markdown parsing to transaction memo #2158

### DIFF
--- a/src/extension/features/accounts/calendar-first-day/index.js
+++ b/src/extension/features/accounts/calendar-first-day/index.js
@@ -73,7 +73,7 @@ export class CalendarFirstDay extends Feature {
 
   observe(changedNodes) {
     if (
-      changedNodes.has('modal-account-calendar js-ynab-new-calendar-overlay modal-overlay active')
+      changedNodes.has('modal-overlay active  modal-account-calendar js-ynab-new-calendar-overlay')
     ) {
       this.isCalendarOpen = true;
       this.reRenderHeader();

--- a/src/extension/features/accounts/memo-as-markdown/index.js
+++ b/src/extension/features/accounts/memo-as-markdown/index.js
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { Feature } from 'toolkit/extension/features/feature';
+import { getEmberView } from 'toolkit/extension/utils/ember';
+import { addToolkitEmberHook } from 'toolkit/extension/utils/toolkit';
+import { componentPrepend } from 'toolkit/extension/utils/react';
+import ReactMarkdown from 'react-markdown';
+
+export class MemoAsMarkdown extends Feature {
+  injectCSS() {
+    return require('./styles.css');
+  }
+
+  shouldInvoke() {
+    return true;
+  }
+
+  applyMarkdown = element => {
+    const view = getEmberView(element.getAttribute('id'));
+    if (!view) {
+      return;
+    }
+
+    const toolkitMemoContainer = element.querySelector('.tk-markdown-memo');
+    if (toolkitMemoContainer) {
+      return;
+    }
+
+    const handleClick = event => {
+      if (event.target.tagName === 'A') {
+        event.stopPropagation();
+      }
+    };
+
+    const note = view.get('attrs.content.value.memo');
+    const originalMemo = element.querySelector('.ynab-grid-cell-memo .user-entered-text');
+    if (note && originalMemo) {
+      originalMemo.remove();
+
+      componentPrepend(
+        <div className="tk-markdown-memo" onClick={handleClick}>
+          <ReactMarkdown
+            source={note}
+            linkTarget="_blank"
+            renderers={{
+              link: ({ href, children }) => (
+                <a href={href} target="_blank" rel="noopener noreferrer">
+                  {children}
+                </a>
+              ),
+            }}
+          />
+        </div>,
+        element.querySelector('.ynab-grid-cell-memo')
+      );
+    }
+  };
+
+  invoke() {
+    addToolkitEmberHook(this, 'register/grid-row', 'didRender', this.applyMarkdown);
+  }
+}

--- a/src/extension/features/accounts/memo-as-markdown/settings.js
+++ b/src/extension/features/accounts/memo-as-markdown/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'MemoAsMarkdown',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Allow Markdown in Memo',
+  description:
+    'Adds Markdown parsing to memos, allowing support for links and other formatting tools. Learn how to use Markdown [here](https://www.markdownguide.org/cheat-sheet).',
+};

--- a/src/extension/features/accounts/memo-as-markdown/styles.css
+++ b/src/extension/features/accounts/memo-as-markdown/styles.css
@@ -1,0 +1,7 @@
+.tk-markdown-memo {
+  display: inline-block;
+}
+
+.tk-markdown-memo p {
+  margin: 0 !important;
+}


### PR DESCRIPTION
GitHub Issue (if applicable): #2158

Trello Link (if applicable):n/a

**Explanation of Bugfix/Feature/Modification:**
I used NotesAsMarkdown feature as reference to implement this one. I noticed this change makes account page a bit slower (e.g. if you have a lot of transactions on page and try to quickly scroll to the end of page), so if you have any ideas how to make it better it would be great
