### PR TITLE
add date to legend on net worth and inflow/outflow toolkit reports (#2415)

### DIFF
--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
@@ -34,6 +34,7 @@ export class InflowOutflowComponent extends React.Component {
         <div className="tk-flex tk-justify-content-end">
           {this.state.hoveredData && (
             <Legend
+              label={this.state.hoveredData.label}
               inflows={this.state.hoveredData.inflows}
               outflows={this.state.hoveredData.outflows}
               diffs={this.state.hoveredData.diffs}
@@ -54,6 +55,7 @@ export class InflowOutflowComponent extends React.Component {
         mouseOver: function () {
           _this.setState({
             hoveredData: {
+              label: labels[this.index],
               inflows: inflows[this.index],
               outflows: outflows[this.index],
               diffs: diffs[this.index],
@@ -236,6 +238,7 @@ export class InflowOutflowComponent extends React.Component {
     this.setState(
       {
         hoveredData: {
+          label: labels[inflows.length - 1] || '',
           inflows: filteredInflows[inflows.length - 1] || 0,
           outflows: filteredOutflows[outflows.length - 1] || 0,
           diffs: filteredDiffs[outflows.length - 1] || 0,

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/component.jsx
@@ -7,6 +7,14 @@ export const Legend = (props) => (
   <React.Fragment>
     <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
+        <div className="tk-mg-0">&nbsp;</div>
+      </div>
+      <div className="tk-inflow-outflow-legend__text-faded">
+        {props.label}
+      </div>
+    </div>
+    <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
+      <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-inflow-outflow-legend__icon-outflows" />
         <div className="tk-mg-l-05">Outflows</div>
       </div>

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/styles.scss
@@ -10,4 +10,8 @@
     height: 16px;
     background-color: #ea6a51;
   }
+
+  &__text-faded {
+    opacity: 70%;
+  }
 }

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -53,6 +53,7 @@ export class NetWorthComponent extends React.Component {
           <div className="tk-flex tk-justify-content-end">
             {this.state.hoveredData && (
               <Legend
+                label={this.state.hoveredData.label}
                 assets={this.state.hoveredData.assets}
                 debts={this.state.hoveredData.debts}
                 debtRatio={this.state.hoveredData.debtRatio}
@@ -84,6 +85,7 @@ export class NetWorthComponent extends React.Component {
         mouseOver: function () {
           _this.setState({
             hoveredData: {
+              label: labels[this.index],
               assets: assets[this.index],
               debts: debts[this.index],
               debtRatio: debtRatios[this.index],
@@ -260,6 +262,7 @@ export class NetWorthComponent extends React.Component {
     this.setState(
       {
         hoveredData: {
+          label: labels[labels.length - 1] || '',
           assets: assets[assets.length - 1] || 0,
           debts: debts[debts.length - 1] || 0,
           debtRatio: debtRatios[debtRatios.length - 1] || 0,

--- a/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
@@ -8,6 +8,14 @@ export const Legend = (props) => (
   <React.Fragment>
     <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
+        <div className="tk-mg-0">&nbsp;</div>
+      </div>
+      <div className="tk-net-worth-legend__text-faded">
+        {props.label}
+      </div>
+    </div>
+    <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
+      <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-net-worth-legend__icon-debts" />
         <div className="tk-mg-l-05">Debts</div>
       </div>

--- a/src/extension/features/toolkit-reports/pages/net-worth/components/legend/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/net-worth/components/legend/styles.scss
@@ -16,4 +16,8 @@
     height: 4px;
     background-color: #6693b0;
   }
+
+  &__text-faded {
+    opacity: 70%;
+  }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2415 

**Explanation of Bugfix/Feature/Modification:**
When viewing a large date range it could be difficult to tell which month's data was being shown in the reports' legend.
This change adds the date of the hovered month to the left side of the legend.

![networth2](https://user-images.githubusercontent.com/83871143/122998973-9652b780-d3a5-11eb-8fd7-6cc24780d19f.png)
![networth](https://user-images.githubusercontent.com/83871143/122998977-9783e480-d3a5-11eb-9dc3-ea626d163bc7.png)

