### PR TITLE
issue-2177: Fix report bug button in the extension popup not opening in Firefox

### DIFF
--- a/src/core/browser/popup/popup.js
+++ b/src/core/browser/popup/popup.js
@@ -25,7 +25,9 @@ export class Popup {
   }
 
   initListeners() {
-    $('#reportBug').click(() => window.close());
+    $('#reportBug').click(() => {
+      setTimeout(() => window.close(), 50);
+    });
     $('#openSettings').click(this._openOptionsPage);
     $('#logo').click(this._toggleToolkitDisabledSetting);
     $('#toggleToolkit').click(this._toggleToolkitDisabledSetting);


### PR DESCRIPTION
GitHub Issue (if applicable): #2177 

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
From what I can gather, this happens because the `window.close()` causes the script to unload and the browser isn't quick enough to open the tab. Adding a 50ms delay was enough in my tests for the tab to open and it is still short enough that it would not be a noticeable delay.

The alternative is to programmatically open the URL from `popup.js`. But I felt it best to use the anchor element for its intended purpose.
