### PR TITLE
fix: hide memo column with scheduled transactions on Firefox #2340

### DIFF
--- a/src/extension/features/accounts/toggle-account-columns/index.css
+++ b/src/extension/features/accounts/toggle-account-columns/index.css
@@ -1,11 +1,3 @@
 body.toolkit-hide-memos .ynab-grid-cell-memo {
   display: none !important;
 }
-
-@-moz-document url-prefix() {
-  body.toolkit-hide-memos .ynab-grid-cell-memo {
-    visibility: collapse !important;
-    border-right: none;
-    display: table-cell !important;
-  }
-}


### PR DESCRIPTION
GitHub Issue (if applicable): #2340

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
As shown in the linked issue, there was a visual glitch when hiding the memo column with scheduled transactions on Firefox.
This seems to be due to a Firefox specific style that is no longer required - current Firefox behaves perfectly with the default style.