### PR TITLE
fix: use toString instead of toNativeDate in category activity copy

### DIFF
--- a/src/extension/features/general/category-activity-copy/index.jsx
+++ b/src/extension/features/general/category-activity-copy/index.jsx
@@ -99,7 +99,7 @@ function copyTransactionsToClipboard(transactions) {
 
     return {
       Account: transaction.get('accountName'),
-      Date: ynab.formatDateLong(transaction.get('date').toNativeDate()),
+      Date: ynab.formatDateLong(transaction.get('date').toString()),
       Payee: payee && payee.get('name') ? payee.get('name') : 'Unknown',
       Category: transaction.get('subCategoryNameWrapped'),
       Memo: transaction.get('memo'),


### PR DESCRIPTION
GitHub Issue (if applicable): #2197

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
`toNativeDate` was giving the wrong date because of UTC time. Just use `toString` which properly applies the timezone.
