### PR TITLE
Add Last Reconciled Date

### DIFF
--- a/src/extension/features/accounts/last-reconciled-date/index.js
+++ b/src/extension/features/accounts/last-reconciled-date/index.js
@@ -1,0 +1,85 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { getEntityManager } from 'toolkit/extension/utils/ynab';
+const YNAB_ACCOUNTS_HEADER_BALANCES = '.accounts-header-balances-right';
+const TK_LAST_RECONCILED_ID = 'tk-last-reconciled-date';
+
+export class LastReconciledDate extends Feature {
+  injectCSS() {
+    return require('./styles.css');
+  }
+
+  shouldInvoke() {
+    let { selectedAccountId } = controllerLookup('accounts');
+    return selectedAccountId && isCurrentRouteAccountsPage();
+  }
+
+  invoke() {
+    // Get the current account id and calculate the last reconciled date
+    let { selectedAccountId } = controllerLookup('accounts');
+    let latestDate = this._calculateLastReconciledDate(selectedAccountId);
+    let textToShow = 'NA';
+    if (latestDate) {
+      textToShow = ynab.YNABSharedLib.dateFormatter.formatDateExpanded(latestDate.utc());
+    }
+    // Retrieve or create the reconcile date container
+    let balanceContainer = $(`#${TK_LAST_RECONCILED_ID}`);
+    if (!balanceContainer || balanceContainer.length === 0) {
+      $(YNAB_ACCOUNTS_HEADER_BALANCES).append(
+        `<div class="tk-accounts-header-last-reconciled">
+        <span id="${TK_LAST_RECONCILED_ID}">${textToShow}</span>
+        <div class="tk-accounts-header-last-reconciled-label">Last Reconciled Date</div>
+      </div>`
+      );
+    }
+
+    // Update the reconcile balance with the most up to date balance
+    balanceContainer.text(textToShow);
+    this._setFeatureVisibility(true);
+  }
+
+  onRouteChanged() {
+    if (this.shouldInvoke()) {
+      this.invoke();
+    } else {
+      this._setFeatureVisibility(false);
+    }
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    // When the reconciled balance icon changes, reevaluate our date
+    if (changedNodes.has('is-reconciled-icon svg-icon lock')) {
+      this.invoke();
+    }
+  }
+
+  /**
+   * Calculate the last reconciled date
+   * @param {String} accountId The account id to get the reconciled balance for
+   * @returns {Moment} the latest date, null otherwise
+   */
+  _calculateLastReconciledDate = accountId => {
+    const account = getEntityManager().getAccountById(accountId);
+
+    let reconciledDates = account
+      .getTransactions()
+      .filter(transaction => transaction.date && transaction.isReconciled())
+      .map(transaction => moment(transaction.date.getUTCTime()));
+
+    return reconciledDates.length ? moment.max(reconciledDates) : null;
+  };
+
+  /**
+   * Helper method to show and hide the reconcile balance container
+   * @param {Boolean} visible True to show the container, false to hide
+   */
+  _setFeatureVisibility = visible => {
+    let featureContainer = $('.tk-accounts-header-last-reconciled');
+    if (featureContainer && featureContainer.length) {
+      featureContainer.toggle(visible);
+    }
+  };
+}

--- a/src/extension/features/accounts/last-reconciled-date/index.js
+++ b/src/extension/features/accounts/last-reconciled-date/index.js
@@ -24,8 +24,8 @@ export class LastReconciledDate extends Feature {
       textToShow = ynab.YNABSharedLib.dateFormatter.formatDateExpanded(latestDate.utc());
     }
     // Retrieve or create the reconcile date container
-    let balanceContainer = $(`#${TK_LAST_RECONCILED_ID}`);
-    if (!balanceContainer || balanceContainer.length === 0) {
+    let dateContainer = $(`#${TK_LAST_RECONCILED_ID}`);
+    if (!dateContainer || dateContainer.length === 0) {
       $(YNAB_ACCOUNTS_HEADER_RIGHT).append(
         `<div class="tk-accounts-header-last-reconciled">
         <span id="${TK_LAST_RECONCILED_ID}">${textToShow}</span>
@@ -35,7 +35,7 @@ export class LastReconciledDate extends Feature {
     }
 
     // Update the reconcile date in the element
-    balanceContainer.text(textToShow);
+    dateContainer.text(textToShow);
     this._setFeatureVisibility(true);
   }
 

--- a/src/extension/features/accounts/last-reconciled-date/index.js
+++ b/src/extension/features/accounts/last-reconciled-date/index.js
@@ -2,7 +2,7 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 import { getEntityManager } from 'toolkit/extension/utils/ynab';
-const YNAB_ACCOUNTS_HEADER_BALANCES = '.accounts-header-balances-right';
+const YNAB_ACCOUNTS_HEADER_RIGHT = '.accounts-header-balances-right';
 const TK_LAST_RECONCILED_ID = 'tk-last-reconciled-date';
 
 export class LastReconciledDate extends Feature {
@@ -26,7 +26,7 @@ export class LastReconciledDate extends Feature {
     // Retrieve or create the reconcile date container
     let balanceContainer = $(`#${TK_LAST_RECONCILED_ID}`);
     if (!balanceContainer || balanceContainer.length === 0) {
-      $(YNAB_ACCOUNTS_HEADER_BALANCES).append(
+      $(YNAB_ACCOUNTS_HEADER_RIGHT).append(
         `<div class="tk-accounts-header-last-reconciled">
         <span id="${TK_LAST_RECONCILED_ID}">${textToShow}</span>
         <div class="tk-accounts-header-last-reconciled-label">Last Reconciled Date</div>
@@ -34,7 +34,7 @@ export class LastReconciledDate extends Feature {
       );
     }
 
-    // Update the reconcile balance with the most up to date balance
+    // Update the reconcile date in the element
     balanceContainer.text(textToShow);
     this._setFeatureVisibility(true);
   }
@@ -50,7 +50,7 @@ export class LastReconciledDate extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    // When the reconciled balance icon changes, reevaluate our date
+    // When the reconciled icon changes, reevaluate our date
     if (changedNodes.has('is-reconciled-icon svg-icon lock')) {
       this.invoke();
     }
@@ -58,7 +58,7 @@ export class LastReconciledDate extends Feature {
 
   /**
    * Calculate the last reconciled date
-   * @param {String} accountId The account id to get the reconciled balance for
+   * @param {String} accountId The account id to get the reconciled date for
    * @returns {Moment} the latest date, null otherwise
    */
   _calculateLastReconciledDate = accountId => {
@@ -73,7 +73,7 @@ export class LastReconciledDate extends Feature {
   };
 
   /**
-   * Helper method to show and hide the reconcile balance container
+   * Helper method to show and hide the reconcile date container
    * @param {Boolean} visible True to show the container, false to hide
    */
   _setFeatureVisibility = visible => {

--- a/src/extension/features/accounts/last-reconciled-date/settings.js
+++ b/src/extension/features/accounts/last-reconciled-date/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'LastReconciledDate',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Show Last Reconciled Date',
+  description: 'Show the last reconciled date of the current account in the header',
+};

--- a/src/extension/features/accounts/last-reconciled-date/styles.css
+++ b/src/extension/features/accounts/last-reconciled-date/styles.css
@@ -1,0 +1,16 @@
+.tk-accounts-header-last-reconciled {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  font-size: 1rem;
+  flex: 0 1 auto;
+  align-self: flex-end;
+}
+
+.tk-accounts-header-last-reconciled-label {
+  font-size: 0.75rem;
+  color: var(--header_label_primary);
+  font-weight: 400;
+  margin-top: 0.1rem;
+}

--- a/src/extension/features/accounts/reconcile-balance/index.js
+++ b/src/extension/features/accounts/reconcile-balance/index.js
@@ -32,7 +32,7 @@ export class ReconcileBalance extends Feature {
       );
     }
 
-    // Update the reconcile date
+    // Update the reconcile balance with the most up to date balance
     balanceContainer.text(reconciledBalance);
     this._setFeatureVisibility(true);
   }

--- a/src/extension/features/accounts/reconcile-balance/index.js
+++ b/src/extension/features/accounts/reconcile-balance/index.js
@@ -32,7 +32,7 @@ export class ReconcileBalance extends Feature {
       );
     }
 
-    // Update the reconcile balance with the most up to date balance
+    // Update the reconcile date
     balanceContainer.text(reconciledBalance);
     this._setFeatureVisibility(true);
   }


### PR DESCRIPTION
GitHub Issue (if applicable): #2275
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2275
https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2237

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Adding the last reconciled date to the accounts header next to the reconcile button.
This works fairly well with Show Reconciled Balance.

Example:
With applicable date: 
![image](https://user-images.githubusercontent.com/24358685/106351717-9d601880-6292-11eb-96b4-bbab8ace692f.png)

No last reconciled date:
![image](https://user-images.githubusercontent.com/24358685/106351703-86b9c180-6292-11eb-869d-a985952e5c06.png)
