### PR TITLE
Fix missing currency class

### DIFF
--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -193,11 +193,11 @@ export class SpendingByCategoryComponent extends React.Component {
         backgroundColor: 'transparent',
         events: {
           drilldown: (event) => {
-            chart.setTitle({ text: `${event.point.name}<br>${formatCurrency(event.point.y)}` });
+            chart.setTitle({ text: `${event.point.name}<br><span class="currency">${formatCurrency(event.point.y)}</span>` });
             _this.setState({ currentDrillDownId: event.point.id });
           },
           drillup: () => {
-            chart.setTitle({ text: `Total Spending<br>${formatCurrency(totalSpending)}` });
+            chart.setTitle({ text: `Total Spending<br><span class="currency">${formatCurrency(totalSpending)}</span>` });
             _this.setState({ currentDrillDownId: null });
           },
         },


### PR DESCRIPTION
Make "Privacy mode" ineffective
Not tested

GitHub Issue (if applicable): #XXX

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
When using "Privacy Mode", if you "drilldown" or "drillup" in the chart generated for "Spending by Category" or "Spending by payee", the privacy don't work for the central number.
