### PR TITLE
fix: total monthly goals not compatible with new inspector (#2434)

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -51,13 +51,15 @@ export class DisplayTotalMonthlyGoals extends Feature {
 
     return $(`
       <section class="card total-monthly-goals-inspector">
-        <h2>
-          Total Monthly Goals
-          <svg width="24" height="24" class="card-chevron"></svg>
-          <span class="user-data currency ${currencyClass}">
-              ${formatCurrency(goalsAmount)}
-          </span>
-        </h2>
+        <div class="card-roll-up">
+          <h2>
+            Total Monthly Goals
+            <svg width="24" height="24" class="card-chevron"></svg>
+            <span class="user-data currency ${currencyClass}">
+                ${formatCurrency(goalsAmount)}
+            </span>
+          </h2>
+        </div>
       </section>
     `);
   }

--- a/src/extension/features/budget/display-total-monthly-goals/index.js
+++ b/src/extension/features/budget/display-total-monthly-goals/index.js
@@ -50,15 +50,15 @@ export class DisplayTotalMonthlyGoals extends Feature {
     const currencyClass = goalsAmount === 0 ? 'zero' : 'positive';
 
     return $(`
-      <div class="total-monthly-goals-inspector">
-        <h3>TOTAL MONTHLY GOALS</h3>
-        <h1 title>
+      <section class="card total-monthly-goals-inspector">
+        <h2>
+          Total Monthly Goals
+          <svg width="24" height="24" class="card-chevron"></svg>
           <span class="user-data currency ${currencyClass}">
-            ${formatCurrency(goalsAmount)}
+              ${formatCurrency(goalsAmount)}
           </span>
-        </h1>
-        <hr />
-      </div>
+        </h2>
+      </section>
     `);
   }
 
@@ -73,23 +73,11 @@ export class DisplayTotalMonthlyGoals extends Feature {
     }
 
     this.createInspectorElement(monthlyGoals.amount).insertBefore(
-      $('.inspector-quick-budget', element)
+      $('.card.budget-breakdown-monthly-totals', element)
     );
   }
 
   invoke() {
-    addToolkitEmberHook(
-      this,
-      'budget/inspector/default-inspector',
-      'didRender',
-      this.addTotalMonthlyGoals
-    );
-
-    addToolkitEmberHook(
-      this,
-      'budget/inspector/multi-select-inspector',
-      'didRender',
-      this.addTotalMonthlyGoals
-    );
+    addToolkitEmberHook(this, 'budget/budget-inspector', 'didRender', this.addTotalMonthlyGoals);
   }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2434

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Updated Total Monthly Goals to display in the new inspector.

<img width="315" alt="totalmonthlygoals" src="https://user-images.githubusercontent.com/83871143/127725429-f9e2b954-7641-49c6-b4c8-65e9ab5dd7de.png">

