### PR TITLE
fix: webpack devtool config error due to webpack upgrade

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = function (env) {
       'web-accessibles/ynab-toolkit': path.resolve(`${CODE_SOURCE_DIR}/extension/index.js`),
     },
 
-    devtool: env.buildType !== 'production' ? 'inline-source-map' : '',
+    devtool: env.buildType !== 'production' ? 'inline-source-map' : false,
 
     output: {
       path: path.join(__dirname, BUILD_ROOT),


### PR DESCRIPTION
GitHub Issue (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
The devtool configuration option has become more strict in webpack v5, and no longer accepts a blank string. I've updated the value to false.