### PR TITLE
feat: expand split transaction when tabbing past last row

### DIFF
--- a/src/extension/features/accounts/split-transaction-tab-expand/index.js
+++ b/src/extension/features/accounts/split-transaction-tab-expand/index.js
@@ -1,0 +1,35 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+
+export class SplitTransactionTabExpand extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage();
+  }
+
+  invoke() {}
+
+  applyNewTabBehavior(event) {
+    // If tab was pressed, simulate a mouse click on the "Add another split" button
+    if (event.keyCode === 9) {
+      let addSplitButton = $('.ynab-grid-split-add-sub-transaction');
+      if (addSplitButton.length !== 0) {
+        // The YNAB app checks the detail property isn't 0, so .click() won't work
+        const clickEvent = new jQuery.Event('click', { detail: 1 });
+        addSplitButton.trigger(clickEvent);
+      }
+    }
+  }
+
+  observe() {
+    if (!this.shouldInvoke()) return;
+    if ($('.ynab-grid-split-add-sub-transaction').length === 0) return;
+
+    const addTransactionGrid = $('.ynab-grid-add-rows');
+    const lastInput = $('input', addTransactionGrid).last();
+
+    if (!lastInput.attr('data-toolkit-tab-expand')) {
+      lastInput.attr('data-toolkit-tab-expand', true);
+      lastInput.on('keydown', this.applyNewTabBehavior);
+    }
+  }
+}

--- a/src/extension/features/accounts/split-transaction-tab-expand/settings.js
+++ b/src/extension/features/accounts/split-transaction-tab-expand/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'SplitTransactionTabExpand',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Tab Expands Split Transactions',
+  description:
+    'When entering a split transaction, add a new split automatically when tabbing past the last split (a la YNAB4).',
+};


### PR DESCRIPTION
GitHub Issue (if applicable):

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Changes behavior of split transaction input to automatically add new splits when tabbing past the last row - speeds up entry of large split transactions.