### PR TITLE
fix: pif credit card assist not recognising budgeting changes (#2447)

### DIFF
--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -37,7 +37,7 @@ export class CheckCreditBalances extends Feature {
       changedNodes.has(
         'budget-table-row js-budget-table-row is-sub-category is-debt-payment-category is-checked'
       ) ||
-      changedNodes.has('budget-header-totals-cell-value user-data')
+      changedNodes.has('to-be-budgeted-amount')
     ) {
       this.invoke();
     }


### PR DESCRIPTION
GitHub Issue (if applicable): #2447 

**Explanation of Bugfix/Feature/Modification:**
The paid in full credit card assist feature was not recognising the budgeted value had changed when the rectify difference button was pressed. This was due to the new header UI and a change in class names.
