### PR TITLE
Bug 2353: Date Last Reconciled Update

### DIFF
--- a/src/extension/features/accounts/last-reconciled-date/index.js
+++ b/src/extension/features/accounts/last-reconciled-date/index.js
@@ -28,7 +28,11 @@ export class LastReconciledDate extends Feature {
       if (latestDate) {
         let todaysDate = moment();
         let differenceInDays = todaysDate.diff(latestDate, 'days');
-        daysSinceTextToShow = differenceInDays + ' days';
+        if (differenceInDays === 1) {
+          daysSinceTextToShow = differenceInDays + ' day';
+        } else {
+          daysSinceTextToShow = differenceInDays + ' days';
+        }
       }
 
       let daysSinceContainer = this._createReconciledContainer(
@@ -37,11 +41,6 @@ export class LastReconciledDate extends Feature {
         'Since Last Reconciled'
       );
       daysSinceContainer.children('span').text(daysSinceTextToShow);
-
-      // Add some margin between if we have both
-      if (this.settings.enabled.includes('last-date')) {
-        daysSinceContainer.addClass('tk-mg-r-1');
-      }
 
       this._setFeatureVisibility(`#${TK_DAYS_SINCE_RECONCILED_ID}`, true);
     }

--- a/src/extension/features/accounts/last-reconciled-date/index.js
+++ b/src/extension/features/accounts/last-reconciled-date/index.js
@@ -91,7 +91,7 @@ export class LastReconciledDate extends Feature {
    * Create the Reconciled Info Container
    * @param {String} id The id of the element
    * @param {String} text The Text to Show
-   * @param {Label} label The Label to Show
+   * @param {String} label The Label to Show
    * @returns JQuery Element
    */
   _createReconciledContainer(id, text, label) {

--- a/src/extension/features/accounts/last-reconciled-date/index.js
+++ b/src/extension/features/accounts/last-reconciled-date/index.js
@@ -25,27 +25,24 @@ export class LastReconciledDate extends Feature {
     if (this.settings.enabled.includes('days-since')) {
       let daysSinceTextToShow = 'NA days';
 
-      // Get the current account id and calculate the last reconciled date
       if (latestDate) {
         let todaysDate = moment();
         let differenceInDays = todaysDate.diff(latestDate, 'days');
         daysSinceTextToShow = differenceInDays + ' days';
       }
 
-      // Retrieve or create the days since reconciled container
-      let daysSinceContainer = $(`#${TK_DAYS_SINCE_RECONCILED_ID}`);
-      if (!daysSinceContainer || daysSinceContainer.length === 0) {
-        $(YNAB_ACCOUNTS_HEADER_RIGHT).append(
-          `<div class="tk-accounts-header-days-since-reconciled">
-          <span id="${TK_DAYS_SINCE_RECONCILED_ID}">${daysSinceTextToShow}</span>
-          <div class="tk-accounts-header-days-since-reconciled-label">Since Last Reconciled</div>
-        </div>`
-        );
+      let daysSinceContainer = this._createReconciledContainer(
+        TK_DAYS_SINCE_RECONCILED_ID,
+        daysSinceTextToShow
+      );
+      daysSinceContainer.text(daysSinceTextToShow);
+
+      // Add some margin between if we have both
+      if (this.settings.enabled.includes('last-date')) {
+        daysSinceContainer.addClass('tk-mg-r-1');
       }
 
-      // Update the days sinces reconciled in the element
-      daysSinceContainer.text(daysSinceTextToShow);
-      this._setFeatureVisibility('.tk-accounts-header-days-since-reconciled', true);
+      this._setFeatureVisibility(`#${TK_DAYS_SINCE_RECONCILED_ID}`, true);
     }
 
     // Handle date last reconciled
@@ -57,20 +54,13 @@ export class LastReconciledDate extends Feature {
         );
       }
 
-      // Retrieve or create the reconcile date container
-      let dateContainer = $(`#${TK_LAST_RECONCILED_ID}`);
-      if (!dateContainer || dateContainer.length === 0) {
-        $(YNAB_ACCOUNTS_HEADER_RIGHT).append(
-          `<div class="tk-accounts-header-last-reconciled">
-          <span id="${TK_LAST_RECONCILED_ID}">${latestDateTextToShow}</span>
-          <div class="tk-accounts-header-last-reconciled-label">Last Reconciled Date</div>
-        </div>`
-        );
-      }
+      let latestDateContainer = this._createReconciledContainer(
+        TK_LAST_RECONCILED_ID,
+        latestDateTextToShow
+      );
 
-      // Update the reconcile date in the element
-      dateContainer.text(latestDateTextToShow);
-      this._setFeatureVisibility($('.tk-accounts-header-last-reconciled'), true);
+      latestDateContainer.text(latestDateTextToShow);
+      this._setFeatureVisibility(`#${TK_LAST_RECONCILED_ID}`, true);
     }
   }
 
@@ -78,18 +68,40 @@ export class LastReconciledDate extends Feature {
     if (this.shouldInvoke()) {
       this.invoke();
     } else {
-      this._setFeatureVisibility('.tk-accounts-header-last-reconciled', false);
-      this._setFeatureVisibility('.tk-accounts-header-days-since-reconciled', false);
+      this._setFeatureVisibility(`#${TK_LAST_RECONCILED_ID}`, false);
+      this._setFeatureVisibility(`#${TK_DAYS_SINCE_RECONCILED_ID}`, false);
     }
   }
 
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    // When the reconciled icon changes, reevaluate our date
-    if (changedNodes.has('is-reconciled-icon svg-icon lock')) {
+    if (
+      changedNodes.has('modal-account-reconcile-reconciled') ||
+      changedNodes.has('nav-account-value user-data') ||
+      changedNodes.has('is-reconciled-icon svg-icon lock')
+    ) {
       this.invoke();
     }
+  }
+
+  /**
+   * Create the Reconciled Info Container
+   * @param {String} id The id of the element
+   * @param {String} text The Text to Show
+   * @returns JQuery Element
+   */
+  _createReconciledContainer(id, text) {
+    let reconciledInfoContainer = $(`#${id}`);
+    if (!reconciledInfoContainer || reconciledInfoContainer.length === 0) {
+      $(YNAB_ACCOUNTS_HEADER_RIGHT).append(
+        `<div class="tk-accounts-header-reconciled-info">
+          <span id="${id}">${text}</span>
+          <div class="tk-accounts-header-reconciled-info-label">Last Reconciled Date</div>
+        </div>`
+      );
+    }
+    return reconciledInfoContainer;
   }
 
   /**

--- a/src/extension/features/accounts/last-reconciled-date/index.js
+++ b/src/extension/features/accounts/last-reconciled-date/index.js
@@ -33,9 +33,10 @@ export class LastReconciledDate extends Feature {
 
       let daysSinceContainer = this._createReconciledContainer(
         TK_DAYS_SINCE_RECONCILED_ID,
-        daysSinceTextToShow
+        daysSinceTextToShow,
+        'Since Last Reconciled'
       );
-      daysSinceContainer.text(daysSinceTextToShow);
+      daysSinceContainer.children('span').text(daysSinceTextToShow);
 
       // Add some margin between if we have both
       if (this.settings.enabled.includes('last-date')) {
@@ -56,10 +57,11 @@ export class LastReconciledDate extends Feature {
 
       let latestDateContainer = this._createReconciledContainer(
         TK_LAST_RECONCILED_ID,
-        latestDateTextToShow
+        latestDateTextToShow,
+        'Last Reconciled Date'
       );
 
-      latestDateContainer.text(latestDateTextToShow);
+      latestDateContainer.children('span').text(latestDateTextToShow);
       this._setFeatureVisibility(`#${TK_LAST_RECONCILED_ID}`, true);
     }
   }
@@ -89,15 +91,16 @@ export class LastReconciledDate extends Feature {
    * Create the Reconciled Info Container
    * @param {String} id The id of the element
    * @param {String} text The Text to Show
+   * @param {Label} label The Label to Show
    * @returns JQuery Element
    */
-  _createReconciledContainer(id, text) {
+  _createReconciledContainer(id, text, label) {
     let reconciledInfoContainer = $(`#${id}`);
     if (!reconciledInfoContainer || reconciledInfoContainer.length === 0) {
       $(YNAB_ACCOUNTS_HEADER_RIGHT).append(
-        `<div class="tk-accounts-header-reconciled-info">
-          <span id="${id}">${text}</span>
-          <div class="tk-accounts-header-reconciled-info-label">Last Reconciled Date</div>
+        `<div id="${id}" class="tk-accounts-header-reconciled-info">
+          <span>${text}</span>
+          <div class="tk-accounts-header-reconciled-info-label">${label}</div>
         </div>`
       );
     }

--- a/src/extension/features/accounts/last-reconciled-date/index.js
+++ b/src/extension/features/accounts/last-reconciled-date/index.js
@@ -44,9 +44,7 @@ export class LastReconciledDate extends Feature {
     if (this.settings.enabled.includes('last-date')) {
       let latestDateTextToShow = 'NA';
       if (latestDate) {
-        latestDateTextToShow = ynab.YNABSharedLib.dateFormatter.formatDateExpanded(
-          latestDate.utc()
-        );
+        latestDateTextToShow = ynab.YNABSharedLib.dateFormatter.formatDateExpanded(latestDate);
       }
 
       let latestDateContainer = this._createReconciledContainer(
@@ -108,13 +106,20 @@ export class LastReconciledDate extends Feature {
    */
   _calculateLastReconciledDate = accountId => {
     const account = getEntityManager().getAccountById(accountId);
+    let lastReconciledDate = account.getLastReconciledAt();
 
-    let reconciledDates = account
-      .getTransactions()
-      .filter(transaction => transaction.date && transaction.isReconciled())
-      .map(transaction => moment(transaction.date.getUTCTime()));
+    // Manually calculate it if one doesn't exist
+    if (!lastReconciledDate) {
+      let reconciledDates = account
+        .getTransactions()
+        .filter(transaction => transaction.date && transaction.isReconciled())
+        .map(transaction => moment(transaction.date.getUTCTime()));
+      lastReconciledDate = reconciledDates.length ? moment.max(reconciledDates) : null;
+    } else {
+      lastReconciledDate = moment(lastReconciledDate);
+    }
 
-    return reconciledDates.length ? moment.max(reconciledDates) : null;
+    return lastReconciledDate;
   };
 
   /**

--- a/src/extension/features/accounts/last-reconciled-date/index.js
+++ b/src/extension/features/accounts/last-reconciled-date/index.js
@@ -28,11 +28,7 @@ export class LastReconciledDate extends Feature {
       if (latestDate) {
         let todaysDate = moment();
         let differenceInDays = todaysDate.diff(latestDate, 'days');
-        if (differenceInDays === 1) {
-          daysSinceTextToShow = differenceInDays + ' day';
-        } else {
-          daysSinceTextToShow = differenceInDays + ' days';
-        }
+        daysSinceTextToShow = differenceInDays + (differenceInDays === 1 ? ' day' : ' days');
       }
 
       let daysSinceContainer = this._createReconciledContainer(
@@ -41,7 +37,6 @@ export class LastReconciledDate extends Feature {
         'Since Last Reconciled'
       );
       daysSinceContainer.children('span').text(daysSinceTextToShow);
-
       this._setFeatureVisibility(`#${TK_DAYS_SINCE_RECONCILED_ID}`, true);
     }
 

--- a/src/extension/features/accounts/last-reconciled-date/styles.css
+++ b/src/extension/features/accounts/last-reconciled-date/styles.css
@@ -1,4 +1,4 @@
-.tk-accounts-header-last-reconciled {
+.tk-accounts-header-reconciled-info {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -8,28 +8,9 @@
   align-self: flex-end;
 }
 
-.tk-accounts-header-last-reconciled-label {
+.tk-accounts-header-reconciled-info-label {
   font-size: 0.75rem;
   color: var(--header_label_primary);
   font-weight: 400;
   margin-top: 0.1rem;
-}
-
-.tk-accounts-header-days-since-reconciled {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  font-size: 1rem;
-  flex: 0 1 auto;
-  align-self: flex-end;
-  padding-right: 0.1em;
-}
-
-.tk-accounts-header-days-since-reconciled-label {
-  font-size: 0.75rem;
-  color: var(--header_label_primary);
-  font-weight: 400;
-  margin-top: 0.1rem;
-  padding-right: 0.1em;
 }

--- a/src/extension/features/accounts/last-reconciled-date/styles.css
+++ b/src/extension/features/accounts/last-reconciled-date/styles.css
@@ -6,6 +6,7 @@
   font-size: 1rem;
   flex: 0 1 auto;
   align-self: flex-end;
+  margin-right: 1rem;
 }
 
 .tk-accounts-header-reconciled-info-label {


### PR DESCRIPTION
GitHub Issue (if applicable): #2353 #2354

Trello Link (if applicable):


**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.

- [x] **Updating Changed Nodes** #2354
- Upon reconciliation through standard flow
- Upon date change of a transaction
- Upon removal of a reconciled transactions
Modifying the changed nodes to check the account value, the reconcile modal and any changes to the reconcile icon.


- [x] **Check for single day since 1 "days" should be "1 day"** #2354
- [x] **Use YNAB account data and fallback to manual calculation**  #2356
- Instead of showing a stale date, use the the most current date if it exists in the account model, otherwise manually calculate it.


Some other changes: 
- Consolidating the container logic into one and using the ID to indicate which one to use during which feature
- Removing duplicate styles

FYI @gpeden, please feel free to review.