### PR TITLE
Balance Over Time LocalStorage

### DIFF
--- a/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.jsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.jsx
@@ -4,8 +4,8 @@ import { FiltersPropType } from 'toolkit-reports/common/components/report-contex
 import { RunningBalanceGraph } from './RunningBalanceGraph';
 import { LabeledCheckbox } from 'toolkit-reports/common/components/labeled-checkbox';
 import { WarningMessage } from './WarningMessage';
-import { useLocalStorage } from '../../../../hooks/useLocalStorage';
-import { getEntityManager } from '../../../../utils/ynab';
+import { useLocalStorage } from 'toolkit/extension/hooks/useLocalStorage';
+import { getEntityManager } from 'toolkit/extension/utils/ynab';
 import {
   dataPointsToHighChartSeries,
   generateRunningBalanceMap,
@@ -17,23 +17,16 @@ import {
 } from './utils';
 
 export const BalanceOverTimeComponent = ({ allReportableTransactions, filters }) => {
-  const LOCALSTORAGE_PREFIX = 'tk-balance-over-time';
   const GROUPED_LABEL = 'Selected Accounts';
   const TRENDLINE_PREFIX = 'Trendline for ';
 
   // Options to group accounts, use a step graph and/or generate trendlines
   const [shouldGroupAccounts, setShouldGroupAccounts] = useLocalStorage(
-    `${LOCALSTORAGE_PREFIX}.shouldGroupAccounts`,
+    'balance-over-time-shouldGroupAccounts',
     false
   );
-  const [useStepGraph, setUseStepGraph] = useLocalStorage(
-    `${LOCALSTORAGE_PREFIX}.useStepGraph`,
-    true
-  );
-  const [useTrendLine, setUseTrendLine] = useLocalStorage(
-    `${LOCALSTORAGE_PREFIX}.useTrendline`,
-    false
-  );
+  const [useStepGraph, setUseStepGraph] = useLocalStorage('balance-over-time-useStepGraph', true);
+  const [useTrendLine, setUseTrendLine] = useLocalStorage('balance-over-time-useTrendline', false);
 
   // Map of accounts to their corresponding datapoints for each date
   const [runningBalanceMap, setRunningBalanceMap] = useState(new Map());

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.jsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.jsx
@@ -4,6 +4,8 @@ import { FiltersPropType } from 'toolkit-reports/common/components/report-contex
 import { RunningBalanceGraph } from './RunningBalanceGraph';
 import { LabeledCheckbox } from 'toolkit-reports/common/components/labeled-checkbox';
 import { WarningMessage } from './WarningMessage';
+import { useLocalStorage } from '../../../../hooks/useLocalStorage';
+import { getEntityManager } from '../../../../utils/ynab';
 import {
   dataPointsToHighChartSeries,
   generateRunningBalanceMap,
@@ -14,15 +16,24 @@ import {
   NUM_DATAPOINTS_LIMIT,
 } from './utils';
 
-import { getEntityManager } from '../../../../utils/ynab';
 export const BalanceOverTimeComponent = ({ allReportableTransactions, filters }) => {
+  const LOCALSTORAGE_PREFIX = 'tk-balance-over-time';
   const GROUPED_LABEL = 'Selected Accounts';
   const TRENDLINE_PREFIX = 'Trendline for ';
 
   // Options to group accounts, use a step graph and/or generate trendlines
-  const [shouldGroupAccounts, setShouldGroupAccounts] = useState(false);
-  const [useStepGraph, setUseStepGraph] = useState(true);
-  const [useTrendLine, setUseTrendLine] = useState(false);
+  const [shouldGroupAccounts, setShouldGroupAccounts] = useLocalStorage(
+    `${LOCALSTORAGE_PREFIX}.shouldGroupAccounts`,
+    false
+  );
+  const [useStepGraph, setUseStepGraph] = useLocalStorage(
+    `${LOCALSTORAGE_PREFIX}.useStepGraph`,
+    true
+  );
+  const [useTrendLine, setUseTrendLine] = useLocalStorage(
+    `${LOCALSTORAGE_PREFIX}.useTrendline`,
+    false
+  );
 
   // Map of accounts to their corresponding datapoints for each date
   const [runningBalanceMap, setRunningBalanceMap] = useState(new Map());

--- a/src/extension/hooks/useLocalStorage.jsx
+++ b/src/extension/hooks/useLocalStorage.jsx
@@ -1,0 +1,26 @@
+// https://usehooks.com/useLocalStorage/
+import { useState } from 'react';
+export function useLocalStorage(key, initialValue) {
+  const [storedValue, setStoredValue] = useState(() => {
+    // Get the saved value if any, otherwise use the initial value
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      return initialValue;
+    }
+  });
+
+  // Wrapper function around setStoredValue to save into Local Storage
+  const setValue = value => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return [storedValue, setValue];
+}

--- a/src/extension/hooks/useLocalStorage.jsx
+++ b/src/extension/hooks/useLocalStorage.jsx
@@ -6,7 +6,8 @@ export function useLocalStorage(key, initialValue) {
   const [storedValue, setStoredValue] = useState(() => {
     // Get the saved value if any, otherwise use the initial value
     try {
-      const item = window.localStorage.getItem(key);
+      let localStorageKey = `${STORAGE_KEY_PREFIX}${key}`;
+      const item = window.localStorage.getItem(localStorageKey);
       return item ? JSON.parse(item) : initialValue;
     } catch (error) {
       return initialValue;

--- a/src/extension/hooks/useLocalStorage.jsx
+++ b/src/extension/hooks/useLocalStorage.jsx
@@ -1,5 +1,7 @@
 // https://usehooks.com/useLocalStorage/
 import { useState } from 'react';
+
+const STORAGE_KEY_PREFIX = 'ynab-toolkit-';
 export function useLocalStorage(key, initialValue) {
   const [storedValue, setStoredValue] = useState(() => {
     // Get the saved value if any, otherwise use the initial value
@@ -16,7 +18,8 @@ export function useLocalStorage(key, initialValue) {
     try {
       const valueToStore = value instanceof Function ? value(storedValue) : value;
       setStoredValue(valueToStore);
-      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      let localStorageKey = `${STORAGE_KEY_PREFIX}${key}`;
+      window.localStorage.setItem(localStorageKey, JSON.stringify(valueToStore));
     } catch (error) {
       console.log(error);
     }


### PR DESCRIPTION
GitHub Issue (if applicable): #2272
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2272

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
Instead of defaulting it, we can keep some sort of saved preferences by saving into localStorage.
- Adding a hooks folder and useLocalStorage hook.
- Replace useState with useLocalStorage for the three options of the Balance Over Time graph.
