### PR TITLE
Add missing js-budget-table-row class for check-credit-balances

### DIFF
--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -34,7 +34,7 @@ export class CheckCreditBalances extends Feature {
       changedNodes.has('budget-number user-data') ||
       changedNodes.has('navlink-budget active') ||
       changedNodes.has('budget-inspector') ||
-      changedNodes.has('budget-table-row is-sub-category is-debt-payment-category is-checked') ||
+      changedNodes.has('budget-table-row js-budget-table-row is-sub-category is-debt-payment-category is-checked') ||
       changedNodes.has('budget-header-totals-cell-value user-data')
     ) {
       this.invoke();


### PR DESCRIPTION
GitHub Issue (if applicable): #2207

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
It looks like YNAB must have added `js-budget-table-row` class recently.  This pull request simply adds the missing class so it properly invokes the `check-credit-balances` or "Paid in full assist" extension when a debt category is selected.
