### PR TITLE
fix: toggle memo column not showing in view options (#2441)

### DIFF
--- a/src/extension/features/accounts/toggle-account-columns/index.js
+++ b/src/extension/features/accounts/toggle-account-columns/index.js
@@ -53,7 +53,12 @@ export class ToggleAccountColumns extends Feature {
   }
 
   invoke() {
-    addToolkitEmberHook(this, 'modals/register/view-menu', 'didRender', this.insertToggles);
+    addToolkitEmberHook(
+      this,
+      'modals/register/register-view-options',
+      'didRender',
+      this.insertToggles
+    );
   }
 
   insertToggles(element) {


### PR DESCRIPTION
GitHub Issue (if applicable): #2441

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The UI update changed the component name of the account view options menu breaking the toggle memo feature.
