### PR TITLE
AllAccountTransactionsViewModel renamed to AllAccountsViewModel

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
@@ -124,29 +124,27 @@ export function withReportContextProvider(InnerComponent) {
     }
 
     componentDidMount() {
-      ynab.YNABSharedLib.getBudgetViewModel_AllAccountTransactionsViewModel().then(
-        transactionsViewModel => {
-          const visibleTransactionDisplayItems = transactionsViewModel.get(
-            'visibleTransactionDisplayItems'
-          );
-          const allReportableTransactions = visibleTransactionDisplayItems.filter(
-            transaction =>
-              !transaction.get('isSplit') &&
-              !transaction.get('isScheduledTransaction') &&
-              !transaction.get('isScheduledSubTransaction')
-          );
+      ynab.YNABSharedLib.getBudgetViewModel_AllAccountsViewModel().then(transactionsViewModel => {
+        const visibleTransactionDisplayItems = transactionsViewModel.get(
+          'visibleTransactionDisplayItems'
+        );
+        const allReportableTransactions = visibleTransactionDisplayItems.filter(
+          transaction =>
+            !transaction.get('isSplit') &&
+            !transaction.get('isScheduledTransaction') &&
+            !transaction.get('isScheduledSubTransaction')
+        );
 
-          this.setState(
-            {
-              filteredTransactions: [],
-              allReportableTransactions,
-            },
-            () => {
-              this._applyFilters(this.state.activeReportKey);
-            }
-          );
-        }
-      );
+        this.setState(
+          {
+            filteredTransactions: [],
+            allReportableTransactions,
+          },
+          () => {
+            this._applyFilters(this.state.activeReportKey);
+          }
+        );
+      });
     }
 
     render() {


### PR DESCRIPTION
We detected the error: `ynab.YNABSharedLib.getBudgetViewModel_AllAccountTransactionsViewModel is not a function` and it is because the internal API `AllAccountTransactionsViewModel` was renamed to `AllAccountsViewModel`.