### PR TITLE
fix: quick budget warning not triggering

### DIFF
--- a/src/extension/features/budget/quick-budget-warning/index.js
+++ b/src/extension/features/budget/quick-budget-warning/index.js
@@ -39,7 +39,8 @@ export class QuickBudgetWarning extends Feature {
     if (
       changedNodes.has('navlink-budget active') ||
       changedNodes.has('budget-inspector') ||
-      changedNodes.has('inspector-quick-budget')
+      changedNodes.has('inspector-quick-budget') ||
+      changedNodes.has('budget-inspector-button')
     ) {
       this.invoke();
     }


### PR DESCRIPTION
GitHub Issue (if applicable):
Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The quick budget warning feature was not triggering - I'm not entirely sure why.
Adding the quick budget button class to the observer seems to have fixed it.
