### PR TITLE
Add "_blank" `target` to release modal, release notes link

### DIFF
--- a/src/core/components/toolkit-release-modal/component.jsx
+++ b/src/core/components/toolkit-release-modal/component.jsx
@@ -16,6 +16,7 @@ export function ToolkitReleaseModal({ onClose }) {
           You are now using version{' '}
           <a
             href="https://github.com/toolkit-for-ynab/toolkit-for-ynab/releases"
+            target="_blank"
             rel="noopener noreferrer"
           >
             {version}


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**

This small PR adds a `target="_blank"` attribute to release modal, release notes link.

I stumbled upon this when I clicked the "you are now using X.xxx" this morning, expecting it to open in new tab, same as when clicking `GitHub Issues` link in the same modal. Thought that this is not the best UX, as I both want to reconcile my budget AND read through release notes in the morning :D 

I am not participating in Hacktoberfest this year, so this is not a lazy PR to rack up PR count, but an honest... opinion, I guess. Mentioning this just in case.

Thank you for the extension!