### PR TITLE
Assisted Clear: Negate CC Input Value

### DIFF
--- a/src/extension/features/accounts/assisted-clear/assistedClearUtils.js
+++ b/src/extension/features/accounts/assisted-clear/assistedClearUtils.js
@@ -11,6 +11,7 @@ export const setTransactionCleared = transaction => {
     }
   }
 };
+
 /**
  * Generate all subsets for an array
  * @param {Array} array Array to generate powerset for

--- a/src/extension/features/accounts/assisted-clear/components/AssistedClearContainer.jsx
+++ b/src/extension/features/accounts/assisted-clear/components/AssistedClearContainer.jsx
@@ -28,7 +28,6 @@ export const ClearAssistantContainer = ({ reconcileInputValue }) => {
     let { clearedBalance } = account.getAccountCalculation();
 
     // Get all the uncleared transactions
-
     let unclearedTransactions = transactions.filter(
       txn => txn.cleared && txn.isUncleared() && !txn.isTombstone
     );

--- a/src/extension/features/accounts/assisted-clear/components/AssistedClearContainer.jsx
+++ b/src/extension/features/accounts/assisted-clear/components/AssistedClearContainer.jsx
@@ -40,19 +40,13 @@ export const ClearAssistantContainer = ({ reconcileInputValue }) => {
     let calculatedTarget = convertedInputValue - clearedBalance;
 
     // Figure out which of the non reconciled transactions add up to our target
-
     let transactionPowerset = generatePowerset(unclearedTransactions);
-
     let possibleMatches = findMatchingSum(transactionPowerset, calculatedTarget);
 
     // Update context state
-
     setClearedTotal(clearedBalance);
-
     setTarget(calculatedTarget);
-
     setMatchingTransactions(possibleMatches);
-
     setModalOpened(true);
   };
 

--- a/src/extension/features/accounts/assisted-clear/components/AssistedClearContainer.jsx
+++ b/src/extension/features/accounts/assisted-clear/components/AssistedClearContainer.jsx
@@ -29,6 +29,11 @@ export const ClearAssistantContainer = ({ reconcileInputValue }) => {
     let unclearedTransactions = transactions.filter(
       txn => txn.cleared && txn.isUncleared() && !txn.isTombstone
     );
+
+    // Note: For credit cards, we'll automatically invert to follow ynab's behavior
+    if (reconcileInputValue > 0 && account.getAccountType() == 'CreditCard') {
+      reconcileInputValue *= -1;
+    }
     let calculatedTarget = Number(reconcileInputValue) * 1000 - clearedBalance;
 
     // Figure out which of the non reconciled transactions add up to our target

--- a/src/extension/features/accounts/assisted-clear/components/AssistedClearModal.jsx
+++ b/src/extension/features/accounts/assisted-clear/components/AssistedClearModal.jsx
@@ -3,9 +3,10 @@ import * as ReactDOM from 'react-dom';
 import { setTransactionCleared } from '../assistedClearUtils';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { ASSISTED_CLEAR_MODAL_PORTAL } from '../index';
+import PropTypes from 'prop-types';
 import '../styles.scss';
 
-export const ClearAssistantModal = ({
+export const AssistedClearModal = ({
   isOpen,
   setModalOpened,
   matchingTransactions,
@@ -163,4 +164,12 @@ export const ClearAssistantModal = ({
     </div>,
     document.getElementById(ASSISTED_CLEAR_MODAL_PORTAL)
   );
+};
+
+AssistedClearModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  setModalOpened: PropTypes.func.isRequired,
+  matchingTransactions: PropTypes.array.isRequired,
+  clearedTotal: PropTypes.number.isRequired,
+  target: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2232

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
In the case of credit cards, ynab allows you to enter positive numbers and it'll think it's a negative. IE

Current Cleared Balance: -25
Enter Reconcile Balance: 30

YNAB will try and add a -5.
Mimicking that behavior here, we'll treat it as -30 in this scenario.

Side Note: My only concern is with positive credit card balances, as this will negate it. Although, actual positive credit card balances are rare.