### PR TITLE
Quick switch order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toolkit-for-ynab",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "private": true,
   "scripts": {
     "build:check": "yarn && yarn gen && yarn lint",

--- a/src/extension/features/general/budget-quick-switch/index.js
+++ b/src/extension/features/general/budget-quick-switch/index.js
@@ -20,7 +20,7 @@ export class BudgetQuickSwitch extends Feature {
     }
 
     const modalList = $('.modal-list', element)[0];
-    let activeBudgetVersionId = controllerLookup('application').get('budgetVersionId');
+    const activeBudgetVersionId = controllerLookup('application').get('budgetVersionId');
 
     ynab.YNABSharedLib.getCatalogViewModel_UserViewModel().then(({ userBudgetDisplayItems }) => {
       userBudgetDisplayItems
@@ -29,6 +29,8 @@ export class BudgetQuickSwitch extends Feature {
             !budget.get('isTombstone') && budget.get('budgetVersionId') !== activeBudgetVersionId
           );
         })
+        // Sort in ascending order as we're prepending the component
+        .sort((a, b) => a.get('lastModifiedAt') - b.get('lastModifiedAt'))
         .forEach((budget, i) => {
           const budgetVersionName = budget.get('budgetVersionName');
           const budgetVersionId = budget.get('budgetVersionId');
@@ -44,7 +46,7 @@ export class BudgetQuickSwitch extends Feature {
 
           componentPrepend(
             <BudgetListItem
-              key={budget.get('budgetVersionId')}
+              key={budgetVersionId}
               budgetVersionId={budgetVersionId}
               budgetVersionName={budgetVersionName}
             />,


### PR DESCRIPTION
GitHub Issue (if applicable): #2282

**Explanation of Bugfix/Feature/Modification:**
I'd like to get some pointers on this fix if possible. I couldn't see a consistent order for the list of budgets returned by `ynab.YNABSharedLib.getCatalogViewModel_UserViewModel()`. I've added a `.sort` after the `.filter` in order to sort by `lastModifiedAt` and also cleaned up a bit of code.
