### PR TITLE
Update bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,9 @@ If applicable, add screenshots to help explain your problem.
 - Toolkit Version [e.g. 2.22.0]
 
 **Setting Export**
-Please replace the text below with your exported Toolkit settings. You can export these by going to the Toolkit Options page, click the `Import/Export Settings` button at the bottom left and copying the text in the modal which appears.
+Please replace the text 'REPLACE_ME_WITH_SETTINGS' below with your exported Toolkit settings. You can export these by going to the Toolkit Options page, click the `Import/Export Settings` button at the bottom left and copying the text in the modal which appears. 
+
+Note! DO NOT replace the leading and trailing ` ``` ` characters as they are required formatting characters.
 
 ```
 REPLACE_ME_WITH_SETTINGS


### PR DESCRIPTION
Added additional instructions to the Setting Export section to hopefully, get users to stop wiping out the markdown ``` characters. We'll see what happens but hope springs eternal. 😀

GitHub Issue (if applicable): #XXX

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.
