### PR TITLE
Net worth report "Flip Debt"

### DIFF
--- a/src/extension/features/general/budget-quick-switch/index.js
+++ b/src/extension/features/general/budget-quick-switch/index.js
@@ -20,7 +20,7 @@ export class BudgetQuickSwitch extends Feature {
     }
 
     const modalList = $('.modal-list', element)[0];
-    let activeBudgetVersionId = controllerLookup('application').get('budgetVersionId');
+    const activeBudgetVersionId = controllerLookup('application').get('budgetVersionId');
 
     ynab.YNABSharedLib.getCatalogViewModel_UserViewModel().then(({ userBudgetDisplayItems }) => {
       userBudgetDisplayItems
@@ -29,6 +29,8 @@ export class BudgetQuickSwitch extends Feature {
             !budget.get('isTombstone') && budget.get('budgetVersionId') !== activeBudgetVersionId
           );
         })
+        // Sort in ascending order as we're prepending the component
+        .sort((a, b) => a.get('lastModifiedAt') - b.get('lastModifiedAt'))
         .forEach((budget, i) => {
           const budgetVersionName = budget.get('budgetVersionName');
           const budgetVersionId = budget.get('budgetVersionId');
@@ -44,7 +46,7 @@ export class BudgetQuickSwitch extends Feature {
 
           componentPrepend(
             <BudgetListItem
-              key={budget.get('budgetVersionId')}
+              key={budgetVersionId}
               budgetVersionId={budgetVersionId}
               budgetVersionName={budgetVersionName}
             />,

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -14,7 +14,9 @@ export class NetWorthComponent extends React.Component {
     allReportableTransactions: PropTypes.array.isRequired,
   };
 
-  state = {};
+  state = {
+    inverseDebt: false,
+  };
 
   componentDidMount() {
     this._calculateData();
@@ -36,9 +38,9 @@ export class NetWorthComponent extends React.Component {
           <div>
             <LabeledCheckbox
               id="someId"
-              checked={true}
+              checked={this.state.inverseDebt}
               label="Flip Debt"
-              // onChange={this.toggleIncome}
+              onChange={this.toggleDebtDirection}
             />
           </div>
         </div>
@@ -58,6 +60,11 @@ export class NetWorthComponent extends React.Component {
       </div>
     );
   }
+
+  toggleDebtDirection = () => {
+    this.setState(prevState => ({ inverseDebt: !prevState.inverseDebt }));
+    this._calculateData();
+  };
 
   _renderReport = () => {
     const _this = this;
@@ -117,7 +124,7 @@ export class NetWorthComponent extends React.Component {
           type: 'column',
           name: l10n('toolkit.debts', 'Debts'),
           color: 'rgba(234,106,81,1)',
-          data: debts,
+          data: this.state.inverseDebt ? debts.map(item => -item) : debts,
           pointPadding: 0,
           point: pointHover,
         },

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -6,6 +6,7 @@ import { localizedMonthAndYear, sortByGettableDate } from 'toolkit/extension/uti
 import { l10n } from 'toolkit/extension/utils/toolkit';
 import { FiltersPropType } from 'toolkit-reports/common/components/report-context/component';
 import { Legend } from './components/legend';
+import { LabeledCheckbox } from 'toolkit-reports/common/components/labeled-checkbox';
 
 export class NetWorthComponent extends React.Component {
   static propTypes = {
@@ -30,18 +31,30 @@ export class NetWorthComponent extends React.Component {
 
   render() {
     return (
-      <div className="tk-flex tk-flex-column tk-flex-grow">
-        <div className="tk-flex tk-justify-content-end">
-          {this.state.hoveredData && (
-            <Legend
-              assets={this.state.hoveredData.assets}
-              debts={this.state.hoveredData.debts}
-              debtRatio={this.state.hoveredData.debtRatio}
-              netWorth={this.state.hoveredData.netWorth}
+      <div className="tk-flex-grow tk-flex tk-flex-column">
+        <div className="tk-flex tk-pd-05 tk-border-b">
+          <div>
+            <LabeledCheckbox
+              id="someId"
+              checked={true}
+              label="Flip Debt"
+              // onChange={this.toggleIncome}
             />
-          )}
+          </div>
         </div>
-        <div className="tk-highcharts-report-container" id="tk-net-worth-chart" />
+        <div className="tk-flex tk-flex-column tk-flex-grow">
+          <div className="tk-flex tk-justify-content-end">
+            {this.state.hoveredData && (
+              <Legend
+                assets={this.state.hoveredData.assets}
+                debts={this.state.hoveredData.debts}
+                debtRatio={this.state.hoveredData.debtRatio}
+                netWorth={this.state.hoveredData.netWorth}
+              />
+            )}
+          </div>
+          <div className="tk-highcharts-report-container" id="tk-net-worth-chart" />
+        </div>
       </div>
     );
   }

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -7,6 +7,11 @@ import { l10n } from 'toolkit/extension/utils/toolkit';
 import { FiltersPropType } from 'toolkit-reports/common/components/report-context/component';
 import { Legend } from './components/legend';
 import { LabeledCheckbox } from 'toolkit-reports/common/components/labeled-checkbox';
+import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+
+const STORAGE_KEYS = {
+  inverseDebt: 'net-worth-inverse-debt',
+};
 
 export class NetWorthComponent extends React.Component {
   static propTypes = {
@@ -15,7 +20,7 @@ export class NetWorthComponent extends React.Component {
   };
 
   state = {
-    inverseDebt: false,
+    inverseDebt: getToolkitStorageKey(STORAGE_KEYS.inverseDebt, false),
   };
 
   componentDidMount() {
@@ -37,7 +42,7 @@ export class NetWorthComponent extends React.Component {
         <div className="tk-flex tk-pd-05 tk-border-b">
           <div>
             <LabeledCheckbox
-              id="someId"
+              id="tk-net-worth-invserse-debt-selector"
               checked={this.state.inverseDebt}
               label="Flip Debt"
               onChange={this.toggleDebtDirection}
@@ -62,7 +67,11 @@ export class NetWorthComponent extends React.Component {
   }
 
   toggleDebtDirection = () => {
-    this.setState(prevState => ({ inverseDebt: !prevState.inverseDebt }));
+    this.setState(prevState => {
+      const inverseDebt = !prevState.inverseDebt;
+      setToolkitStorageKey(STORAGE_KEYS.inverseDebt, inverseDebt);
+      return { inverseDebt };
+    });
     this._calculateData();
   };
 

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -42,7 +42,7 @@ export class NetWorthComponent extends React.Component {
         <div className="tk-flex tk-pd-05 tk-border-b">
           <div>
             <LabeledCheckbox
-              id="tk-net-worth-invserse-debt-selector"
+              id="tk-net-worth-inverse-debt-selector"
               checked={this.state.inverseDebt}
               label="Flip Debt"
               onChange={this.toggleDebtDirection}


### PR DESCRIPTION
GitHub Issue (if applicable): #2297 

**Explanation of Bugfix/Feature/Modification:**
Added a "Flip Debt" toggle for the **Net Worth** Toolkit Report so that it displays the debt total below the y-axis. I think this is a bit more intuitive.

**Flip Debt Off**
![image](https://user-images.githubusercontent.com/24278706/109842554-17910d80-7c42-11eb-8fc8-1d928c8d44fb.png)

**Flip Debt On**
![image](https://user-images.githubusercontent.com/24278706/109842593-211a7580-7c42-11eb-817d-88f7fe1779bf.png)
