### PR TITLE
Income from last month

### DIFF
--- a/src/extension/features/budget/income-from-last-month/index.css
+++ b/src/extension/features/budget/income-from-last-month/index.css
@@ -1,3 +1,7 @@
+.to-be-budgeted {
+  height: 100%;
+}
+
 #toolkit-income-from-last-month-container {
   display: block;
   width: 260px;

--- a/src/extension/features/budget/income-from-last-month/index.css
+++ b/src/extension/features/budget/income-from-last-month/index.css
@@ -1,10 +1,4 @@
-.budget-header-item.budget-header-totals {
-  padding-top: 4px;
-  padding-bottom: 4px;
-}
-
 #toolkit-income-from-last-month-container {
   display: block;
   width: 260px;
-  height: 100%;
 }

--- a/src/extension/features/budget/income-from-last-month/index.css
+++ b/src/extension/features/budget/income-from-last-month/index.css
@@ -2,3 +2,9 @@
   padding-top: 4px;
   padding-bottom: 4px;
 }
+
+#toolkit-income-from-last-month-container {
+  display: block;
+  width: 260px;
+  height: 100%;
+}

--- a/src/extension/features/budget/income-from-last-month/index.css
+++ b/src/extension/features/budget/income-from-last-month/index.css
@@ -2,7 +2,19 @@
   height: 100%;
 }
 
-#toolkit-income-from-last-month-container {
+.to-be-budgeted.ynab-breakdown {
   display: block;
   width: 260px;
+}
+
+.to-be-budgeted.ynab-breakdown > hr {
+  margin: 0.25rem 0 0.25rem 0;
+}
+
+.toolkit-income-from-last-month > .ynab-breakdown {
+  margin: 0;
+}
+
+.toolkit-income-from-last-month > .ynab-breakdown > div {
+  margin: 0;
 }

--- a/src/extension/features/budget/income-from-last-month/index.js
+++ b/src/extension/features/budget/income-from-last-month/index.js
@@ -63,7 +63,6 @@ export class IncomeFromLastMonth extends Feature {
           class: 'budget-header-item budget-header-totals toolkit-income-from-last-month user-data',
         }).append(
           $('<div>', {
-            id: 'toolkit-income-from-last-month-container',
             class: 'to-be-budgeted ember-view ynab-breakdown',
           }).append(
             $('<div>', {
@@ -82,27 +81,32 @@ export class IncomeFromLastMonth extends Feature {
     }
 
     // Create income line
+    const incomeType = incomeBudgetCalculation.immediateIncome > 0 ? 'positive' : 'negative';
     const incomeContents = `<div>${l10n(
       'toolkit.incomeIn',
       'Income in'
-    )} ${incomeMonthName}</div><div class="user-data"><span class="user-data currency positive">${formatCurrency(
+    )} ${incomeMonthName}</div><div class="user-data budget-breakdown-to-be-budgeted-${incomeType}"><span class="user-data currency ${incomeType}">${formatCurrency(
       incomeBudgetCalculation.immediateIncome
     )}</span></div>`;
 
     // Create assigned line
+    const assignedType = currentBudgetCalculation.budgeted <= 0 ? 'positive' : 'negative';
     const assignedContents = `<div>${l10n(
       'toolkit.assignedIn',
       'Assigned in'
-    )} ${currentMonthName}</div><div class="user-data"><span class="user-data currency positive">${formatCurrency(
+    )} ${currentMonthName}</div><div class="user-data budget-breakdown-to-be-budgeted-${assignedType}"><span class="user-data currency ${assignedType}">${formatCurrency(
       currentBudgetCalculation.budgeted
     )}</span></div>`;
 
     // Create variance line
+    const varianceAmount =
+      incomeBudgetCalculation.immediateIncome - currentBudgetCalculation.budgeted;
+    const varianceType = varianceAmount > 0 ? 'positive' : 'negative';
     const varianceContents = `<div>${l10n(
       'toolkit.varianceIn',
       'Variance'
-    )}</div><div class="user-data"><span class="user-data currency positive">${formatCurrency(
-      incomeBudgetCalculation.immediateIncome - currentBudgetCalculation.budgeted
+    )}</div><div class="user-data budget-breakdown-to-be-budgeted-${varianceType}"><span class="user-data currency ${varianceType}"> =${formatCurrency(
+      varianceAmount
     )}</span></div>`;
 
     // Insert income from last month lines

--- a/src/extension/features/budget/income-from-last-month/index.js
+++ b/src/extension/features/budget/income-from-last-month/index.js
@@ -71,6 +71,10 @@ export class IncomeFromLastMonth extends Feature {
             }),
             $('<div>', {
               class: 'toolkit-income-from-last-month-assigned',
+            }),
+            $('<hr>'),
+            $('<div>', {
+              class: 'toolkit-income-from-last-month-variance',
             })
           )
         )
@@ -93,9 +97,18 @@ export class IncomeFromLastMonth extends Feature {
       currentBudgetCalculation.budgeted
     )}</span></div>`;
 
+    // Create variance line
+    const varianceContents = `<div>${l10n(
+      'toolkit.varianceIn',
+      'Variance'
+    )}</div><div class="user-data"><span class="user-data currency positive">${formatCurrency(
+      incomeBudgetCalculation.immediateIncome - currentBudgetCalculation.budgeted
+    )}</span></div>`;
+
     // Insert income from last month lines
     $('.toolkit-income-from-last-month-income').html(incomeContents);
     $('.toolkit-income-from-last-month-assigned').html(assignedContents);
+    $('.toolkit-income-from-last-month-variance').html(varianceContents);
   }
 
   // Listen for events that require an update

--- a/src/extension/features/budget/income-from-last-month/index.js
+++ b/src/extension/features/budget/income-from-last-month/index.js
@@ -19,22 +19,28 @@ export class IncomeFromLastMonth extends Feature {
   invoke() {
     // Do nothing if no header found.
     if ($('.budget-header-totals').length === 0) return;
-    // Get current month and adjust per settings for which month to use for 'last month'
-    const currentBudgetDate = getCurrentBudgetDate();
-    const currentYear = parseInt(currentBudgetDate['year']);
-    const currentMonth = parseInt(currentBudgetDate['month']);
 
+    // Get current month and year
+    const currentBudgetDate = getCurrentBudgetDate();
+    const currentYear = parseInt(currentBudgetDate.year);
+    const currentMonth = parseInt(currentBudgetDate.month);
+
+    // Calculate income month and year based on settings
+    // Adjust year/month when it rolls over
     const incomeYear = currentMonth - this.settings.enabled > 0 ? currentYear : currentYear - 1;
     const incomeMonth =
       currentMonth - this.settings.enabled > 0
         ? currentMonth - this.settings.enabled
         : currentMonth - this.settings.enabled + 12;
 
+    // Get short name for current and income months
     const currentMonthName = l10nMonth(currentMonth - 1, MonthStyle.Short);
     const incomeMonthName = l10nMonth(incomeMonth - 1, MonthStyle.Short);
 
+    // Get all budget calculations from YNAB
     const allBudgetCalculations = getEntityManager().getAllMonthlyBudgetCalculations();
 
+    // Find current month budget calculations
     const currentBudgetCalculation = allBudgetCalculations.filter((budgetItem) => {
       const budgetItemDate = budgetItem.monthlyBudgetId.split('/')[1].split('-');
       return (
@@ -42,6 +48,7 @@ export class IncomeFromLastMonth extends Feature {
       );
     })[0];
 
+    // Find income month budget calculations
     const incomeBudgetCalculation = allBudgetCalculations.filter((budgetItem) => {
       const budgetItemDate = budgetItem.monthlyBudgetId.split('/')[1].split('-');
       return (
@@ -86,6 +93,7 @@ export class IncomeFromLastMonth extends Feature {
       currentBudgetCalculation.budgeted
     )}</span></div>`;
 
+    // Insert income from last month lines
     $('.toolkit-income-from-last-month-income').html(incomeContents);
     $('.toolkit-income-from-last-month-assigned').html(assignedContents);
   }


### PR DESCRIPTION
GitHub Issue (if applicable): #2490 

Trello Link (if applicable): N/A

## Explanation of Bugfix/Feature/Modification

Update the `Income from Last Month` feature with a new card. The current feature is broken because it's parent node no longer exists with the recent changes from `To Be Budgeted` to `Ready to Assign`. The information is available in the `Ready to Assign` breakdown, but it requires an extra click every time you want to look at it.


## Prototypes
I have set up two options for this:

[99bf90c](https://github.com/toolkit-for-ynab/toolkit-for-ynab/commit/99bf90c6c29df3ac0760e5b6698c85bd9cc44c55) adds a simple card with just the previous month (setting dependent) and the current month assigned.

![Card without variance](https://i.imgur.com/xrBwFys.png)

[0d0f5c7](https://github.com/toolkit-for-ynab/toolkit-for-ynab/commit/0d0f5c7f2f86df7fa1fc41003c8dcf9778735be8) adds the same card as above, but includes a variance line to show over/under allocation. I will add colors to the card or variance line if this is the preferred option.

![Card with variance](https://i.imgur.com/7s7nD3a.png)

## Technical Implementation

The feature used to use the `getAllTransactions()` function, then reduce to sum only income items. I have updated the feature to use only the `getAllMonthlyBudgetCalculations()` function, which contains the pre-calculated income and assigned values provided by YNAB. I am not super familiar with the API yet, but from my testing it seems to hold up well even with rapidly changing budget data and massive transaction history. Overall it was a good performance increase in my personal budget.

## Feedback Request

I am very open to comments and feedback on the design and implementation! My partner has been very frustrated with how hard it is to find this information in the UI and I think there are many out there would be interested in having a clean zero-click option for maintaining the "live on last month's income" method of YNAB4.

Thoughts on UI updates before merging:
- Make the text smaller or reduce padding
- Keep/remove the variance line
- Mark the text or card red when it's not balanced