### PR TITLE
fix: easy transaction approval alters row selection (#2368)

### DIFF
--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -100,6 +100,32 @@ export class EasyTransactionApproval extends Feature {
     this.initKeyLoop = false;
   }
 
+  clickCallback(event) {
+    // prevent defaults
+    event.preventDefault();
+    event.stopPropagation();
+
+    const selectedRows = $('.ynab-grid-body-row .ynab-grid-cell-checkbox button.is-checked');
+
+    const checkbox = $(this).closest('.ynab-grid-body-row').find('.ynab-grid-cell-checkbox button');
+    const isChecked = checkbox.hasClass('is-checked');
+
+    // if the row clicked isn't already selected, select only that row for approval
+    if (!isChecked) {
+      selectedRows.click();
+      checkbox.click();
+    }
+
+    // approve transactions
+    event.data();
+
+    // restore original selection
+    if (!isChecked) {
+      selectedRows.click();
+      checkbox.click();
+    }
+  }
+
   watchForRightClick() {
     var _this = this;
 
@@ -108,44 +134,13 @@ export class EasyTransactionApproval extends Feature {
       $('.ynab-grid').off(
         'contextmenu',
         '.ynab-grid-body-row .ynab-grid-cell-notification button.transaction-notification-info',
-        function (event) {
-          // prevent defaults
-          event.preventDefault();
-          event.stopPropagation();
-
-          // select row
-          const checkbox = $(this)
-            .closest('.ynab-grid-body-row')
-            .find('.ynab-grid-cell-checkbox button:not(.is-checked)')
-            .click();
-
-          // approve transactions
-          _this.approveTransactions();
-
-          // restore original selection
-          checkbox.click();
-        }
+        _this.clickCallback
       );
       $('.ynab-grid').on(
         'contextmenu',
         '.ynab-grid-body-row .ynab-grid-cell-notification button.transaction-notification-info',
-        function (event) {
-          // prevent defaults
-          event.preventDefault();
-          event.stopPropagation();
-
-          // select row
-          const checkbox = $(this)
-            .closest('.ynab-grid-body-row')
-            .find('.ynab-grid-cell-checkbox button:not(.is-checked)')
-            .click();
-
-          // approve transactions
-          _this.approveTransactions();
-
-          // restore original selection
-          checkbox.click();
-        }
+        _this.approveTransactions,
+        _this.clickCallback
       );
     });
 

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -114,13 +114,16 @@ export class EasyTransactionApproval extends Feature {
           event.stopPropagation();
 
           // select row
-          $(this)
+          const checkbox = $(this)
             .closest('.ynab-grid-body-row')
             .find('.ynab-grid-cell-checkbox button:not(.is-checked)')
             .click();
 
           // approve transactions
           _this.approveTransactions();
+
+          // restore original selection
+          checkbox.click();
         }
       );
       $('.ynab-grid').on(
@@ -132,13 +135,16 @@ export class EasyTransactionApproval extends Feature {
           event.stopPropagation();
 
           // select row
-          $(this)
+          const checkbox = $(this)
             .closest('.ynab-grid-body-row')
             .find('.ynab-grid-cell-checkbox button:not(.is-checked)')
             .click();
 
           // approve transactions
           _this.approveTransactions();
+
+          // restore original selection
+          checkbox.click();
         }
       );
     });
@@ -160,8 +166,5 @@ export class EasyTransactionApproval extends Feature {
     keycode2.which = 67;
     keycode2.keyCode = 67;
     $('body').trigger(keycode2);
-
-    // unselect transactions after approval
-    $('.ynab-grid-body-row.is-checked').find('.ynab-grid-cell-checkbox button').click();
   }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2368 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
When approving a transaction with easy transaction approval, any rows selected would be unselected when approving, breaking keyboard navigation.
I have altered the feature to retain any row selection when approving.
I have also changed click approval behaviour - when selecting multiple rows, clicking an icon in a selected row will approve all selected rows, while clicking an icon outside selected rows will only approve the clicked row.
