### PR TITLE
issue-2187: modernize approach and fix issues with flag names

### DIFF
--- a/src/extension/features/accounts/custom-flag-names/index.css
+++ b/src/extension/features/accounts/custom-flag-names/index.css
@@ -1,0 +1,16 @@
+.modal-account-flags .modal .modal-list button .label {
+  flex: 1 !important;
+  margin-right: 3em;
+}
+
+.modal-account-flags input.tk-flag-input {
+  color: white;
+  height: 30px;
+  padding: 0 0.7em;
+  margin-bottom: 0.3em;
+  border: none;
+}
+
+.modal-account-flags input.tk-flag-input:focus {
+  color: black;
+}

--- a/src/extension/features/accounts/custom-flag-names/index.js
+++ b/src/extension/features/accounts/custom-flag-names/index.js
@@ -1,127 +1,135 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
-import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+import {
+  addToolkitEmberHook,
+  getToolkitStorageKey,
+  setToolkitStorageKey,
+} from 'toolkit/extension/utils/toolkit';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
-let flags;
-let redFlagLabel;
-let blueFlagLabel;
-let orangeFlagLabel;
-let yellowFlagLabel;
-let greenFlagLabel;
-let purpleFlagLabel;
+const defaultFlags = {
+  red: {
+    label: 'Red',
+    color: '#d43d2e',
+  },
+  orange: {
+    label: 'Orange',
+    color: '#ff7b00',
+  },
+  yellow: {
+    label: 'Yellow',
+    color: '#f8e136',
+  },
+  green: {
+    label: 'Green',
+    color: '#9ac234',
+  },
+  blue: {
+    label: 'Blue',
+    color: '#0082cb',
+  },
+  purple: {
+    label: 'Purple',
+    color: '#9384b7',
+  },
+};
 
 export class CustomFlagNames extends Feature {
-  constructor() {
-    super();
-    if (!getToolkitStorageKey('flags')) {
-      this.storeDefaultFlags();
-    }
-    if (typeof flags === 'undefined') {
-      flags = getToolkitStorageKey('flags');
-      this.updateFlagLabels();
-    }
+  injectCSS() {
+    return require('./index.css');
   }
 
   shouldInvoke() {
-    return isCurrentRouteAccountsPage();
+    return true;
   }
 
   invoke() {
-    $('.ynab-grid-cell-flag .ynab-flag-red')
-      .parent()
-      .attr('title', redFlagLabel);
-    $('.ynab-grid-cell-flag .ynab-flag-blue')
-      .parent()
-      .attr('title', blueFlagLabel);
-    $('.ynab-grid-cell-flag .ynab-flag-orange')
-      .parent()
-      .attr('title', orangeFlagLabel);
-    $('.ynab-grid-cell-flag .ynab-flag-yellow')
-      .parent()
-      .attr('title', yellowFlagLabel);
-    $('.ynab-grid-cell-flag .ynab-flag-green')
-      .parent()
-      .attr('title', greenFlagLabel);
-    $('.ynab-grid-cell-flag .ynab-flag-purple')
-      .parent()
-      .attr('title', purpleFlagLabel);
+    addToolkitEmberHook(
+      this,
+      'modals/accounts/transaction-flags',
+      'didRender',
+      this.injectEditFlags
+    );
+
+    addToolkitEmberHook(this, 'register/grid-row', 'didRender', this.applyFlagTitle);
   }
 
-  observe(changedNodes) {
-    if (!this.shouldInvoke()) return;
+  applyFlagTitle(element) {
+    const flags = getToolkitStorageKey('flags', defaultFlags);
 
-    if (changedNodes.has('layout user-logged-in') || changedNodes.has('ynab-grid-body')) {
-      this.invoke();
-    }
-
-    if (changedNodes.has('ynab-u modal-popup modal-account-flags modal-overlay active')) {
-      $('.ynab-flag-red .label, .ynab-flag-red .label-bg').text(redFlagLabel);
-      $('.ynab-flag-blue .label, .ynab-flag-blue .label-bg').text(blueFlagLabel);
-      $('.ynab-flag-orange .label, .ynab-flag-orange .label-bg').text(orangeFlagLabel);
-      $('.ynab-flag-yellow .label, .ynab-flag-yellow .label-bg').text(yellowFlagLabel);
-      $('.ynab-flag-green .label, .ynab-flag-green .label-bg').text(greenFlagLabel);
-      $('.ynab-flag-purple .label, .ynab-flag-purple .label-bg').text(purpleFlagLabel);
-
-      $('.modal-account-flags .modal')
-        .css({ height: '22em' })
-        .append(
-          $('<div>', { id: 'account-flags-actions' })
-            .css({ padding: '0 .3em' })
-            .append(
-              $('<button>', {
-                id: 'flags-edit',
-                class: 'button button-primary',
-              })
-                .append('Edit Flag Names ')
-                .append($('<i>', { class: 'flaticon stroke compose-3' }))
-            )
-        );
-
-      this.addEventListeners();
-    }
-  }
-
-  onRouteChanged() {
-    if (!this.shouldInvoke()) return;
-
-    this.invoke();
-  }
-
-  addEventListeners() {
-    let $this = this;
-    $('#flags-edit').click(function() {
-      $('.modal-account-flags .modal-list').empty();
-
-      for (let key in flags) {
-        let flag = flags[key];
-
-        $('.modal-account-flags .modal-list').append(
-          $('<li>').append(
-            $('<input>', {
-              id: key,
-              type: 'text',
-              class: 'flag-input',
-              value: flag.label,
-              placeholder: flag.label,
-            }).css({
-              color: '#fff',
-              fill: flag.color,
-              'background-color': flag.color,
-              height: 30,
-              padding: '0 .7em',
-              'margin-bottom': '.3em',
-              border: 'none',
-            })
-          )
-        );
+    ['red', 'blue', 'orange', 'yellow', 'green', 'purple'].forEach(color => {
+      const flag = element.querySelector(`.ynab-flag-${color}`);
+      if (flag === null) {
+        return;
       }
 
-      $('#account-flags-actions').empty();
+      flag.parentElement.setAttribute('title', flags[color].label);
+    });
+  }
 
-      $('#account-flags-actions').append(
+  injectEditFlags(element) {
+    const flags = getToolkitStorageKey('flags', defaultFlags);
+
+    $('.ynab-flag-red .label').text(flags.red.label);
+    $('.ynab-flag-blue .label').text(flags.blue.label);
+    $('.ynab-flag-orange .label').text(flags.orange.label);
+    $('.ynab-flag-yellow .label').text(flags.yellow.label);
+    $('.ynab-flag-green .label').text(flags.green.label);
+    $('.ynab-flag-purple .label').text(flags.purple.label);
+
+    if (element.querySelector('#tk-edit-flags') === null) {
+      $('.modal', element).append(
+        $('<div>', { id: 'tk-edit-flags' }).append(
+          $('<button>', {
+            id: 'flags-edit',
+            class: 'button button-primary',
+          })
+            .append('Edit Flag Names ')
+            .append($('<i>', { class: 'flaticon stroke compose-3' }))
+            .on('click', this.showEditFlags)
+        )
+      );
+    }
+  }
+
+  showEditFlags = () => {
+    const flags = getToolkitStorageKey('flags', defaultFlags);
+
+    $('.modal-account-flags .modal-list').empty();
+
+    for (let key in flags) {
+      let flag = flags[key];
+
+      $('.modal-account-flags .modal-list').append(
+        $('<li>').append(
+          $('<input>', {
+            id: key,
+            type: 'text',
+            class: 'tk-flag-input',
+            value: flag.label,
+            placeholder: defaultFlags[key].label,
+          })
+            .css({
+              fill: flag.color,
+              'background-color': flag.color,
+            })
+            .on('change', event => {
+              const { value } = event.currentTarget;
+
+              if (value) {
+                flags[key].label = event.currentTarget.value;
+              } else {
+                flags[key].label = defaultFlags[key].value;
+              }
+            })
+        )
+      );
+    }
+
+    $('#tk-edit-flags')
+      .empty()
+      .append(
         $('<button>', {
-          id: 'flags-close',
+          id: 'tk-flags-close',
           class: 'button button-primary',
         })
           .append('Ok ')
@@ -130,76 +138,16 @@ export class CustomFlagNames extends Feature {
               class: 'flaticon stroke checkmark-2',
             })
           )
+          .on('click', () => {
+            setToolkitStorageKey('flags', flags);
+            controllerLookup('application').send('closeModal');
+
+            ['red', 'blue', 'orange', 'yellow', 'green', 'purple'].forEach(color => {
+              $(`.ynab-flag-${color}`)
+                .parent()
+                .attr('title', flags[color].label);
+            });
+          })
       );
-
-      $('input.flag-input').focus(function() {
-        $(this).css({
-          color: '#000',
-        });
-      });
-
-      $('input.flag-input').blur(function() {
-        $(this).css({
-          color: '#fff',
-        });
-        $this.saveFlag($(this));
-      });
-
-      $('#flags-close').click(function() {
-        controllerLookup('application').send('closeModal');
-      });
-    });
-  }
-
-  saveFlag(flag) {
-    if (flag.attr('placeholder') !== flag.val()) {
-      let key = flag.attr('id');
-
-      flags[key].label = flag.val();
-      setToolkitStorageKey('flags', flags);
-
-      this.updateFlagLabels();
-      this.invoke();
-    }
-  }
-
-  updateFlagLabels() {
-    redFlagLabel = flags.red.label;
-    blueFlagLabel = flags.blue.label;
-    orangeFlagLabel = flags.orange.label;
-    yellowFlagLabel = flags.yellow.label;
-    greenFlagLabel = flags.green.label;
-    purpleFlagLabel = flags.purple.label;
-  }
-
-  storeDefaultFlags() {
-    const flagsJSON = {
-      red: {
-        label: 'Red',
-        color: '#d43d2e',
-      },
-      orange: {
-        label: 'Orange',
-        color: '#ff7b00',
-      },
-      yellow: {
-        label: 'Yellow',
-        color: '#f8e136',
-      },
-      green: {
-        label: 'Green',
-        color: '#9ac234',
-      },
-      blue: {
-        label: 'Blue',
-        color: '#0082cb',
-      },
-      purple: {
-        label: 'Purple',
-        color: '#9384b7',
-      },
-    };
-
-    setToolkitStorageKey('flags', flagsJSON);
-  }
+  };
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2187 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Custom flag names was one of the victims of an overall dom change to modals which caused many features to change when `modal-overlay` got moved around in `changedNodes` but I took this opportunity to update how the feature works using toolkit hooks.
