### PR TITLE
fix: resize goal column on smaller screens (#2405)

### DIFF
--- a/src/extension/features/budget/budget-category-features/goal-container.css
+++ b/src/extension/features/budget/budget-category-features/goal-container.css
@@ -12,6 +12,15 @@
   font-size: 0.8em;
   margin-left: auto;
 
-  width: 15%;
+  width: 18%;
   justify-content: flex-end !important;
+}
+
+@media only screen and (max-width: 1650px) {
+  .tk-budget-table-cell-goal,
+  .budget-table-container .budget-table-cell-activity,
+  .budget-table-container .budget-table-cell-available,
+  .budget-table-container .budget-table-cell-budgeted {
+    width: 15%;
+  }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2405 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The change in #2374 moving goals into their own column has caused an issue for users with smaller screen resolutions.
The space taken by the goal column has reduced the space available for the category name column causing category names to cut off quickly.
I have increased the size of the goal column on larger resolutions from 15% to 18% to match the other number columns, and reduced the size of all columns to 15% when the resolution is less than 1650 pixels wide.