### PR TITLE
fix: quick budget warning applies to edit target button

### DIFF
--- a/src/extension/features/budget/quick-budget-warning/index.js
+++ b/src/extension/features/budget/quick-budget-warning/index.js
@@ -10,8 +10,14 @@ export class QuickBudgetWarning extends Feature {
     // target only buttons so other elements with same class can be added without forcing
     // confirmation, which can break the quick budget functionality for quick budget
     // items added by the Toolkit
-    $('button.budget-inspector-button').off('click', this.confirmClick);
-    $('button.budget-inspector-button').on('click', this.confirmClick);
+    $('.budget-breakdown-auto-assign button.budget-inspector-button').off(
+      'click',
+      this.confirmClick
+    );
+    $('.budget-breakdown-auto-assign button.budget-inspector-button').on(
+      'click',
+      this.confirmClick
+    );
   }
 
   confirmClick(event) {


### PR DESCRIPTION
GitHub Issue (if applicable): N/A
Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
The quick budget warning feature was applying to the edit target button in the inspector. I've increased the specificity to only target buttons in the auto assign card.