### PR TITLE
fix: split transaction tab expand doesn't apply to existing transactions

### DIFF
--- a/src/extension/features/accounts/split-transaction-tab-expand/index.js
+++ b/src/extension/features/accounts/split-transaction-tab-expand/index.js
@@ -3,7 +3,7 @@ import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class SplitTransactionTabExpand extends Feature {
   shouldInvoke() {
-    return isCurrentRouteAccountsPage();
+    return isCurrentRouteAccountsPage() && $('.ynab-grid-split-add-sub-transaction').length;
   }
 
   invoke() {}
@@ -22,10 +22,8 @@ export class SplitTransactionTabExpand extends Feature {
 
   observe() {
     if (!this.shouldInvoke()) return;
-    if ($('.ynab-grid-split-add-sub-transaction').length === 0) return;
 
-    const addTransactionGrid = $('.ynab-grid-add-rows');
-    const lastInput = $('input', addTransactionGrid).last();
+    const lastInput = $('.ynab-grid-body-row.is-editing input').last();
 
     if (!lastInput.attr('data-toolkit-tab-expand')) {
       lastInput.attr('data-toolkit-tab-expand', true);


### PR DESCRIPTION
GitHub Issue (if applicable): N/A
Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
The split transaction tab expand feature I wrote only checked for the add transaction grid, so when editing a split transaction it wasn't picked up. I've changed what the feature looks for to account for that.
