### PR TITLE
issue-2185: Fix dark mode button and page headers disappearing when toggled on

### DIFF
--- a/src/assets/common/lib/dream-admin-theme/css/custom-styles.css
+++ b/src/assets/common/lib/dream-admin-theme/css/custom-styles.css
@@ -67,6 +67,10 @@ padding-bottom: 9px;
 margin: 10px 0 45px;
 border-bottom: 1px solid #C7D1DD;
 }
+.settingsPage .page-header.sticky-header {
+  position:sticky;
+  width: 100%;
+}
 .panel-back {
     background-color:#fff;
 
@@ -318,7 +322,8 @@ padding-top: 4px;
 	background:none;
 }
 .sidebar-collapse .nav {
-	padding:0;
+  padding:0;
+  flex: 1;
 }
 .sidebar-collapse .nav > li > a {
 	color:black;
@@ -345,10 +350,25 @@ background: #172D44;
 	outline:0;
 }
 
-.navbar-side {
+nav.navbar-side {
 	border:none;
 	background-color: transparent;
-
+  height: calc(100vh - 120px);
+  position: sticky;
+  float: left;
+  top: 120px;
+}
+.navbar-side .sidebar-collapse {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+}
+.navbar-side .options {
+  position: relative;
+  left: auto;
+  bottom: auto;
+  margin-bottom: 15px;
 }
 .top-navbar {
 	border-bottom:none;

--- a/src/core/browser/options/index.html
+++ b/src/core/browser/options/index.html
@@ -38,6 +38,7 @@
           </button>
         </div>
       </nav>
+      <div class="clearfix"></div>
       <!--/. NAV TOP  -->
       <nav class="navbar-default navbar-side" role="navigation">
         <div class="sidebar-collapse">


### PR DESCRIPTION
GitHub Issue (if applicable): #2185 

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
It doesn't actually disappear, it pops to the bottom of the page when the dark filter is added as described here: https://stackoverflow.com/questions/52937708/css-filter-on-parent-breaks-child-positioning
Using `position: sticky` doesn't have the same restrictions, but requires some extra layout work. I have tried to keep changes as isolated as possible. I also fixed the page headers as well as they were broken in the dark options theme.
