### PR TITLE
feat: add "Highlight Budget Rows On Hover" feature

### DIFF
--- a/src/extension/features/budget/highlight-budget-rows-on-hover/index.css
+++ b/src/extension/features/budget/highlight-budget-rows-on-hover/index.css
@@ -1,0 +1,18 @@
+body,
+body.theme-new-default {
+  --tk-hovered-budget-row-color: #e3e3e3;
+}
+
+body.theme-classic {
+  --tk-hovered-budget-row-color: #e3e3e3;
+}
+
+body.theme-dark {
+  --tk-hovered-budget-row-color: #3f3f43;
+}
+
+.budget-table-row.is-sub-category:hover:not(.is-checked):not(.is-editing):not(.ynab-grid-body-empty):not(.ynab-grid-actions) {
+  background-color: var(
+    --tk-hovered-budget-row-color
+  ) !important; /* We have to use !important here to avoid conflicts with "striped budget rows" */
+}

--- a/src/extension/features/budget/highlight-budget-rows-on-hover/index.js
+++ b/src/extension/features/budget/highlight-budget-rows-on-hover/index.js
@@ -1,0 +1,7 @@
+import { Feature } from 'toolkit/extension/features/feature';
+
+export class HoveredBudgetRows extends Feature {
+  injectCSS() {
+    return require('./index.css');
+  }
+}

--- a/src/extension/features/budget/highlight-budget-rows-on-hover/settings.js
+++ b/src/extension/features/budget/highlight-budget-rows-on-hover/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'HoveredBudgetRows',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Highlight Budget Rows On Hover',
+  description: 'Shows a light gray background on category rows when hovered over.',
+};


### PR DESCRIPTION
GitHub Issue (if applicable): ---

Trello Link (if applicable): ---

**Explanation of Bugfix/Feature/Modification:**
Added a simple CSS-only feature to highlight rows in the budget screen on hover. Tested and confirmed it works well with all three themes, and plays nice with "Striped Budget Rows".

![image](https://user-images.githubusercontent.com/1538723/110199765-fc7ff280-7e27-11eb-9a1d-0543ebd55d9a.png)
![image](https://user-images.githubusercontent.com/1538723/110199771-0570c400-7e28-11eb-935a-4216abffcee3.png)
![image](https://user-images.githubusercontent.com/1538723/110199776-0bff3b80-7e28-11eb-9228-b11b3f56376d.png)

It also does not conflict with "Show Upcoming Transaction Total":
![image](https://user-images.githubusercontent.com/1538723/110199832-5e405c80-7e28-11eb-9865-e9a08e3a78a4.png)
![image](https://user-images.githubusercontent.com/1538723/110199852-73b58680-7e28-11eb-9e04-d8bb3807b231.png)
