### PR TITLE
Feature: Subtract Upcoming Transactions from Available Balance

### DIFF
--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -1,0 +1,116 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
+import { getEmberView } from 'toolkit/extension/utils/ember';
+import * as currency from 'toolkit/extension/utils/currency';
+import { addToolkitEmberHook } from 'toolkit/extension/utils/toolkit';
+
+export class SubtractUpcomingFromAvailable extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteBudgetPage();
+  }
+
+  invoke() {
+    let totalUpcoming = 0;
+
+    $('.budget-table-row.is-sub-category').each((_, element) => {
+      const category = getEmberView(element.id, 'category');
+      if (!category) {
+        return;
+      }
+
+      if (category.upcomingTransactions) {
+        const availableObject = $(`#${element.id} .ynab-new-budget-available-number`);
+        const availableElement = availableObject[0];
+
+        const availableTextObject = $(`#${availableElement.id} .user-data`);
+        const availableTextElement = availableTextObject[0];
+
+        const available = Number(currency.stripCurrency(availableTextElement.innerText));
+        const upcoming = Number(category.upcomingTransactions);
+        const availableAfterUpcoming = available + upcoming;
+
+        $(availableTextObject).text(currency.formatCurrency(availableAfterUpcoming));
+
+        availableObject.children('svg.icon-upcoming').remove();
+
+        const hasCautiousCredit =
+          availableObject.hasClass('cautious') && availableObject.hasClass('credit');
+
+        if (!hasCautiousCredit) {
+          const classes = 'cautious upcoming credit positive zero negative';
+
+          availableObject.removeClass(classes);
+          availableTextObject.removeClass(classes);
+
+          const currencyClass = this.determineCurrencyClass(availableAfterUpcoming);
+          availableObject.addClass(currencyClass);
+          availableTextObject.addClass(currencyClass);
+        }
+
+        totalUpcoming += upcoming;
+      }
+    });
+
+    addToolkitEmberHook(this, 'budget/inspector/default-inspector', 'didRender', () =>
+      this.addTotalAvailableAfterUpcoming(totalUpcoming)
+    );
+
+    addToolkitEmberHook(this, 'budget/inspector/multi-select-inspector', 'didRender', () =>
+      this.addTotalAvailableAfterUpcoming(totalUpcoming)
+    );
+  }
+
+  determineCurrencyClass(amount) {
+    let currencyClass = 'positive';
+
+    if (amount < 0) {
+      currencyClass = 'negative';
+    } else if (amount === 0) {
+      currencyClass = 'zero';
+    }
+
+    return currencyClass;
+  }
+
+  createInspectorElement(totalAvailableAfterUpcoming) {
+    const currencyClass = this.determineCurrencyClass(totalAvailableAfterUpcoming);
+
+    totalAvailableAfterUpcoming = currency.formatCurrency(totalAvailableAfterUpcoming);
+
+    return $(`
+      <div class="total-available-after-upcoming-inspector">
+        <h3>TOTAL AVAILABLE AFTER UPCOMING TRANSACTIONS</h3>
+        <h1 title>
+          <span class="user-data currency ${currencyClass}">
+            ${totalAvailableAfterUpcoming}
+          </span>
+        </h1>
+        <hr />
+      </div>
+    `);
+  }
+
+  addTotalAvailableAfterUpcoming(totalUpcoming) {
+    $('.total-available-after-upcoming-inspector').remove();
+
+    const totalAvailableHeader = $('.budget-inspector-content')
+      .find('h3')
+      .filter(function() {
+        return $(this).text() === 'TOTAL AVAILABLE';
+      });
+
+    const endOfTotalAvailable = totalAvailableHeader.nextAll('hr')[0];
+    const totalAvailableData = totalAvailableHeader.next();
+
+    const totalAvailableElement = totalAvailableData.find('span.user-data')[0];
+    const totalAvailable = Number(currency.stripCurrency(totalAvailableElement.innerText));
+    const totalAvailableAfterUpcoming = totalAvailable + totalUpcoming;
+
+    this.createInspectorElement(totalAvailableAfterUpcoming).insertAfter(endOfTotalAvailable);
+  }
+
+  onRouteChanged() {
+    if (!this.shouldInvoke()) return;
+    this.invoke();
+  }
+}

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -63,8 +63,6 @@ export class SubtractUpcomingFromAvailable extends Feature {
   }
 
   addTotalAvailableAfterUpcoming(element) {
-    $('#total-available-after-upcoming').remove();
-
     const elementObject = $(element);
     const budgetInspectorObject = elementObject.hasClass('budget-inspector')
       ? elementObject
@@ -73,6 +71,8 @@ export class SubtractUpcomingFromAvailable extends Feature {
 
     const budgetInspector = getEmberView(element.id);
     if (!budgetInspector) return;
+
+    $('#total-available-after-upcoming').remove();
 
     // When one category is selected, YNAB provides their own "Available After Upcoming" so we don't need ours.
     const localizedMessage = l10n(

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -30,9 +30,7 @@ export class SubtractUpcomingFromAvailable extends Feature {
 
     $('.budget-table-row.is-sub-category').each((_, element) => {
       const category = getEmberView(element.id, 'category');
-      if (!category) {
-        return;
-      }
+      if (!category) return;
 
       if (category.upcomingTransactions) {
         const categoryRow = $(`[data-entity-id=${category.subCategoryId}]`);
@@ -70,7 +68,10 @@ export class SubtractUpcomingFromAvailable extends Feature {
   addTotalAvailableAfterUpcoming() {
     const budgetInspectorObject = $('.budget-inspector-content').children().first();
     if (!budgetInspectorObject.length) return;
+
     const budgetInspectorElement = budgetInspectorObject[0];
+    if (!budgetInspectorElement.id) return;
+
     const budgetInspector = getEmberView(budgetInspectorElement.id);
     if (!budgetInspector) return;
 

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -55,6 +55,9 @@ export class SubtractUpcomingFromAvailable extends Feature {
           availableObject.addClass('cautious');
           availableTextObject.addClass('cautious');
         }
+      } else if (!subCategory.isOverSpent) {
+        availableObject.removeClass('cautious');
+        availableTextObject.removeClass('cautious');
       }
     }
   }

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -89,9 +89,17 @@ export class SubtractUpcomingFromAvailable extends Feature {
 
     const totalAvailable = budgetInspector.budgetTotals.available;
     const totalUpcoming = this.getTotalUpcoming(budgetInspector);
-    if (totalUpcoming === 0) return;
+    const totalOfCCBalances = this.getTotalOfCCBalances(budgetInspector);
 
-    const totalAvailableAfterUpcoming = totalAvailable + totalUpcoming;
+    let totalAvailableAfterUpcoming = totalAvailable;
+
+    if (this.settings.enabled === 'upcoming-only') totalAvailableAfterUpcoming += totalUpcoming;
+    if (this.settings.enabled === 'cc-only') totalAvailableAfterUpcoming += totalOfCCBalances;
+    if (this.settings.enabled === 'both')
+      totalAvailableAfterUpcoming += totalUpcoming + totalOfCCBalances;
+
+    if (totalAvailableAfterUpcoming === totalAvailable) return;
+
     const availableBreakdownObject = $('.ynab-breakdown', budgetInspectorObject);
 
     this.createInspectorElement(totalAvailableAfterUpcoming).prependTo(availableBreakdownObject);
@@ -127,6 +135,16 @@ export class SubtractUpcomingFromAvailable extends Feature {
     }
 
     return totalUpcoming;
+  }
+
+  getTotalOfCCBalances(budgetInspector) {
+    let totalOfCCBalances = 0;
+
+    for (const category of budgetInspector.inspectorCategories) {
+      if (category.isCreditCardPaymentCategory) totalOfCCBalances -= category.available;
+    }
+
+    return totalOfCCBalances;
   }
 
   determineCurrencyClass(amount) {

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -18,6 +18,15 @@ export class SubtractUpcomingFromAvailable extends Feature {
         return;
       }
 
+    addToolkitEmberHook(this, 'budget/inspector/default-inspector', 'didRender', () => {
+      if (!this.shouldInvoke()) return;
+      this.addTotalAvailableAfterUpcoming(totalUpcoming);
+    });
+
+    addToolkitEmberHook(this, 'budget/inspector/multi-select-inspector', 'didRender', () => {
+      if (!this.shouldInvoke()) return;
+      this.addTotalAvailableAfterUpcoming(totalUpcoming);
+    });
       if (category.upcomingTransactions) {
         const availableObject = $(`#${element.id} .ynab-new-budget-available-number`);
         const availableElement = availableObject[0];

--- a/src/extension/features/budget/subtract-upcoming-from-available/settings.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'SubtractUpcomingFromAvailable',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Subtract Upcoming Transactions from Available Balance',
+  description:
+    'Subtracts upcoming transactions from the available balance for each category. In other words, treat upcoming transactions as if the money has already been spent. Also shows the total available after upcoming transactions in the budget inspector.',
+};

--- a/src/extension/features/budget/subtract-upcoming-from-available/settings.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/settings.js
@@ -1,9 +1,20 @@
 module.exports = {
   name: 'SubtractUpcomingFromAvailable',
-  type: 'checkbox',
-  default: false,
+  type: 'select',
+  default: '0',
   section: 'budget',
   title: 'Subtract Upcoming Transactions from Available Balance',
   description:
-    'Subtracts upcoming transactions from the available balance for each category. In other words, treat upcoming transactions as if the money has already been spent. Also shows the total available after upcoming transactions in the budget inspector.',
+    'Subtracts upcoming transactions from the available balance for each category.' +
+    ' In other words, treat upcoming transactions as if the money has already been spent. Also adds "Available After Upcoming Transactions" to the budget breakdown.' +
+    '\n\nEnabling "Subtract Credit Card Balances from Total Available" will total the amounts in the "Payment" column' +
+    ' of your CC category group and subtract that from the "Available After Upcoming Transactions" in the budget breakdown.' +
+    ' This allows to see how much you have available, excluding the money "reserved" in your Credit Card Payments category group.' +
+    ' (Probably only useful if you pay off your CCs in full every month.)',
+  options: [
+    { name: 'Disabled', value: '0' },
+    { name: 'Both', value: 'both' },
+    { name: 'Subtract Upcoming from Available', value: 'upcoming-only' },
+    { name: 'Subtract Credit Card Balances from Total Available', value: 'cc-only' },
+  ],
 };


### PR DESCRIPTION
GitHub Issue (if applicable): #1849 

Trello Link (if applicable): https://trello.com/c/kmCAkWVP

**Explanation of Bugfix/Feature/Modification:**
Subtracts upcoming transactions from the available balance for each category. In other words, treat upcoming transactions as if the money has already been spent. Also shows the total available after upcoming transactions in the budget inspector.

![image](https://user-images.githubusercontent.com/1844269/120728251-cdd3ef80-c4dc-11eb-833b-d7500663511f.png)

There are currently some issues with this that I'm not sure how to solve. Any help is greatly appreciated.

**Known Issues:**
- Any change made to a category will overwrite the changes made by this feature (e.g. money is moved in or out of the category). Similarly, YNAB seems to refresh the values in the budget page seemingly at random, causing the same issue.
  - Fix(?): `invoke()` needs to be run whenever anything is updated.
-   Switching to the reports page causes YNAB to break: `Something has gone wrong likely having to do with internets and tubes. Refresh your browser to get back in business.` For some reason the feature is being invoked despite the fact that it should only be running on the budget page.
- CSS from Square Negative Mode is not being applied from balances that are being updated by this feature.

There is of course a mismatch between what available says vs. what is actually available with this feature enabled. For example, available could say -$50 (say, $50 budgeted and $100 upcoming), but if you go to move money from the category it will say you have $50 to move. It will also show up as money you can use to cover overspending and such. Personally I think it makes sense. Available should show at a glance the amount you can actually safely spend (point of this feature being that funds for upcoming transactions are not safe to spend). But if you actually need to move money from a category with upcoming transactions, you can.