### PR TITLE
issue-2185: Fix dark mode in options not loading

### DIFF
--- a/src/core/browser/options/options.js
+++ b/src/core/browser/options/options.js
@@ -412,7 +412,7 @@ jq(() => {
 
     restoreOptions(userSettings);
 
-    storage.getStorageItem('options.dark-mode').then(function(data) {
+    storage.getFeatureSetting('options.dark-mode').then(function(data) {
       applyDarkMode(data);
 
       jq('#darkMode').bootstrapSwitch('state', data);

--- a/src/core/browser/popup/popup.js
+++ b/src/core/browser/popup/popup.js
@@ -14,7 +14,7 @@ export class Popup {
     $('.toolkit-name').text(manifest.name);
 
     Promise.all([
-      this._storage.getStorageItem('options.dark-mode', { default: false }),
+      this._storage.getFeatureSetting('options.dark-mode', { default: false }),
       this._storage.getFeatureSetting(TOOLKIT_DISABLED_FEATURE_SETTING, {
         default: false,
       }),


### PR DESCRIPTION
GitHub Issue (if applicable): #2185 

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
The toggle is saved via `setFeatureSetting` which applies the 'toolkit-feature:' prefix but loaded via `getStorageItem` which does not add the prefix. Loading the value via `getFeatureSetting` does apply the prefix.
