### PR TITLE
fix: "Highlight Current Month" text color in new-default theme

### DIFF
--- a/src/extension/features/budget/highlight-current-month/index.css
+++ b/src/extension/features/budget/highlight-current-month/index.css
@@ -3,19 +3,19 @@ body.theme-new-default {
   --tk-current-month-background-color: var(--sidebar_button_background_selected);
   --tk-current-month-control-color: #bee6ef;
   --tk-current-month-header-color: #ffffff;
-  --tk-current-month-note-color: #rgba(255, 255, 255, 0.4);
+  --tk-current-month-note-color: rgba(255, 255, 255, 0.6);
 }
 
 body.theme-classic {
   --tk-current-month-control-color: var(--primary_action);
   --tk-current-month-header-color: #ffffff;
-  --tk-current-month-note-color: #rgba(255, 255, 255, 0.4);
+  --tk-current-month-note-color: rgba(255, 255, 255, 0.6);
 }
 
 body.theme-dark {
   --tk-current-month-control-color: #ffffff;
   --tk-current-month-header-color: #ffffff;
-  --tk-current-month-note-color: #rgba(255, 255, 255, 0.4);
+  --tk-current-month-note-color: rgba(255, 255, 255, 0.6);
 }
 
 /* add transitions */
@@ -45,6 +45,11 @@ body.theme-dark {
 .budget-header .toolkit-highlight-current-month .flaticon {
   color: var(--tk-current-month-control-color);
 }
+
+.budget-header .toolkit-highlight-current-month .budget-header-calendar-date-button {
+  color: var(--tk-current-month-header-color);
+}
+
 .budget-header .toolkit-highlight-current-month .budget-header-calendar-note {
   color: var(--tk-current-month-note-color);
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2012, #2044

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
It seems that the current month highlighting still wasn't working for me in the "new default" theme. I'd been using the classic theme until this month so I never noticed before, but this fixes it for me.

## Before

### Default
<img width="335" alt="Screenshot 2021-04-01 at 10 26 55" src="https://user-images.githubusercontent.com/1148665/113325715-06d1c700-92d6-11eb-9e7c-27da2b32b0ba.png">

### Dark
<img width="321" alt="Screenshot 2021-04-01 at 10 29 33" src="https://user-images.githubusercontent.com/1148665/113325758-13eeb600-92d6-11eb-8a7d-633e89711eca.png">

### Classic
<img width="316" alt="Screenshot 2021-04-01 at 10 29 38" src="https://user-images.githubusercontent.com/1148665/113325788-1c46f100-92d6-11eb-8264-b3adfd10c645.png">

## After

### Default
<img width="322" alt="Screenshot 2021-04-01 at 10 28 05" src="https://user-images.githubusercontent.com/1148665/113325742-0df8d500-92d6-11eb-846c-c7b09df4056f.png">

### Dark
<img width="311" alt="Screenshot 2021-04-01 at 10 30 41" src="https://user-images.githubusercontent.com/1148665/113325821-236dff00-92d6-11eb-8789-3e2fdec815c8.png">

### Classic
<img width="307" alt="Screenshot 2021-04-01 at 10 30 45" src="https://user-images.githubusercontent.com/1148665/113325855-2bc63a00-92d6-11eb-8255-ee4b6517197a.png">
