### PR TITLE
Adjust SpendingBy* Labels

### DIFF
--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -204,6 +204,10 @@ export class SpendingByCategoryComponent extends React.Component {
                 this.percentage
               )}%)</span>`;
             },
+            style: {
+              color: 'var(--label_primary)',
+              textOutline: 'none',
+            },
           },
           states: {
             inactive: {
@@ -231,6 +235,9 @@ export class SpendingByCategoryComponent extends React.Component {
       ],
       drilldown: {
         series: drillDownData,
+        activeDataLabelStyle: {
+          color: 'var(--label_primary)',
+        },
       },
     });
 

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -173,6 +173,10 @@ export class SpendingByPayeeComponent extends React.Component {
                 this.percentage
               )}%)</span>`;
             },
+            style: {
+              color: 'var(--label_primary)',
+              textOutline: 'none',
+            },
           },
           states: {
             inactive: {


### PR DESCRIPTION
GitHub Issue (if applicable): #2143 
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2143
Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
The labels were a bit hard to read in dark mode. Updated the color to use the header label css var and removed the text outline.

The issue suggested we give the user the option to specify font styles. Instead, we could just make our current one a bit more readable by passing in styles for the highcharts chart.


Before:
<img width="550" alt="Screen Shot 2020-10-19 at 11 34 03 PM" src="https://user-images.githubusercontent.com/24358685/96549026-bef93f00-1263-11eb-9a85-e96a61c12053.png">

After:
<img width="550" alt="Screen Shot 2020-10-19 at 11 31 55 PM" src="https://user-images.githubusercontent.com/24358685/96549091-da644a00-1263-11eb-9610-94772ccfe25b.png">


