### PR TITLE
fix: upcoming transaction total displaces money moves icon (#2327)

### DIFF
--- a/src/extension/features/budget/display-upcoming-amount/index.css
+++ b/src/extension/features/budget/display-upcoming-amount/index.css
@@ -1,12 +1,12 @@
 .toolkit-activity-upcoming {
-  display: flex !important;
-  flex-direction: row !important;
   justify-content: flex-end !important;
-  align-items: center !important;
 }
 
 .toolkit-activity-upcoming-amount {
   margin-right: 0.5rem;
+  margin-left: 0.25rem;
   color: darkgray;
   font-size: 0.7rem;
+  flex-basis: 100%;
+  white-space: nowrap;
 }

--- a/src/extension/features/budget/display-upcoming-amount/index.js
+++ b/src/extension/features/budget/display-upcoming-amount/index.js
@@ -27,17 +27,23 @@ export class DisplayUpcomingAmount extends Feature {
         monthlySubCategoryBudgetCalculation &&
         monthlySubCategoryBudgetCalculation.upcomingTransactions
       ) {
-        $('.budget-table-cell-activity', element)
-          .addClass('toolkit-activity-upcoming')
-          .prepend(
-            $('<div>', {
-              class: 'toolkit-activity-upcoming-amount currency',
-              title: `Total upcoming transaction amount in this month for ${subCategory.get(
-                'name'
-              )}`,
-              text: formatCurrency(monthlySubCategoryBudgetCalculation.upcomingTransactions),
-            })
-          );
+        let activity = $('.budget-table-cell-activity', element);
+        activity.addClass('toolkit-activity-upcoming');
+
+        let upcoming = $('<div>', {
+          class: 'toolkit-activity-upcoming-amount currency',
+          title: `Total upcoming transaction amount in this month for ${subCategory.get('name')}`,
+          text: formatCurrency(monthlySubCategoryBudgetCalculation.upcomingTransactions),
+        });
+
+        let moneyMoves = $('.budget-table-cell-category-moves', activity);
+        if (moneyMoves.length === 0) {
+          // Shouldn't happen as of time of writing, even when not applicable the element exists
+          // Included only to make feature slightly less brittle
+          activity.prepend(upcoming);
+        } else {
+          moneyMoves.after(upcoming);
+        }
       }
     });
   }


### PR DESCRIPTION
GitHub Issue (if applicable): #2327

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The budget feature "Show upcoming transaction total" was displacing the new Money Moves icon.
I have modified the code to place the upcoming total after the Money Moves icon, and tweaked the stylesheet to keep the icon in the correct place.
