### PR TITLE
Adds new setting for a confetti animation on reconciliation

### DIFF
--- a/src/extension/features/accounts/reconcile-confetti/index.css
+++ b/src/extension/features/accounts/reconcile-confetti/index.css
@@ -1,0 +1,23 @@
+@keyframes confetti {
+  from {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+}
+
+@keyframes falldown {
+  to {
+    top: 100%;
+    opacity: 0;
+  }
+}
+
+i.confetti {
+  position: absolute;
+  display: block;
+  border-radius: 15%;
+  left: 50%;
+  top: 50%;
+  width: 5px;
+  height: 10px;
+}

--- a/src/extension/features/accounts/reconcile-confetti/index.js
+++ b/src/extension/features/accounts/reconcile-confetti/index.js
@@ -1,0 +1,41 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+const NUM_CONFETTI = 100;
+const RECONCILE_SUCCESS_MODAL_CLASS = 'modal-account-reconcile-reconciled';
+
+export class ReconcileConfetti extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage();
+  }
+
+  invoke() {}
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (changedNodes.has(RECONCILE_SUCCESS_MODAL_CLASS)) {
+      this.throwConfetti();
+    }
+  }
+
+  throwConfetti() {
+    const container = $(`.${RECONCILE_SUCCESS_MODAL_CLASS}`).parent();
+    for (let i = 0; i < NUM_CONFETTI; i++) {
+      const xPos = Math.random() * 300 - 150;
+      const yPos = Math.random() * 150 - 150;
+      const rot = Math.random() * 360;
+      const color = Math.random() * 360;
+
+      const e = document.createElement('i');
+      e.classList.add('confetti');
+      e.style.cssText = `transform: translate3d(${xPos}px, ${yPos}px, 0) rotate(${rot}deg);
+        background: hsla(${color}, 100%, 50%, 1.0);
+        animation: confetti 800ms cubic-bezier(.15, .75, .50, 1) forwards, falldown 400ms ease-in 600ms forwards;`;
+      container.append(e);
+    }
+  }
+
+  injectCSS() {
+    return require('./index.css');
+  }
+}

--- a/src/extension/features/accounts/reconcile-confetti/settings.js
+++ b/src/extension/features/accounts/reconcile-confetti/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'ReconcileConfetti',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Show Reconcile Confetti',
+  description:
+    'When an account is sucessfully reconciled, show a fun confetti animation to mark your tremendous achievement.',
+};


### PR DESCRIPTION
GitHub Issue (if applicable): N/A

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
(Just for fun) Adds new setting for a confetti animation on account reconciliation. Disabled by default.
