### PR TITLE
issue-2324: make sure to get an array from visibleTransactions

### DIFF
--- a/src/extension/features/accounts/spare-change/index.js
+++ b/src/extension/features/accounts/spare-change/index.js
@@ -67,9 +67,8 @@ export class SpareChange extends Feature {
   }
 
   setSelectedTransactions() {
-    let visibleTransactionDisplayItems = this.accountsController.get(
-      'visibleTransactionDisplayItems'
-    );
+    let visibleTransactionDisplayItems =
+      this.accountsController.get('visibleTransactionDisplayItems') || [];
     this.selectedTransactions = visibleTransactionDisplayItems.filter(
       i => i.isChecked && i.get('outflow')
     );


### PR DESCRIPTION
GitHub Issue (if applicable): #2324

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Prevent filter on undefined.
