### PR TITLE
Fix series (of Balance Over Time - Group By Type) showing incorrect labels

### DIFF
--- a/src/extension/utils/toolkit.js
+++ b/src/extension/utils/toolkit.js
@@ -100,9 +100,9 @@ export function l10nAccountType(accountType) {
     case ynab.enums.AccountType.Savings:
       return l10n('Savings', 'Savings');
     case ynab.enums.AccountType.Cash:
-      return l10n('Cash', 'Credit Card');
+      return l10n('Cash', 'Cash');
     case ynab.enums.AccountType.CreditCard:
-      return l10n('CreditCard', 'Cash');
+      return l10n('CreditCard', 'Credit Card');
     case ynab.enums.AccountType.LineOfCredit:
       return l10n('LineOfCredit', 'Line of Credit');
     case ynab.enums.AccountType.Mortgage:


### PR DESCRIPTION
This commit fixes the swapped series labels for Credit Cards and Cash.

GitHub Issue (if applicable): #2314 

**Explanation of Bugfix/Feature/Modification:**
On the 'Balance Over Time' screen, the series labels "Cash" and "Credit Card" are swapped.
That is, cash accounts are labeled as 'Credit Card' and credit card accounts are labeled as 'Cash'.
This PR fixes these two swapped out strings.