### PR TITLE
fix: CopyWebpackPlugin error on windows due to path separators

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -116,7 +116,7 @@ module.exports = function (env) {
             globOptions: { ignore: '**/*.js' },
           },
           {
-            from: path.join(__dirname, `${CODE_SOURCE_DIR}/extension/legacy/**/*.css`),
+            from: path.join(__dirname, `${CODE_SOURCE_DIR}/extension/legacy/**/*.css`).replace(/\\/g, '/'),
             to: path.join(__dirname, `${BUILD_PATH}/web-accessibles`),
             context: 'src/extension',
           },
@@ -124,7 +124,7 @@ module.exports = function (env) {
             from: path.join(
               __dirname,
               `${CODE_SOURCE_DIR}/extension/legacy/features/l10n/locales/*.js`
-            ),
+            ).replace(/\\/g, '/'),
             to: path.join(__dirname, `${BUILD_PATH}/web-accessibles`),
             context: 'src/extension',
           },


### PR DESCRIPTION
GitHub Issue (if applicable): N/A

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Building the extension was failing after I reset my build environment.
> ERROR in unable to locate 'C:\Users\--\repos\toolkit-for-ynab\src\extension\legacy\features\l10n\locales\*.js' glob
> ERROR in unable to locate 'C:\Users\--\repos\toolkit-for-ynab\src\extension\legacy\**\*.css' glob

I think the error is caused by path.join using backslash as a path separator on Windows - which the [docs](https://webpack.js.org/plugins/copy-webpack-plugin/#from) warn against when using glob expressions.
Replacing the backslashes with forward slashes as in the docs seems to have fixed the issue for me.