### PR TITLE
Feature: Adds toggle to "Income Breakdown" chart to hide subcategories

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/labeled-checkbox/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/labeled-checkbox/component.jsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import './styles.scss';
 
-export const LabeledCheckbox = ({ id, checked, label, onChange }) => {
+export const LabeledCheckbox = ({ id, checked, disabled, label, onChange }) => {
   return (
     <label className="tk-labeled-checkbox tk-flex tk-align-items-center">
-      <input checked={checked} name={id} onChange={onChange} type="checkbox" />
+      <input checked={checked} name={id} onChange={onChange} disabled={disabled} type="checkbox" />
       <span className="tk-mg-l-05">{label}</span>
     </label>
   );
@@ -14,6 +14,11 @@ export const LabeledCheckbox = ({ id, checked, label, onChange }) => {
 LabeledCheckbox.propTypes = {
   id: PropTypes.string.isRequired,
   checked: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+};
+
+LabeledCheckbox.defaultProps = {
+  disabled: false,
 };

--- a/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
@@ -26,6 +26,7 @@ export class IncomeBreakdownComponent extends React.Component {
     this.state = {
       showIncome: true,
       showExpense: true,
+      showSubCategories: true,
       showLossGain: true,
       groupPositiveCategories: false,
     };
@@ -42,7 +43,13 @@ export class IncomeBreakdownComponent extends React.Component {
   }
 
   render() {
-    const { showIncome, showExpense, showLossGain, groupPositiveCategories } = this.state;
+    const {
+      showIncome,
+      showExpense,
+      showSubCategories,
+      showLossGain,
+      groupPositiveCategories,
+    } = this.state;
     return (
       <div className="tk-flex-grow tk-flex tk-flex-column">
         <div className="tk-flex tk-pd-05 tk-border-b">
@@ -56,10 +63,19 @@ export class IncomeBreakdownComponent extends React.Component {
           </div>
           <div className="tk-income-breakdown__filter">
             <LabeledCheckbox
-              id="tk-income-breakdown-hide-epxense-selector"
+              id="tk-income-breakdown-hide-expense-selector"
               checked={showExpense}
               label="Show Expense"
               onChange={this.toggleExpense}
+            />
+          </div>
+          <div className="tk-income-breakdown__filter">
+            <LabeledCheckbox
+              id="tk-income-breakdown-hide-sub-category-selector"
+              checked={showSubCategories}
+              disabled={!showExpense}
+              label="Show Subcategories"
+              onChange={this.toggleSubCategories}
             />
           </div>
           <div className="tk-income-breakdown__filter">
@@ -107,6 +123,12 @@ export class IncomeBreakdownComponent extends React.Component {
   toggleExpense = ({ currentTarget }) => {
     const { checked } = currentTarget;
     this.setState({ showExpense: checked });
+    this._calculateData();
+  };
+
+  toggleSubCategories = ({ currentTarget }) => {
+    const { checked } = currentTarget;
+    this.setState({ showSubCategories: checked });
     this._calculateData();
   };
 
@@ -189,6 +211,7 @@ export class IncomeBreakdownComponent extends React.Component {
       expenses,
       showLossGain,
       showExpense,
+      showSubCategories,
       showIncome,
       groupPositiveCategories,
     } = this.state;
@@ -266,7 +289,9 @@ export class IncomeBreakdownComponent extends React.Component {
       categorySeries = categorySeries.sort((a, b) => b.masterEntry.weight - a.masterEntry.weight);
       categorySeries.forEach(categorySerie => {
         seriesData.push(categorySerie.masterEntry);
-        seriesData.push(...categorySerie.subEntries);
+        if (showSubCategories) {
+          seriesData.push(...categorySerie.subEntries);
+        }
       });
     }
 


### PR DESCRIPTION
GitHub Issue (if applicable): N/A

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**

Since the ability to show/hide income/expenses is there, I thought it would make sense to add an additional toggle if the user only wants to see the master categories (all categories can become quite cluttered at times).

The "Show Subcategories" checkbox will become conditionally disabled if the "Show expenses" checkbox is unchecked, since they are related.