### PR TITLE
Update Budget Quick Switch Selector

### DIFF
--- a/src/extension/features/general/budget-quick-switch/index.js
+++ b/src/extension/features/general/budget-quick-switch/index.js
@@ -42,7 +42,7 @@ export class BudgetQuickSwitch extends Feature {
   }
 
   observe(changedNodes) {
-    if (changedNodes.has('ynab-u ynab-new-settings-menu modal-overlay active')) {
+    if (changedNodes.has('modal-overlay  ynab-u ynab-new-settings-menu')) {
       this.populateBudgetList();
     }
   }


### PR DESCRIPTION
GitHub Issue (if applicable): #2178 
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2178

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
The menu was never populated since the current selectors were not found in the changedNodes set. An update to ynab probably caused this.

Similar to https://github.com/toolkit-for-ynab/toolkit-for-ynab/pull/2188, we'll update the selector
to adapt `modal-overlay  ynab-u ynab-new-settings-menu`.

This will allow it to populate the menu and add the list items.

For reference, putting a breakpoint on the observe and logging the changedNode set yields:
```
changedNodes
Set(27) {"sidebar-nav-menu sidebar-nav-menu-budget js-sidebar-nav-menu user-data button  active", "layout user-logged-in", "", "modal-overlay  ynab-u ynab-new-settings-menu", "modal", …}
[[Entries]]
0: "sidebar-nav-menu sidebar-nav-menu-budget js-sidebar-nav-menu user-data button active"
1: "layout user-logged-in"
2: ""
3: "modal-overlay ynab-u ynab-new-settings-menu"
4: "modal"
5: "modal-list"
6: "modal-select-budget-create"
7: "flaticon stroke plus-2"
8: "modal-select-budget-open"
9: "flaticon stroke open-folder-1"
10: "modal-select-budget-fresh-start"
11: "flaticon stroke leaf-1"
12: "modal-select-budget-settings"
13: "flaticon stroke wrench-2"
14: "modal-select-theme-switcher"
15: "ynab-new-icon"
16: "modal-select-budget-manage-payees"
17: "flaticon stroke group"
18: "modal-select-budget-manage-connections"
19: "flaticon stroke government-1"
20: "modal-select-budget-export"
21: "flaticon stroke download-document-1"
22: "modal-select-budget-my-account"
23: "flaticon stroke user-4"
24: "modal-select-budget-workshops"
25: "flaticon stroke open-book"
26: "flaticon stroke logout-1"
```

