### PR TITLE
fix: overbudgeting warning not showing on spending goals (#2367)

### DIFF
--- a/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.css
+++ b/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.css
@@ -1,7 +1,7 @@
 .toolkit-display-goal-warn {
-  color: #ff4545;
+  color: var(--label_negative);
 }
 
 .toolkit-display-goal-highlight {
-  color: #00b300;
+  color: var(--label_positive);
 }

--- a/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.js
+++ b/src/extension/features/budget/budget-category-features/display-target-goal-amount/index.js
@@ -52,65 +52,36 @@ export class DisplayTargetGoalAmount extends Feature {
         return;
       }
 
-      const { monthlyFunding, goalTargetAmount } = subCategory.getProperties(
-        'monthlyFunding',
-        'goalTargetAmount'
-      );
-      const {
-        goalTarget,
-        goalOverallFunded,
-        goalTotalNeededAmount,
-      } = monthlySubCategoryBudgetCalculation;
-      const budgeted = monthlySubCategoryBudget.get('budgeted');
+      const goalTargetAmount = subCategory.get('goalTargetAmount');
+      const { budgeted, goalTarget, isGoalValidForMonth } = monthlySubCategoryBudgetCalculation;
 
       let goalAmount = null;
+      let goalFundedThreshold = null;
       let applyEmphasis = false;
-      switch (goalType) {
-        case ynab.constants.SubCategoryGoalType.MonthlyFunding:
-          goalAmount = monthlyFunding;
-          if (userSetting === Settings.WarnBudgetOverTarget && budgeted > monthlyFunding) {
-            applyEmphasis = true;
-          } else if (userSetting === Settings.GreenBudgetOverTarget && budgeted >= monthlyFunding) {
-            applyEmphasis = true;
-          }
-          break;
-        case ynab.constants.SubCategoryGoalType.Needed:
-          goalAmount = goalTargetAmount;
-          if (goalTarget) {
+      if (isGoalValidForMonth) {
+        switch (goalType) {
+          case ynab.constants.SubCategoryGoalType.TargetBalance:
+            goalAmount = goalTargetAmount;
+            goalFundedThreshold = goalTargetAmount;
+            break;
+          case ynab.constants.SubCategoryGoalType.MonthlyFunding:
+          case ynab.constants.SubCategoryGoalType.Needed:
+          case ynab.constants.SubCategoryGoalType.TargetBalanceOnDate:
             goalAmount = goalTarget;
-          }
+            goalFundedThreshold = goalTarget;
+            break;
+        }
 
-          if (
-            userSetting === Settings.WarnBudgetOverTarget &&
-            goalOverallFunded > goalTotalNeededAmount
-          ) {
+        if (goalAmount) {
+          if (userSetting === Settings.WarnBudgetOverTarget && budgeted > goalFundedThreshold) {
             applyEmphasis = true;
           } else if (
             userSetting === Settings.GreenBudgetOverTarget &&
-            goalOverallFunded > goalTotalNeededAmount
+            budgeted >= goalFundedThreshold
           ) {
             applyEmphasis = true;
           }
-          break;
-        case ynab.constants.SubCategoryGoalType.TargetBalance:
-          goalAmount = goalTargetAmount;
-          if (userSetting === Settings.WarnBudgetOverTarget && budgeted > goalTargetAmount) {
-            applyEmphasis = true;
-          } else if (
-            userSetting === Settings.GreenBudgetOverTarget &&
-            budgeted >= goalTargetAmount
-          ) {
-            applyEmphasis = true;
-          }
-          break;
-        case ynab.constants.SubCategoryGoalType.TargetBalanceOnDate:
-          goalAmount = goalTarget;
-          if (userSetting === Settings.WarnBudgetOverTarget && budgeted > goalTarget) {
-            applyEmphasis = true;
-          } else if (userSetting === Settings.GreenBudgetOverTarget && budgeted >= goalTarget) {
-            applyEmphasis = true;
-          }
-          break;
+        }
       }
 
       const goalAmountElement = element.querySelector('.toolkit-target-goal-amount');

--- a/src/extension/features/budget/budget-category-features/display-target-goal-amount/settings.js
+++ b/src/extension/features/budget/budget-category-features/display-target-goal-amount/settings.js
@@ -9,7 +9,7 @@ module.exports = {
   options: [
     { name: 'Do not display goal amount (default)', value: '0' },
     { name: 'Display goal amount and warn of overbudget with red', value: '1' },
-    { name: 'Display goal amount but show overbudget as green', value: '2' },
+    { name: 'Display goal amount and show funded goals as green', value: '2' },
     { name: 'Display goal amount with no emphasis', value: '3' },
   ],
 };


### PR DESCRIPTION
GitHub Issue (if applicable): #2367 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Fixed overbudgeting warning not showing on spending goals. The issue seems to be that the goalTotalNeededAmount property was removed. Clarified setting behaviour when showing funded goals as green.
Also fixed goals showing from future months - if you'd rather a seperate commit/pull, let me know, I'm pretty new to this :)