### PR TITLE
fix: easy transaction approval in filtered view toggles cleared status

### DIFF
--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
-import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { controllerLookup, serviceLookup } from 'toolkit/extension/utils/ember';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 
 export class EasyTransactionApproval extends Feature {
@@ -150,20 +150,9 @@ export class EasyTransactionApproval extends Feature {
   }
 
   approveTransactions() {
-    // open the edit menu
-    $('.accounts-toolbar-edit-transaction').click();
-
-    // attempt to find and click the approve button
-    $('.modal-account-edit-transaction-list .button-list')
-      .filter(
-        (index, el) =>
-          el.textContent && el.textContent.trim() === l10n('accounts.approve', 'Approve')
-      )
-      .click();
-
-    // if the edit menu is still open, close it
-    if ($('.modal-account-edit-transaction-list').length) {
-      $('.modal-account-edit-transaction-list').click();
-    }
+    const accountsService = serviceLookup('accounts');
+    accountsService.areChecked.forEach((transaction) => {
+      if (transaction.needsApproval) transaction.approve();
+    });
   }
 }

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -1,6 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { l10n } from 'toolkit/extension/utils/toolkit';
 
 export class EasyTransactionApproval extends Feature {
   initBudgetVersion = true;
@@ -149,17 +150,20 @@ export class EasyTransactionApproval extends Feature {
   }
 
   approveTransactions() {
-    // call 'c' keypress clearing and approving transaction using built in YNAB functionality
-    var keycode = jQuery.Event('keydown'); // eslint-disable-line new-cap
-    keycode.which = 67;
-    keycode.keyCode = 67;
-    $('body').trigger(keycode);
+    // open the edit menu
+    $('.accounts-toolbar-edit-transaction').click();
 
-    // call 'c' keypress again, to reset clear state back to previous
-    // completely separate event is needed, otherwise event doesn't fire properly the second time
-    var keycode2 = jQuery.Event('keydown'); // eslint-disable-line new-cap
-    keycode2.which = 67;
-    keycode2.keyCode = 67;
-    $('body').trigger(keycode2);
+    // attempt to find and click the approve button
+    $('.modal-account-edit-transaction-list .button-list')
+      .filter(
+        (index, el) =>
+          el.textContent && el.textContent.trim() === l10n('accounts.approve', 'Approve')
+      )
+      .click();
+
+    // if the edit menu is still open, close it
+    if ($('.modal-account-edit-transaction-list').length) {
+      $('.modal-account-edit-transaction-list').click();
+    }
   }
 }

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -90,7 +90,7 @@ export class EasyTransactionApproval extends Feature {
     $('body').on('keydown', function (e) {
       if ((e.which === 13 || e.which === 65) && _this.watchForKeys) {
         // approve selected transactions when 'a' or 'enter is pressed'
-        _this.approveTransactions();
+        _this.approveSelectedTransactions();
 
         // disable keydown watch until selection is changed again
         _this.watchForKeys = false;
@@ -106,24 +106,24 @@ export class EasyTransactionApproval extends Feature {
     event.preventDefault();
     event.stopPropagation();
 
-    const selectedRows = $('.ynab-grid-body-row .ynab-grid-cell-checkbox button.is-checked');
+    const clickedRow = $(this).closest('.ynab-grid-body-row');
+    const clickedRowEntityId = clickedRow.attr('data-row-id');
 
-    const checkbox = $(this).closest('.ynab-grid-body-row').find('.ynab-grid-cell-checkbox button');
-    const isChecked = checkbox.hasClass('is-checked');
+    const accountsService = serviceLookup('accounts');
+    const isChecked =
+      accountsService.areChecked.filter(
+        (transaction) => transaction.entityId === clickedRowEntityId
+      ).length > 0;
 
-    // if the row clicked isn't already selected, select only that row for approval
+    // if the row clicked isn't already selected, approve only that transaction
     if (!isChecked) {
-      selectedRows.click();
-      checkbox.click();
-    }
-
-    // approve transactions
-    event.data();
-
-    // restore original selection
-    if (!isChecked) {
-      selectedRows.click();
-      checkbox.click();
+      accountsService.selectedAccount.getTransactions().forEach((transaction) => {
+        if (transaction.entityId === clickedRowEntityId && !transaction.accepted) {
+          transaction.setAccepted(true);
+        }
+      });
+    } else {
+      event.data.approveSelectedTransactions();
     }
   }
 
@@ -140,7 +140,7 @@ export class EasyTransactionApproval extends Feature {
       $('.ynab-grid').on(
         'contextmenu',
         '.ynab-grid-body-row .ynab-grid-cell-notification button.transaction-notification-info',
-        _this.approveTransactions,
+        _this,
         _this.clickCallback
       );
     });
@@ -149,17 +149,17 @@ export class EasyTransactionApproval extends Feature {
     this.initClickLoop = false;
   }
 
-  approveTransactions() {
+  approveSelectedTransactions() {
+    const accountsService = serviceLookup('accounts');
+
     const editingService = serviceLookup('transaction-editor');
     const editingId = editingService.editingId;
-    const accountsService = serviceLookup('accounts');
+
     accountsService.areChecked.forEach((transaction) => {
-      if (transaction.needsApproval) {
-        if (editingId && editingId === transaction.entityId) {
-          transaction.setAccepted(true);
-        } else {
-          transaction.approve();
-        }
+      if (editingId && editingId === transaction.entityId) {
+        transaction.setAccepted(true);
+      } else {
+        transaction.approve();
       }
     });
   }

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -150,9 +150,17 @@ export class EasyTransactionApproval extends Feature {
   }
 
   approveTransactions() {
+    const editingService = serviceLookup('transaction-editor');
+    const editingId = editingService.editingId;
     const accountsService = serviceLookup('accounts');
     accountsService.areChecked.forEach((transaction) => {
-      if (transaction.needsApproval) transaction.approve();
+      if (transaction.needsApproval) {
+        if (editingId && editingId === transaction.entityId) {
+          transaction.setAccepted(true);
+        } else {
+          transaction.approve();
+        }
+      }
     });
   }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2383 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
When using easy transaction approval in the Is: Unapproved filtered view, approving a transaction would toggle its cleared state.
This was due to the feature toggling the cleared status twice to approve it - after the first toggle, the transaction would disappear from the view as it had been approved. I've instead implemented a method based on the edit menu.
This is a more fragile method but should resolve that particular issue. Please let me know if you have any better ideas.
