### PR TITLE
fix: markdown in memo not working in split transactions (#2283)

### DIFF
--- a/src/extension/features/accounts/memo-as-markdown/index.js
+++ b/src/extension/features/accounts/memo-as-markdown/index.js
@@ -58,5 +58,6 @@ export class MemoAsMarkdown extends Feature {
 
   invoke() {
     addToolkitEmberHook(this, 'register/grid-row', 'didRender', this.applyMarkdown);
+    addToolkitEmberHook(this, 'register/grid-sub', 'didRender', this.applyMarkdown);
   }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2283

**Explanation of Bugfix/Feature/Modification:**
Markdown in memo wasn't applying to the sub transactions in a split, due to the sub transaction rows having a different component name.
