### PR TITLE
Adjust PieChart style for TotalSpending

### DIFF
--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -214,7 +214,7 @@ export class SpendingByCategoryComponent extends React.Component {
         align: 'center',
         verticalAlign: 'middle',
         text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>`,
-        style: { color: 'var(--header_label_primary)' },
+        style: { color: 'var(--label_primary)' },
       },
       series: [
         {

--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -214,6 +214,7 @@ export class SpendingByCategoryComponent extends React.Component {
         align: 'center',
         verticalAlign: 'middle',
         text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>`,
+        style: { color: 'var(--header_label_primary)' },
       },
       series: [
         {

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -181,8 +181,9 @@ export class SpendingByPayeeComponent extends React.Component {
       },
       title: {
         align: 'center',
-        verticalAlign: 'top',
+        verticalAlign: 'middle',
         text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>`,
+        style: { color: 'var(--header_label_primary)' },
       },
       series: [
         {

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -183,7 +183,7 @@ export class SpendingByPayeeComponent extends React.Component {
         align: 'center',
         verticalAlign: 'middle',
         text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>`,
-        style: { color: 'var(--header_label_primary)' },
+        style: { color: 'var(--label_primary)' },
       },
       series: [
         {


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
In dark mode, the pie chart "Total Spending" color was hard to read.

Affected Features: SpendingByCategory and SpendingByPayee Reports
- Use CSS variable to adjust font color per theme
- Center align SpendingByPayee 
