### PR TITLE
Don't hide percentage in privacy mode

### DIFF
--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -207,9 +207,9 @@ export class SpendingByCategoryComponent extends React.Component {
           dataLabels: {
             formatter: function () {
               let formattedNumber = formatCurrency(this.y);
-              return `${this.point.name}<br><span class="currency">${formattedNumber} (${Math.round(
+              return `${this.point.name}<br><span class="currency">${formattedNumber}</span> (${Math.round(
                 this.percentage
-              )}%)</span>`;
+              )}%)`;
             },
             style: {
               color: 'var(--label_primary)',

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -173,9 +173,9 @@ export class SpendingByPayeeComponent extends React.Component {
           dataLabels: {
             formatter: function () {
               let formattedNumber = formatCurrency(this.y);
-              return `${this.point.name}<br><span class="currency">${formattedNumber} (${Math.round(
+              return `${this.point.name}<br><span class="currency">${formattedNumber}</span> (${Math.round(
                 this.percentage
-              )}%)</span>`;
+              )}%)`;
             },
             style: {
               color: 'var(--label_primary)',


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Don't hide percentage in "Spending By Payee" and "Spending By Category" in "Privacy Mode". Only hide currency.
