### PR TITLE
fix: pacing column values don't display (#2432)

### DIFF
--- a/src/extension/utils/pacing.js
+++ b/src/extension/utils/pacing.js
@@ -15,7 +15,7 @@ export function setDeemphasizedCategories(categories) {
 
 export function pacingForCategory(budgetMonthDisplayItem) {
   if (
-    budgetMonthDisplayItem.getEntityType() !==
+    budgetMonthDisplayItem.getDisplayEntityType() !==
     ynab.constants.DisplayEntityType.BudgetMonthDisplayItem
   ) {
     throw new Error('Invalid Argument to calculate pacing. Expected BudgetMonthDisplayItem');


### PR DESCRIPTION
GitHub Issue (if applicable): #2432

**Explanation of Bugfix/Feature/Modification:**
The pacing columns feature was failing as the getEntityType method no longer existed on the category object. I have updated it to getDisplayEntityType which seems to return equivalent values.
