### PR TITLE
fix: import/export settings not fixed to viewport in dark mode (#2423)

### DIFF
--- a/src/core/options/options.js
+++ b/src/core/options/options.js
@@ -354,9 +354,9 @@ jq(() => {
 
   function applyDarkMode(activate) {
     if (activate) {
-      jq('body').addClass('inverted');
+      jq('html').addClass('inverted');
     } else {
-      jq('body').removeClass('inverted');
+      jq('html').removeClass('inverted');
     }
   }
 

--- a/src/core/options/styles.css
+++ b/src/core/options/styles.css
@@ -1,10 +1,12 @@
-body {
-  min-width: 900px;
-
+html {
   -webkit-transition: all 1s ease;
   -moz-transition: all 1s ease;
   -o-transition: all 1s ease;
   transition: all 1s ease;
+}
+
+body {
+  min-width: 900px;
 }
 
 .inverted {


### PR DESCRIPTION
GitHub Issue (if applicable): #2423 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
When dark mode was enabled in the options menu opening the import/export settings modal would open it at the top of the document rather than fixed to the viewport. This was due to the invert filter rule creating a containing block and a new stacking context. I've moved the filter rule from the body to the html element.
