### PR TITLE
fix: poor contrast on toolkit update modal in dark theme (#2308)

### DIFF
--- a/src/core/components/toolkit-release-modal/styles.scss
+++ b/src/core/components/toolkit-release-modal/styles.scss
@@ -28,3 +28,8 @@
     text-align: center;
   }
 }
+
+body.theme-dark .tk-release-modal__logo {
+  -webkit-filter: invert(1) hue-rotate(180deg) brightness(1.2);
+  filter: invert(1) hue-rotate(180deg) brightness(1.2);
+}

--- a/src/extension/ynab-toolkit.css
+++ b/src/extension/ynab-toolkit.css
@@ -19,8 +19,8 @@ body.theme-classic {
 
 body.theme-dark {
   --tk-modal-backdrop: rgba(99, 99, 99, 0.5);
-  --tk-default-background-color: #909090;
-  --tk-default-font-color: #000000;
+  --tk-default-background-color: #2c2c2e;
+  --tk-default-font-color: #ffffff;
   --tk-positive-currency-color: #6d9f38;
   --tk-zero-currency-color: #8e8e93;
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2308 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Updated the style sheet for the toolkit update modal in dark theme. Changed to white text on dark grey to match the rest of the theme and give better contrast for the links. Inverted the logo via the same method as dark mode in the options menu.

Before:
![updatemodal1](https://user-images.githubusercontent.com/83871143/118734318-0b2a5300-b836-11eb-9a8c-53d07d34f9a8.jpg)

After:
![updatemodal2](https://user-images.githubusercontent.com/83871143/118734327-0f567080-b836-11eb-9c1a-623a7d51ebc0.jpg)
