### PR TITLE
Update SetFlags Invocation Selectors

### DIFF
--- a/src/extension/features/accounts/set-multiple-flags/index.js
+++ b/src/extension/features/accounts/set-multiple-flags/index.js
@@ -27,16 +27,11 @@ export class SetMultipleFlags extends Feature {
     if (!$editModal.length) {
       return;
     }
-
     this._injectButtons($editModal);
   }
 
   observe(changedNodes) {
-    if (
-      changedNodes.has(
-        'ynab-u modal-popup modal-account-edit-transaction-list modal-overlay active'
-      )
-    ) {
+    if (changedNodes.has('modal-overlay  ynab-u modal-popup modal-account-edit-transaction-list')) {
       this.invoke();
     }
   }


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2176

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
Looks like there was an update to the selectors which failed the changedNodes invocation condition.

Before it used to be: `ynab-u modal-popup modal-account-edit-transaction-list modal-overlay active`

Putting a breakpoint upon opening the edit transaction modal. Changed nodes has this Set:
```
changedNodes
Set(19) {"accounts-toolbar-edit-transaction button  active", "layout user-logged-in", "", "modal-overlay  ynab-u modal-popup modal-account-edit-transaction-list", "modal", …}
[[Entries]]
0: "accounts-toolbar-edit-transaction button active"
1: "layout user-logged-in"
2: ""
3: "modal-overlay ynab-u modal-popup modal-account-edit-transaction-list"
4: "modal"
5: "modal-list"
6: "button-list modal-account-mark-as-cleared button-disabled"
7: "ynab-new-icon"
8: "button-list modal-account-mark-as-uncleared"
9: "button-list button-disabled"
10: "button-list button-make-repeating button-disabled"
11: "button-list"
12: "ynab-new-icon arrow-right"
13: "modal-account-edit-subcategories"
14: "modal-account-edit-transaction-move"
15: "button-list user-data"
16: "button-list modal-account-edit-transaction-delete"
17: "modal-arrow"
18: "tk-bulk-edit-memo"
```

I'm assuming we wanted to observe `modal-overlay ynab-u modal-popup modal-account-edit-transaction-list` so I went ahead and updated the condition.

After, the two buttons now appear.

<img width="663" alt="Screen Shot 2020-10-17 at 11 13 37 AM" src="https://user-images.githubusercontent.com/24358685/96350415-80e4fb00-106a-11eb-9458-0cdadaa4203d.png">

