### PR TITLE
Fix Pacing not appearing

### DIFF
--- a/src/extension/utils/pacing.js
+++ b/src/extension/utils/pacing.js
@@ -14,13 +14,6 @@ export function setDeemphasizedCategories(categories) {
 }
 
 export function pacingForCategory(budgetMonthDisplayItem) {
-  if (
-    budgetMonthDisplayItem.getEntityType() !==
-    ynab.constants.DisplayEntityType.BudgetMonthDisplayItem
-  ) {
-    throw new Error('Invalid Argument to calculate pacing. Expected BudgetMonthDisplayItem');
-  }
-
   const subCategory = budgetMonthDisplayItem.get('subCategory');
   if (!subCategory) {
     throw new Error('Pacing can only be calculated for subCategories.');


### PR DESCRIPTION
GitHub Issue (if applicable): #2428 

**Explanation of Bugfix/Feature/Modification:**
`getEntityType()` no longer exists, resulting in errors when trying to generate the pacing data. This function is also not used anywhere else.

As far as I can tell this function wasn't renamed, but completely removed. The remaining pacing generation will fail if any of the `get()` commands return null, so I think it's safe enough to remove unless anyone can foresee any issues?