### PR TITLE
Dark Theme Font Color for Toolkit Reports

### DIFF
--- a/src/extension/features/toolkit-reports/pages/balance-over-time/RunningBalanceGraph.jsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/RunningBalanceGraph.jsx
@@ -7,33 +7,53 @@ import { NUM_DATAPOINTS_LIMIT } from './utils';
 
 export const RunningBalanceGraph = ({ series }) => {
   const GRAPH_ID = 'tk-balance-over-time-report-graph';
+  let textColor = 'var(--label_primary)';
 
   // On every change of series, rerender our graph to the report container
   useEffect(() => {
     Highcharts.chart(GRAPH_ID, {
-      title: { text: 'Balance Over Time' },
+      title: {
+        text: 'Balance Over Time',
+        style: { color: textColor },
+      },
       series: series,
       yAxis: {
-        title: { text: 'Balance' },
+        title: {
+          text: 'Balance',
+          style: { color: textColor },
+        },
         labels: {
           formatter: e => {
             return formatCurrency(e.value, false);
           },
+          style: { color: textColor },
         },
       },
+      chart: {
+        backgroundColor: 'transparent',
+      },
       xAxis: {
-        title: { text: 'Time' },
+        title: {
+          text: 'Time',
+          style: { color: textColor },
+        },
         type: 'datetime',
         dateTimeLabelFormats: {
           day: '%b %d',
           week: '%b %d, %y',
           month: '%b %Y',
         },
+        labels: {
+          style: { color: textColor },
+        },
       },
       legend: {
         layout: 'vertical',
         align: 'right',
         verticalAlign: 'middle',
+        itemStyle: {
+          color: textColor,
+        },
       },
       tooltip: {
         useHTML: true,

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/RunningBalanceGraph.jsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/RunningBalanceGraph.jsx
@@ -7,10 +7,10 @@ import { NUM_DATAPOINTS_LIMIT } from './utils';
 
 export const RunningBalanceGraph = ({ series }) => {
   const GRAPH_ID = 'tk-balance-over-time-report-graph';
-  let textColor = 'var(--label_primary)';
 
   // On every change of series, rerender our graph to the report container
   useEffect(() => {
+    let textColor = 'var(--label_primary)';
     Highcharts.chart(GRAPH_ID, {
       title: {
         text: 'Balance Over Time',

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
@@ -72,13 +72,19 @@ export class InflowOutflowComponent extends React.Component {
       legend: { enabled: false },
       title: { text: '' },
       tooltip: { enabled: false },
-      xAxis: { categories: labels },
+      xAxis: {
+        categories: labels,
+        labels: {
+          style: { color: 'var(--label_primary)' },
+        },
+      },
       yAxis: {
         title: { text: '' },
         labels: {
           formatter: function() {
             return formatCurrency(this.value);
           },
+          style: { color: 'var(--label_primary)' },
         },
       },
       plotOptions: {

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -74,13 +74,19 @@ export class NetWorthComponent extends React.Component {
       legend: { enabled: false },
       title: { text: '' },
       tooltip: { enabled: false },
-      xAxis: { categories: labels },
+      xAxis: {
+        categories: labels,
+        labels: {
+          style: { color: 'var(--label_primary)' },
+        },
+      },
       yAxis: {
         title: { text: '' },
         labels: {
           formatter: function() {
             return formatCurrency(this.value);
           },
+          style: { color: 'var(--label_primary)' },
         },
       },
       series: [


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
Problem: In Dark Mode, the background color for the BalanceOverTime report was white.
In DarkMode the yAxis and xAxis for NetWorth and Inflow/Outflow were a dark grey.

Affected Features: NetWorth, Inflow/Outflows, BalanceOverTime
Changes:
- Set the chart color to transparent like other reports
- Set the title, labels, legends, xAxis, yAxis to use CSS var
