### PR TITLE
fix: memo as markdown not operating (#2366)

### DIFF
--- a/src/extension/features/accounts/memo-as-markdown/index.js
+++ b/src/extension/features/accounts/memo-as-markdown/index.js
@@ -32,7 +32,7 @@ export class MemoAsMarkdown extends Feature {
     };
 
     const note = view.get('attrs.content.value.memo');
-    const originalMemo = element.querySelector('.ynab-grid-cell-memo .user-entered-text');
+    const originalMemo = element.querySelector('.ynab-grid-cell-memo span');
     if (note && originalMemo) {
       originalMemo.remove();
 


### PR DESCRIPTION
GitHub Issue (if applicable): #2366 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The memo as markdown feature was not working due to a change in the structure of memo elements.
