### PR TITLE
Feature: Hide the add accounts button

### DIFF
--- a/src/extension/features/general/hide-add-accounts/index.css
+++ b/src/extension/features/general/hide-add-accounts/index.css
@@ -1,0 +1,3 @@
+button.nav-add-account {
+  display: none !important;
+}

--- a/src/extension/features/general/hide-add-accounts/index.js
+++ b/src/extension/features/general/hide-add-accounts/index.js
@@ -1,0 +1,7 @@
+import { Feature } from 'toolkit/extension/features/feature';
+
+export class HideAddAccounts extends Feature {
+  injectCSS() {
+    return require('./index.css');
+  }
+}

--- a/src/extension/features/general/hide-add-accounts/settings.js
+++ b/src/extension/features/general/hide-add-accounts/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'HideAddAccounts',
+  type: 'checkbox',
+  default: false,
+  section: 'general',
+  title: 'Hide Add Account Button',
+  description: 'Hides the Add Account button on the side navigation menu',
+};


### PR DESCRIPTION
GitHub Issue (if applicable): #2240 


Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
User requested we hide the add accounts button on the bottom left navigation. Adding in feature change under switch in general settings.

