### PR TITLE
fix: AoM and DoB date formatting broken on mouse over

### DIFF
--- a/src/extension/features/budget/date-of-money/index.css
+++ b/src/extension/features/budget/date-of-money/index.css
@@ -1,5 +1,4 @@
-.toolkit-days-of-buffering .budget-header-days-age {
-  color: #23b2ce;
+.budget-header-days .budget-header-days-age {
   min-width: 6em;
 }
 

--- a/src/extension/features/budget/date-of-money/index.js
+++ b/src/extension/features/budget/date-of-money/index.js
@@ -20,7 +20,7 @@ export class DateOfMoney extends Feature {
      * 		1. To get the Age Of Money (AOM)
      * 		2. Display the Date of Money to the user
      */
-    const budgetHeaderDaysContainer = document.querySelector('.budget-header-days');
+    const budgetHeaderDaysContainer = document.querySelector('.budget-header-days > div');
 
     /*
      * Get the div containing the Age Of Money (AOM) and add a mouse over function to display date of money.

--- a/src/extension/features/budget/date-of-money/index.js
+++ b/src/extension/features/budget/date-of-money/index.js
@@ -3,6 +3,10 @@ import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
 export class DateOfMoney extends Feature {
+  injectCSS() {
+    return require('./index.css');
+  }
+
   shouldInvoke() {
     return isCurrentRouteBudgetPage() && document.querySelector('.tk-date-of-money') === null;
   }

--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -191,7 +191,7 @@ ${l10n('toolkit.dob.avgOutflow', 'Average daily outflow')}: ~${formatCurrency(av
      *    1. To get the Days Of Buffering
      *    2. Display the Date of Buffering to the user
      */
-    const toolkitDaysOfBuffering = document.querySelector('.toolkit-days-of-buffering');
+    const toolkitDaysOfBuffering = document.querySelector('.toolkit-days-of-buffering > div');
 
     /*
      * Get the div containing the Age Of Money (AOM)


### PR DESCRIPTION
GitHub Issue (if applicable): #2400 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Both the "Date of Money" and "Days Of Buffering Metric - Date" features weren't working correctly - both would replace the value with unformatted text when moused over and then not revert after. This seems to be due to an extra div layer the features weren't expecting.
I have also added a minimum width to the containers so that the header doesn't adjust position each time the content is changed on mouse over. There may be a better way to do this with flexboxes but I didn't want to override too many of the native styles.
