### PR TITLE
Feature: Add Auto fill Payee for Split Transactions

### DIFF
--- a/src/extension/features/accounts/split-transaction-auto-fill-payee/index.js
+++ b/src/extension/features/accounts/split-transaction-auto-fill-payee/index.js
@@ -9,7 +9,8 @@ export class SplitTransactionAutoFillPayee extends Feature {
   invoke() {
     const cells = $('.is-editing .ynab-grid-cell-payeeName .ember-text-field').toArray();
     cells.forEach((cell, i) => {
-      if (i !== 0 && cell.value === '') {
+      if (i !== 0 && !$(cell).data('tk-auto-filled-payee')) {
+        $(cell).data('tk-auto-filled-payee', true);
         $(cell).val(cells[0].value);
         $(cell).trigger('change');
         $(cell).trigger('blur');

--- a/src/extension/features/accounts/split-transaction-auto-fill-payee/index.js
+++ b/src/extension/features/accounts/split-transaction-auto-fill-payee/index.js
@@ -1,0 +1,24 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+
+export class SplitTransactionAutoFillPayee extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage() && $('.ynab-grid-split-add-sub-transaction').length !== 0;
+  }
+
+  invoke() {
+    const cells = $('.is-editing .ynab-grid-cell-payeeName .ember-text-field').toArray();
+    cells.forEach((cell, i) => {
+      if (i !== 0 && cell.value === '') {
+        $(cell).val(cells[0].value);
+        $(cell).trigger('change');
+        $(cell).trigger('blur');
+      }
+    });
+  }
+
+  observe() {
+    if (!this.shouldInvoke()) return;
+    this.invoke();
+  }
+}

--- a/src/extension/features/accounts/split-transaction-auto-fill-payee/settings.js
+++ b/src/extension/features/accounts/split-transaction-auto-fill-payee/settings.js
@@ -5,5 +5,5 @@ module.exports = {
   section: 'accounts',
   title: "Auto-Fill Split Transactions' Payee",
   description:
-    'When entering split transactions, each additional split will be auto-filled with the original Payee.',
+    'When entering split transactions, each additional split will be auto-filled with the first Payee.',
 };

--- a/src/extension/features/accounts/split-transaction-auto-fill-payee/settings.js
+++ b/src/extension/features/accounts/split-transaction-auto-fill-payee/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'SplitTransactionAutoFillPayee',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: "Auto-Fill Split Transactions' Payee",
+  description:
+    'When entering split transactions, each additional split will be auto-filled with the original Payee.',
+};


### PR DESCRIPTION
GitHub Issue (if applicable): N/A

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**

After being a little tired of split transactions not showing up because they lack a Payee, I figured I'd add a feature to auto-fill the Payee field for split transactions, and thought it might help some others as well.

e.g.

https://user-images.githubusercontent.com/1148665/117893952-9628ad80-b278-11eb-830f-5f84636f3147.mov

Comments welcome on naming or other conventions I may have missed.

~One thing I found is that the field will always be changed to the first payee, unless actively changed. This behavior may not be desirable, but I'm not sure how to check if the field has been edited manually and not edit that.~ Fixed this by using a data attribute. Tried adding a css class, but that ended up not working.

<details><summary>Fixed</summary>
(e.g. after 30 seconds in this demo:)

https://user-images.githubusercontent.com/1148665/117894464-9e351d00-b279-11eb-8580-bbaf1935674a.mov
</details>