### PR TITLE
SwapClearedFlagged: force correct width on .ynab-grid-cell-cleared

### DIFF
--- a/src/extension/features/accounts/swap-cleared-flagged/index.css
+++ b/src/extension/features/accounts/swap-cleared-flagged/index.css
@@ -1,0 +1,3 @@
+.ynab-grid-cell-cleared {
+  width: 1.625rem;
+}

--- a/src/extension/features/accounts/swap-cleared-flagged/index.js
+++ b/src/extension/features/accounts/swap-cleared-flagged/index.js
@@ -6,6 +6,10 @@ export class SwapClearedFlagged extends Feature {
     return true;
   }
 
+  injectCSS() {
+    return require('./index.css');
+  }
+
   invoke() {
     const rows = [
       'register/grid-header',


### PR DESCRIPTION
Fixes #2253.

As far as I can tell, the SwapClearedFlagged feature isn't *really* the cause of the columns being out of alignment. Rather, something within toolkit is causing the width on the checkbox, flagged, and cleared columns to be increased. Or more specifically, something is causing YNAB itself to change the width as if the user dragged to expand them, even though you can't normally change the width of those columns that way. If you clear the cookies on YNAB (which wipes out any column width adjustments), everything looks as it should.

Whenever the width on those columns gets messed up, and SwapClearedFlagged runs, everything gets out of alignment because YNAB's CSS has an extra `.ynab-grid-cell-cleared` selector for some reason:

```
.ynab-grid-cell-cleared {
    width: 2.25rem;
}
```

The width on the other columns is set by:

```
.ynab-grid-cell-checkbox, .ynab-grid-cell-cleared, .ynab-grid-cell-flag, .ynab-grid-cell-notification {
    /* other stuff */
    width: 1.625rem;
}
```

That extra selector normally isn't an issue because the cleared column is all the way to the right, so nothing is affected. When cleared and flagged get swapped, the cleared column header is wider than the other cleared cells.

![image](https://user-images.githubusercontent.com/1844269/129695418-b1f228d7-99f6-4e1a-a1a7-909777bd0edf.png)

This PR simply injects CSS when SwapClearedFlagged is enabled to set the width on `.ynab-grid-cell-cleared` back to `1.625rem`. This fixes the alignment issue.

Also, the only way I've found to reproduce the issue is to toggle the memo column off. That causes the mentioned columns to widen. However, if you toggle the memo column back on, it goes back to normal. I was able to get the changes to stick one time after I toggled memos back on, but I'm not sure what I did different that time. I also have run into this issue before and I had never toggled memos on/off before, so I'm really not sure what could be causing that.