### PR TITLE
fix: turning off aom and dob causes large white space (#2466)

### DIFF
--- a/src/extension/features/budget/hide-age-of-money/index.css
+++ b/src/extension/features/budget/hide-age-of-money/index.css
@@ -1,4 +1,3 @@
-.budget-header-days:not(.toolkit-days-of-buffering) {
+.budget-header-days:not(.toolkit-days-of-buffering) div {
   display: none;
-  border-left: none;
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2466

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The header background is set by the contained elements rather than the container. I've changed the feature styles to disable the div inside the header item in order to maintain the background. 