### PR TITLE
issue-2156: Fix right click menu clipping out of window

### DIFF
--- a/src/extension/features/accounts/right-click-to-edit/index.css
+++ b/src/extension/features/accounts/right-click-to-edit/index.css
@@ -1,9 +1,19 @@
-.modal-account-edit-transaction-list .modal-above .modal-arrow
-{
-	bottom: auto !important;
-	top: 100% !important;
-	border-bottom-color: transparent !important;
-	border-top-color: #fff !important;
+.modal-account-edit-transaction-list .modal-arrow {
+  transform-origin: top center;
+}
+.modal-account-edit-transaction-list .modal-above .modal-arrow {
+  transform: rotate(180deg);
+  transform-origin: center;
+}
+.modal-account-edit-transaction-list .modal-right .modal-arrow {
+  transform: rotate(270deg);
+}
+.modal-account-edit-transaction-list .modal-left .modal-arrow {
+  transform: rotate(90deg);
+}
+
+.modal-account-edit-transaction-list .modal-list .modal-sub-left {
+  left: calc(4% - 256px);
 }
 
 .modal-account-edit-transaction-list .modal-above li ul {

--- a/src/extension/features/accounts/right-click-to-edit/index.js
+++ b/src/extension/features/accounts/right-click-to-edit/index.js
@@ -1,6 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
+const SCREEN_PADDING = 8;
+const ROW_ARROW_DOWN_START = 34 * 0.75;
+const ROW_ARROW_UP_START = 34 * 0.25;
+const ARROW_HORIZONTAL_OFFSET = 8;
+
 export class RightClickToEdit extends Feature {
   isCurrentlyRunning = false;
 
@@ -30,29 +35,85 @@ export class RightClickToEdit extends Feature {
     $('.accounts-toolbar-edit-transaction').click();
 
     // determine if modal needs to be positioned above or below clicked element
-    let height = $('.modal-account-edit-transaction-list .modal').outerHeight();
-    let below = event.pageY + height > $(window).height() ? false : true; // eslint-disable-line no-unneeded-ternary
+    const $modal =  $('.modal-account-edit-transaction-list .modal');
+    const modalHeight = $modal.outerHeight();
+    const modalWidth = $modal.outerWidth();
+    const halfModalWidth = modalWidth / 2;
+    const $modalArrow =  $modal.find('.modal-arrow');
+    const modalArrowHeight = $modalArrow.outerHeight();
+    const modalArrowWidth = $modalArrow.outerWidth();
+    const halfModalArrowWidth = modalArrowWidth / 2;
+    const $window = $(window);
+    const windowHeight = $window.height();
+    const windowWidth = $window.width();
+    const modalClipsTop = event.pageY - modalHeight < SCREEN_PADDING;
+    const modalClipsBottom = event.pageY + modalHeight > windowHeight - SCREEN_PADDING;
+    const modalClipsLeft = event.pageX - modalWidth < SCREEN_PADDING;
+    const modalClipsRight = event.pageX + modalWidth > windowWidth - SCREEN_PADDING;
 
     // sometimes, offset is undefined -- if this is the case, just show the normal un-positioned edit menu
-    let offset = $element.offset(); // move context menu
+    const offset = $element.offset(); // move context menu
     if (!offset) {
       return;
     }
 
     Ember.run.next(() => {
-      if (below) {
-        // position below
-        $('.modal-account-edit-transaction-list .modal')
-          .addClass('modal-below')
-          .css('left', event.pageX - 115)
-          .css('top', offset.top + 41);
+      let top;
+      let left = event.pageX - halfModalWidth;
+      let arrowLeft = halfModalWidth - halfModalArrowWidth;
+      let arrowBottom = '100%';
+      let cls
+      if (!modalClipsBottom) {
+        cls = 'modal-below';
+        top = offset.top + modalArrowHeight + ROW_ARROW_DOWN_START;
+      } else if (!modalClipsTop) {
+        cls = 'modal-above';
+        top = offset.top - modalHeight - ROW_ARROW_UP_START;
+        arrowBottom = 'auto';
       } else {
-        // position above
-        $('.modal-account-edit-transaction-list .modal')
-          .addClass('modal-above')
-          .css('left', event.pageX - 115)
-          .css('top', offset.top - height - 8);
+        // Clips both top and bottom, need to position to side
+        top = windowHeight - modalHeight - SCREEN_PADDING;
+        arrowBottom = modalHeight - event.pageY + top - halfModalArrowWidth;
+        if (top > event.pageY - halfModalArrowWidth) {
+          top = `calc(${event.pageY}px - ${$modal.css('border-top-left-radius')} - ${halfModalArrowWidth}px`;
+        }
+        if (!modalClipsRight) {
+          cls = 'modal-right';
+          left = event.pageX + modalArrowHeight + ARROW_HORIZONTAL_OFFSET;
+          arrowLeft = -modalArrowWidth;
+        } else if (!modalClipsLeft) {
+          cls = 'modal-left';
+          left = event.pageX - modalWidth - modalArrowHeight - ARROW_HORIZONTAL_OFFSET;
+          arrowLeft = modalWidth;
+        } else {
+          // Can't display the modal at all without clipping
+          top = event.pageY + halfModalArrowWidth;
+          arrowLeft = halfModalWidth - halfModalArrowWidth;
+        }
       }
+
+      // If the modal clips outside the screen left or right then stick it to the edge
+      if (left + modalWidth > windowWidth - SCREEN_PADDING) {
+        left = windowWidth - modalWidth - SCREEN_PADDING;
+        arrowLeft = event.pageX - left - halfModalArrowWidth;
+      } else if (left < SCREEN_PADDING) {
+        left = SCREEN_PADDING;
+        arrowLeft = event.pageX - SCREEN_PADDING - halfModalArrowWidth;
+      }
+
+      // Re-position any sub lists that would open to the right of the right edge
+      const modalRight = left + modalWidth;
+      $modal.find('.modal-list>li>ul')
+        .filter((_, subList) => modalRight + $(subList).outerWidth() > windowWidth)
+        .addClass('modal-sub-left');
+
+      $modal.addClass(cls)
+        .css('left', left)
+        .css('top', top);
+
+      $modalArrow
+        .css('left', arrowLeft)
+        .css('bottom', arrowBottom);
     });
 
     return false;


### PR DESCRIPTION
GitHub Issue (if applicable): #2156 

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
Added some calculations of the menu position and make a few attempts at moving it so it stays within the window. Most notably by placing to the left or right of the cursor if there is not enough room above or below the selected row for the menu to fully show.

![firefox_2020-10-30_16-58-41](https://user-images.githubusercontent.com/1681249/97658810-2455f700-1ad2-11eb-856b-68b6888ba0af.png) The menu goes to the right of the mouse by default

![firefox_2020-10-30_17-07-10](https://user-images.githubusercontent.com/1681249/97658890-5c5d3a00-1ad2-11eb-8d1f-448b5256bc0a.png) The menu goes to the left of the mouse if near the right of the screen

![firefox_2020-10-30_16-58-15](https://user-images.githubusercontent.com/1681249/97658911-6a12bf80-1ad2-11eb-9c95-52bba63bede4.png) Also fixed it so the sub list will open up on the left if it would otherwise open outside of the viewport

![firefox_2020-10-30_16-57-27](https://user-images.githubusercontent.com/1681249/97658944-8282da00-1ad2-11eb-8129-646c3f46002c.png) This is the same as normal behaviour except that if the menu would clip off the screen then it gets clamped to the edge of the viewport


