### PR TITLE
issue-2339: rename budgetVersionName to budgetName

### DIFF
--- a/src/extension/features/general/budget-quick-switch/components/budget-list-item.jsx
+++ b/src/extension/features/general/budget-quick-switch/components/budget-list-item.jsx
@@ -6,14 +6,14 @@ import { getApplicationService } from 'toolkit/extension/utils/ynab';
 export const BudgetListItem = props => {
   const handleClick = () => {
     const appService = getApplicationService();
-    appService.loadBudget(props.budgetVersionId, props.budgetVersionName);
+    appService.loadBudget(props.budgetVersionId, props.budgetName);
   };
 
   return (
     <li onClick={handleClick}>
       <button>
         <i className="flaticon stroke mail-1" />
-        {` Open ${props.budgetVersionName}`}
+        {` Open ${props.budgetName}`}
       </button>
     </li>
   );
@@ -21,5 +21,5 @@ export const BudgetListItem = props => {
 
 BudgetListItem.propTypes = {
   budgetVersionId: PropTypes.string.isRequired,
-  budgetVersionName: PropTypes.string.isRequired,
+  budgetName: PropTypes.string.isRequired,
 };

--- a/src/extension/features/general/budget-quick-switch/index.js
+++ b/src/extension/features/general/budget-quick-switch/index.js
@@ -32,7 +32,7 @@ export class BudgetQuickSwitch extends Feature {
         // Sort in ascending order as we're prepending the component
         .sort((a, b) => a.get('lastModifiedAt') - b.get('lastModifiedAt'))
         .forEach((budget, i) => {
-          const budgetVersionName = budget.get('budgetVersionName');
+          const budgetName = budget.get('budgetName');
           const budgetVersionId = budget.get('budgetVersionId');
 
           if (i === 0) {
@@ -48,7 +48,7 @@ export class BudgetQuickSwitch extends Feature {
             <BudgetListItem
               key={budgetVersionId}
               budgetVersionId={budgetVersionId}
-              budgetVersionName={budgetVersionName}
+              budgetName={budgetName}
             />,
             modalList
           );


### PR DESCRIPTION
GitHub Issue (if applicable): #2339

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**

Fixes #2339 by adjusting the `budgetVersionName` property to it's new, shorter name: `budgetName`.

Before:
<img width="229" alt="Screenshot 2021-03-30 at 16 30 58" src="https://user-images.githubusercontent.com/1148665/113065164-a6c40f00-9175-11eb-8977-e9932b8b501d.png">


After (Actual budget names do appear, these are mine):
<img width="221" alt="Screenshot 2021-03-30 at 16 31 36" src="https://user-images.githubusercontent.com/1148665/113065173-ac215980-9175-11eb-8b23-ded3d843cb9e.png">
