### PR TITLE
import momentjs instead of relying on YNAB global instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "highcharts": "^9.1.1",
     "jest-progress-bar-reporter": "^1.0.21",
     "jquery": "^3.6.0",
+    "moment": "^2.29.1",
     "raven-js": "^3.25.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",

--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -4,6 +4,7 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { Collections } from 'toolkit/extension/utils/collections';
+import moment from 'moment';
 
 export class DaysOfBuffering extends Feature {
   _lookbackMonths = parseInt(ynabToolKit.options.DaysOfBufferingHistoryLookup);

--- a/src/extension/features/budget/stealing-from-future/index.js
+++ b/src/extension/features/budget/stealing-from-future/index.js
@@ -2,6 +2,7 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteBudgetPage, transitionTo } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 import { l10nMonth, MonthStyle } from 'toolkit/extension/utils/toolkit';
+import moment from 'moment';
 
 // TODO: move income-from-last-month to the new framework and just export this
 // variable from that feature

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/utils.js
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/utils.js
@@ -1,5 +1,6 @@
 // Common util methods to help generate a running total
 import regression from 'regression';
+import moment from 'moment';
 
 // Constant for how many datapoints to allow per graph line
 // https://api.highcharts.com/highcharts/plotOptions.series.turboThreshold

--- a/src/extension/utils/date.js
+++ b/src/extension/utils/date.js
@@ -1,5 +1,6 @@
 import { l10nMonth, MonthStyle } from './toolkit';
 import { getEntityManager } from './ynab';
+import moment from 'moment';
 
 export function getCurrentDate(format) {
   return ynabDate(format, false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5466,7 +5466,7 @@ mkdirp@1.x:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@2.29.1:
+moment@2.29.1, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
Hopefully I didn't miss anything. I'm not sure if we were relying on YNAB doing anything weird with their global instance. It builds fine and doesn't throw any errors from what I tested.