### PR TITLE
fix: Adjust alignment of cancel/clear button in category filter feature

### DIFF
--- a/src/extension/features/budget/filter-categories/index.css
+++ b/src/extension/features/budget/filter-categories/index.css
@@ -30,7 +30,7 @@
   cursor: pointer;
   position: absolute;
   right: 0;
-  top: 0.12rem;
+  top: 0.45rem;
   z-index: 11;
 }
 


### PR DESCRIPTION
GitHub Issue (if applicable): _none_

Trello Link (if applicable): _none_

**Explanation of Bugfix/Feature/Modification:**

Slightly tweak the positioning of the filter cancel icon to be visually aligned within the input.

The existing alignment seems to have been set explicitly, so please disregard if there's a reason for that.

_Before:_

![CleanShot 2021-08-04 at 20 05 46@2x](https://user-images.githubusercontent.com/3461087/128275169-dea1af36-ad24-4bb9-b3ee-e1d42922b268.png)

_After:_

![CleanShot 2021-08-04 at 20 07 30@2x](https://user-images.githubusercontent.com/3461087/128275258-72c0e693-400f-4014-8571-46e8695631ee.png)
