### PR TITLE
fix: table styles cut off in income/expense report on firefox (#2274)

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/styles.scss
@@ -1,5 +1,6 @@
 .tk-totals-table {
   width: fit-content;
+  width: -moz-fit-content;
 
   &__child-row,
   &__child-summary-row,

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/styles.scss
@@ -29,6 +29,7 @@ body.theme-dark {
     border-top: 3px solid var(--tk-ive-report-border-color);
     border-bottom: 3px solid var(--tk-ive-report-border-color);
     width: fit-content;
+    width: -moz-fit-content;
 
     .tk-monthly-totals-row {
       &__title-cell {


### PR DESCRIPTION
GitHub Issue (if applicable): #2274

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
As shown in the linked issue, when opening the Income vs Expense toolkit report with a wide enough date range, on Firefox, the report formatting is lost past the initial scroll window, and the report does not scroll correctly. This seems to be due to Firefox requiring a vendor prefix on width: fit-content.

Before
![reportbefore](https://user-images.githubusercontent.com/83871143/118737740-6744a580-b83d-11eb-9005-0ab1d7eaa30a.jpg)

After
![reportafter](https://user-images.githubusercontent.com/83871143/118737752-6b70c300-b83d-11eb-9beb-5bbf47cdbfed.jpg)