### PR TITLE
add destroy methods to general features

### DIFF
--- a/src/extension/features/budget/filter-categories/index.css
+++ b/src/extension/features/budget/filter-categories/index.css
@@ -30,7 +30,7 @@
   cursor: pointer;
   position: absolute;
   right: 0;
-  top: 0.12rem;
+  top: 0.45rem;
   z-index: 11;
 }
 

--- a/src/extension/features/general/budget-quick-switch/index.js
+++ b/src/extension/features/general/budget-quick-switch/index.js
@@ -3,7 +3,7 @@ import { componentPrepend } from 'toolkit/extension/utils/react';
 import { Feature } from 'toolkit/extension/features/feature';
 import { BudgetListItem } from './components/budget-list-item';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
-import { addToolkitEmberHook, removeToolkitEmberHooks } from 'toolkit/extension/utils/toolkit';
+import { addToolkitEmberHook, removeToolkitEmberHook } from 'toolkit/extension/utils/toolkit';
 
 export class BudgetQuickSwitch extends Feature {
   shouldInvoke() {
@@ -15,7 +15,7 @@ export class BudgetQuickSwitch extends Feature {
   }
 
   destroy() {
-    removeToolkitEmberHooks(this, 'settings-menu', 'didRender');
+    removeToolkitEmberHook('settings-menu', 'didRender', this.injectQuickSwitch);
 
     const quickSwitch = document.querySelector('#tk-quick-switch');
     if (!quickSwitch) return;

--- a/src/extension/features/general/budget-quick-switch/index.js
+++ b/src/extension/features/general/budget-quick-switch/index.js
@@ -3,7 +3,7 @@ import { componentPrepend } from 'toolkit/extension/utils/react';
 import { Feature } from 'toolkit/extension/features/feature';
 import { BudgetListItem } from './components/budget-list-item';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
-import { addToolkitEmberHook } from 'toolkit/extension/utils/toolkit';
+import { addToolkitEmberHook, removeToolkitEmberHooks } from 'toolkit/extension/utils/toolkit';
 
 export class BudgetQuickSwitch extends Feature {
   shouldInvoke() {
@@ -12,6 +12,16 @@ export class BudgetQuickSwitch extends Feature {
 
   invoke() {
     addToolkitEmberHook(this, 'settings-menu', 'didRender', this.injectQuickSwitch);
+  }
+
+  destroy() {
+    removeToolkitEmberHooks(this, 'settings-menu', 'didRender');
+
+    const quickSwitch = document.querySelector('#tk-quick-switch');
+    if (!quickSwitch) return;
+
+    while (quickSwitch.previousSibling) quickSwitch.previousSibling.remove();
+    quickSwitch.remove();
   }
 
   injectQuickSwitch(element) {

--- a/src/extension/features/general/category-activity-copy/index.jsx
+++ b/src/extension/features/general/category-activity-copy/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEntityManager } from 'toolkit/extension/utils/ynab';
 import { controllerLookup, getEmberView } from 'toolkit/extension/utils/ember';
-import { addToolkitEmberHook } from 'toolkit/extension/utils/toolkit';
+import { addToolkitEmberHook, removeToolkitEmberHooks } from 'toolkit/extension/utils/toolkit';
 import { componentAppend } from 'toolkit/extension/utils/react';
 
 function CopyTransactionsButton({ transactions }) {
@@ -56,6 +56,12 @@ export class CategoryActivityCopy extends Feature {
       'didRender',
       this.handleReportActivityModal
     );
+  }
+
+  destroy() {
+    removeToolkitEmberHooks(this, 'budget/budget-activity', 'didRender');
+    removeToolkitEmberHooks(this, 'modals/reports/activity-transactions', 'didRender');
+    $('#tk-copy-transactions').remove();
   }
 
   handleBudgetActivityModal = (element) => {

--- a/src/extension/features/general/category-activity-copy/index.jsx
+++ b/src/extension/features/general/category-activity-copy/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEntityManager } from 'toolkit/extension/utils/ynab';
 import { controllerLookup, getEmberView } from 'toolkit/extension/utils/ember';
-import { addToolkitEmberHook, removeToolkitEmberHooks } from 'toolkit/extension/utils/toolkit';
+import { addToolkitEmberHook, removeToolkitEmberHook } from 'toolkit/extension/utils/toolkit';
 import { componentAppend } from 'toolkit/extension/utils/react';
 
 function CopyTransactionsButton({ transactions }) {
@@ -59,8 +59,12 @@ export class CategoryActivityCopy extends Feature {
   }
 
   destroy() {
-    removeToolkitEmberHooks(this, 'budget/budget-activity', 'didRender');
-    removeToolkitEmberHooks(this, 'modals/reports/activity-transactions', 'didRender');
+    removeToolkitEmberHook('budget/budget-activity', 'didRender', this.handleBudgetActivityModal);
+    removeToolkitEmberHook(
+      'modals/reports/activity-transactions',
+      'didRender',
+      this.handleReportActivityModal
+    );
     $('#tk-copy-transactions').remove();
   }
 

--- a/src/extension/features/general/customize-colour-scheme/index.js
+++ b/src/extension/features/general/customize-colour-scheme/index.js
@@ -265,6 +265,11 @@ export class CustomizeColourScheme extends Feature {
     this.loadSettings();
   }
 
+  destroy() {
+    this.setEnabled(false);
+    $('.tk-custom-colours-option').remove();
+  }
+
   createColourOption(name, label) {
     const value = this.getColour(name);
 

--- a/src/extension/features/general/hide-closed-accounts/index.jsx
+++ b/src/extension/features/general/hide-closed-accounts/index.jsx
@@ -7,7 +7,7 @@ import {
   l10n,
   getToolkitStorageKey,
   setToolkitStorageKey,
-  removeToolkitEmberHooks,
+  removeToolkitEmberHook,
 } from 'toolkit/extension/utils/toolkit';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
@@ -61,7 +61,7 @@ export class HideClosedAccounts extends Feature {
   }
 
   destroy() {
-    removeToolkitEmberHooks(this, 'settings-menu', 'didRender');
+    removeToolkitEmberHook('settings-menu', 'didRender', this.insertHideClosed);
     $('#tk-hide-closed-accounts').remove();
     $('body').removeClass('tk-hide-closed');
   }

--- a/src/extension/features/general/hide-closed-accounts/index.jsx
+++ b/src/extension/features/general/hide-closed-accounts/index.jsx
@@ -63,6 +63,7 @@ export class HideClosedAccounts extends Feature {
   destroy() {
     removeToolkitEmberHooks(this, 'settings-menu', 'didRender');
     $('#tk-hide-closed-accounts').remove();
+    $('body').removeClass('tk-hide-closed');
   }
 
   setHiddenState = (state) => {

--- a/src/extension/features/general/hide-closed-accounts/index.jsx
+++ b/src/extension/features/general/hide-closed-accounts/index.jsx
@@ -7,6 +7,7 @@ import {
   l10n,
   getToolkitStorageKey,
   setToolkitStorageKey,
+  removeToolkitEmberHooks,
 } from 'toolkit/extension/utils/toolkit';
 import { controllerLookup } from 'toolkit/extension/utils/ember';
 
@@ -57,6 +58,11 @@ export class HideClosedAccounts extends Feature {
     const initialState = getToolkitStorageKey('hide-closed', true);
     this.setHiddenState(initialState);
     addToolkitEmberHook(this, 'settings-menu', 'didRender', this.insertHideClosed);
+  }
+
+  destroy() {
+    removeToolkitEmberHooks(this, 'settings-menu', 'didRender');
+    $('#tk-hide-closed-accounts').remove();
   }
 
   setHiddenState = (state) => {

--- a/src/extension/features/general/hide-help/index.jsx
+++ b/src/extension/features/general/hide-help/index.jsx
@@ -8,7 +8,7 @@ import {
   l10n,
   getToolkitStorageKey,
   setToolkitStorageKey,
-  removeToolkitEmberHooks,
+  removeToolkitEmberHook,
 } from 'toolkit/extension/utils/toolkit';
 
 const HideHelpButton = ({ toggleHiddenState }) => {
@@ -61,7 +61,7 @@ export class HideHelp extends Feature {
   }
 
   destroy() {
-    removeToolkitEmberHooks(this, 'settings-menu', 'didRender');
+    removeToolkitEmberHook('settings-menu', 'didRender', this.insertHideHelp);
     $('#tk-hide-help').remove();
     $('body').removeClass('toolkit-hide-help');
   }

--- a/src/extension/features/general/hide-help/index.jsx
+++ b/src/extension/features/general/hide-help/index.jsx
@@ -8,6 +8,7 @@ import {
   l10n,
   getToolkitStorageKey,
   setToolkitStorageKey,
+  removeToolkitEmberHooks,
 } from 'toolkit/extension/utils/toolkit';
 
 const HideHelpButton = ({ toggleHiddenState }) => {
@@ -57,6 +58,12 @@ export class HideHelp extends Feature {
     const initialState = getToolkitStorageKey('hide-help', true);
     this.setHiddenState(initialState);
     addToolkitEmberHook(this, 'settings-menu', 'didRender', this.insertHideHelp);
+  }
+
+  destroy() {
+    removeToolkitEmberHooks(this, 'settings-menu', 'didRender');
+    $('#tk-hide-help').remove();
+    $('body').removeClass('toolkit-hide-help');
   }
 
   setHiddenState = (state) => {

--- a/src/extension/features/general/import-notification/index.js
+++ b/src/extension/features/general/import-notification/index.js
@@ -35,6 +35,12 @@ export class ImportNotification extends Feature {
     this.checkImportTransactions();
   };
 
+  destroy() {
+    $(`.nav-account-row .nav-account-name.${this.importClass}`)
+      .removeAttr('title')
+      .removeClass(this.importClass);
+  }
+
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
     // To minimize checking for imported transactions, only do it if the changed nodes includes ynab-grid-body

--- a/src/extension/features/general/pos-style-currency-entry-mode/index.js
+++ b/src/extension/features/general/pos-style-currency-entry-mode/index.js
@@ -28,18 +28,26 @@ export class POSStyleCurrencyEntryMode extends Feature {
     this.wrapCurrencyInput('ynab-new-currency-input');
   }
 
+  destroy() {
+    const newCurrencyInputComponent = componentLookup('ynab-new-currency-input');
+    const originalNewCurrencyInputComponentActions =
+      Object.getPrototypeOf(newCurrencyInputComponent).actions;
+    originalNewCurrencyInputComponentActions.commitValue =
+      this.originalNewCurrencyInputComponentCallback;
+  }
+
   wrapCurrencyInput(name) {
     const self = this;
 
     const newCurrencyInputComponent = componentLookup(name);
     const originalNewCurrencyInputComponentActions =
       Object.getPrototypeOf(newCurrencyInputComponent).actions;
-    const originalNewCurrencyInputComponentCallback =
+    this.originalNewCurrencyInputComponentCallback =
       originalNewCurrencyInputComponentActions.commitValue;
 
     originalNewCurrencyInputComponentActions.commitValue = function () {
       const newArgs = [].slice.call(arguments);
-      newArgs.push(self, originalNewCurrencyInputComponentCallback);
+      newArgs.push(self, self.originalNewCurrencyInputComponentCallback);
       self.commitValueWrapper.apply(this, newArgs);
     };
   }

--- a/src/extension/features/general/privacy-mode/index.js
+++ b/src/extension/features/general/privacy-mode/index.js
@@ -6,6 +6,7 @@ const Settings = {
   Toggle: '2',
 };
 
+const TEXT_BLUR_SVG_ID = 'tk-privacy-mode-svg';
 const TEXT_BLUR_FILTER_ID = 'text-blur';
 
 const PRIVACY_TOOLKIT_STORAGE_KEY = 'privacy-mode';
@@ -60,6 +61,12 @@ export class PrivacyMode extends Feature {
     this.updatePrivacyMode();
   }
 
+  destroy() {
+    $('#tk-toggle-privacy').remove();
+    $('body').removeClass('tk-privacy-mode');
+    $(`#${TEXT_BLUR_SVG_ID}`).remove();
+  }
+
   onRouteChanged() {
     this.invoke();
   }
@@ -86,9 +93,9 @@ export class PrivacyMode extends Feature {
 
   _getBlurSVG() {
     return /* html */ `
-      <svg version="1.1" width="0" height="0">
+      <svg id="${TEXT_BLUR_SVG_ID}" version="1.1" width="0" height="0">
         <defs>
-          <filter id="text-blur">
+          <filter id="${TEXT_BLUR_FILTER_ID}">
             <feGaussianBlur stdDeviation="6" result="blur" />
           </filter>
         </defs>

--- a/src/extension/features/general/uncleared-account-highlight/index.js
+++ b/src/extension/features/general/uncleared-account-highlight/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
-import { addToolkitEmberHook, removeToolkitEmberHooks } from 'toolkit/extension/utils/toolkit';
+import { addToolkitEmberHook, removeToolkitEmberHook } from 'toolkit/extension/utils/toolkit';
 
 const INDICATOR_CLASS = 'tk-uncleared-account-indicator';
 const INDICATOR_ELEMENT = `<div class="${INDICATOR_CLASS} flaticon solid copyright"></div>`;
@@ -79,7 +79,7 @@ export class UnclearedAccountHighlight extends Feature {
   }
 
   destroy() {
-    removeToolkitEmberHooks(this, 'accounts-list', 'didRender');
+    removeToolkitEmberHook('accounts-list', 'didRender', this.updateSidebarIndicator);
     $(`.nav-account-row .${INDICATOR_CLASS}`).remove();
     $('.tk-nav-account-icons-right-space').removeClass('tk-nav-account-icons-right-space');
   }

--- a/src/extension/features/general/uncleared-account-highlight/index.js
+++ b/src/extension/features/general/uncleared-account-highlight/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
-import { addToolkitEmberHook } from 'toolkit/extension/utils/toolkit';
+import { addToolkitEmberHook, removeToolkitEmberHooks } from 'toolkit/extension/utils/toolkit';
 
 const INDICATOR_CLASS = 'tk-uncleared-account-indicator';
 const INDICATOR_ELEMENT = `<div class="${INDICATOR_CLASS} flaticon solid copyright"></div>`;
@@ -76,5 +76,11 @@ export class UnclearedAccountHighlight extends Feature {
 
   invoke() {
     addToolkitEmberHook(this, 'accounts-list', 'didRender', this.updateSidebarIndicator);
+  }
+
+  destroy() {
+    removeToolkitEmberHooks(this, 'accounts-list', 'didRender');
+    $(`.nav-account-row .${INDICATOR_CLASS}`).remove();
+    $('.tk-nav-account-icons-right-space').removeClass('tk-nav-account-icons-right-space');
   }
 }

--- a/src/extension/utils/toolkit.js
+++ b/src/extension/utils/toolkit.js
@@ -124,13 +124,13 @@ export function addToolkitEmberHook(context, componentKey, lifecycleHook, fn) {
   ynabToolKit.hookedComponents.add(componentKey);
 }
 
-export function removeToolkitEmberHooks(context, componentKey, lifecycleHook) {
+export function removeToolkitEmberHook(componentKey, lifecycleHook, fn) {
   const componentProto = Object.getPrototypeOf(componentLookup(componentKey));
 
   let hooks = componentProto[emberComponentToolkitHookKey(lifecycleHook)];
   if (hooks) {
     componentProto[emberComponentToolkitHookKey(lifecycleHook)] = hooks.filter(
-      (hook) => hook.context !== context
+      (hook) => hook.fn !== fn
     );
   }
 }

--- a/src/extension/utils/toolkit.js
+++ b/src/extension/utils/toolkit.js
@@ -123,3 +123,14 @@ export function addToolkitEmberHook(context, componentKey, lifecycleHook, fn) {
 
   ynabToolKit.hookedComponents.add(componentKey);
 }
+
+export function removeToolkitEmberHooks(context, componentKey, lifecycleHook) {
+  const componentProto = Object.getPrototypeOf(componentLookup(componentKey));
+
+  let hooks = componentProto[emberComponentToolkitHookKey(lifecycleHook)];
+  if (hooks) {
+    componentProto[emberComponentToolkitHookKey(lifecycleHook)] = hooks.filter(
+      (hook) => hook.context !== context
+    );
+  }
+}


### PR DESCRIPTION
I've written destroy methods for all of the non-style-based features in the general category.
I've read through each feature and added code to revert each change to the DOM and remove hooks.
I've done some basic testing on each feature to ensure the methods work correctly.
I've added a removeToolkitEmberHooks method in utils/toolkit to mirror the addToolkitEmberHook method. If there's a better way of doing this or you're planning any other changes let me know and I'll modify the methods to fit.