### PR TITLE
invoke feature hooks on individual enable

### DIFF
--- a/src/extension/utils/ember.js
+++ b/src/extension/utils/ember.js
@@ -23,12 +23,13 @@ export function serviceLookup(serviceName) {
   return containerLookup(`service:${serviceName}`);
 }
 
-export function forEachRenderedComponent(key, fn) {
-  return Object.values(getViewRegistry()).forEach((view) => {
-    if (view._debugContainerKey === `component:${key}`) {
-      fn(view);
-    }
+export function getRenderedEmberViews(componentKey) {
+  const renderedEmberViews = [];
+  Object.values(getViewRegistry()).forEach((view) => {
+    if (view._debugContainerKey === `component:${componentKey}`) renderedEmberViews.push(view);
   });
+
+  return renderedEmberViews;
 }
 
 /* Private Functions */

--- a/src/extension/utils/toolkit.js
+++ b/src/extension/utils/toolkit.js
@@ -121,7 +121,18 @@ export function addToolkitEmberHook(context, componentKey, lifecycleHook, fn) {
     hooks.push({ context, fn });
   }
 
-  ynabToolKit.hookedComponents.add(componentKey);
+  if (!ynabToolKit.featureComponentHooks[context.featureName])
+    ynabToolKit.featureComponentHooks[context.featureName] = {};
+
+  if (!ynabToolKit.featureComponentHooks[context.featureName][componentKey])
+    ynabToolKit.featureComponentHooks[context.featureName][componentKey] = new Set();
+
+  ynabToolKit.featureComponentHooks[context.featureName][componentKey].add(lifecycleHook);
+
+  if (!ynabToolKit.hookedComponents[componentKey])
+    ynabToolKit.hookedComponents[componentKey] = new Set();
+
+  ynabToolKit.hookedComponents[componentKey].add(lifecycleHook);
 }
 
 export function removeToolkitEmberHook(componentKey, lifecycleHook, fn) {

--- a/src/extension/ynab-toolkit.tsx
+++ b/src/extension/ynab-toolkit.tsx
@@ -222,14 +222,7 @@ export class YNABToolkit {
     for (const [componentKey, lifecycleNameSet] of Object.entries(
       window.ynabToolKit.featureComponentHooks[featureName]
     )) {
-      for (const view of getRenderedEmberViews(componentKey) as ToolkitEnabledComponent[]) {
-        lifecycleNameSet.forEach((lifecycleName) => {
-          const hooks = view[emberComponentToolkitHookKey(lifecycleName)];
-          if (hooks) {
-            hooks.forEach((hook) => hook.fn.call(hook.context, view.element));
-          }
-        });
-      }
+      this.invokeHooks(componentKey, lifecycleNameSet);
     }
   };
 
@@ -237,14 +230,18 @@ export class YNABToolkit {
     for (const [componentKey, lifecycleNameSet] of Object.entries(
       window.ynabToolKit.hookedComponents
     )) {
-      for (const view of getRenderedEmberViews(componentKey) as ToolkitEnabledComponent[]) {
-        lifecycleNameSet.forEach((lifecycleName) => {
-          const hooks = view[emberComponentToolkitHookKey(lifecycleName)];
-          if (hooks) {
-            hooks.forEach((hook) => hook.fn.call(hook.context, view.element));
-          }
-        });
-      }
+      this.invokeHooks(componentKey, lifecycleNameSet);
+    }
+  };
+
+  private invokeHooks = (componentKey: string, lifecycleNameSet: Set<SupportedEmberHook>) => {
+    for (const view of getRenderedEmberViews(componentKey) as ToolkitEnabledComponent[]) {
+      lifecycleNameSet.forEach((lifecycleName) => {
+        const hooks = view[emberComponentToolkitHookKey(lifecycleName)];
+        if (hooks) {
+          hooks.forEach((hook) => hook.fn.call(hook.context, view.element));
+        }
+      });
     }
   };
 

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,8 +1,7 @@
-import Object from '@ember/object';
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { settingsMap } from 'toolkit/core/settings';
-import { Feature } from 'toolkit/extension/features/feature';
+import { SupportedEmberHook } from 'toolkit/extension/ynab-toolkit';
 
 export interface YNABToolkitObject {
   assets: {
@@ -10,7 +9,14 @@ export interface YNABToolkitObject {
   };
   environment: 'development' | 'beta' | 'production';
   extensionId: string;
-  hookedComponents: Set<Feature>;
+  featureComponentHooks: {
+    [featureName: string]: {
+      [componentKey: string]: Set<SupportedEmberHook>;
+    };
+  };
+  hookedComponents: {
+    [componentKey: string]: Set<SupportedEmberHook>;
+  };
   invokeFeature(featureName: FeatureName): void;
   options: {
     [settingName in FeatureName]: FeatureSetting;


### PR DESCRIPTION
Primarily, I added a function in `ynab-toolkit.tsx` that allows you to invoke all the hooks on a specific feature (currently there's only a function for invoking all hooks on all features). This is needed with the new live settings because some features don't load/render on enable. Their ember view hook is never invoked.

Using the new function, we simply invoke the feature's hooks after invoking the feature itself:
```
if (isFeatureEnabled(value)) {
  // ...
  this.invokeFeature(name);
  this.invokeFeatureHook(name);
}
```

This function uses a new object on the `ynabToolKit` global called `featureComponentHooks`. Each key is a feature name and its value is an object that contains each componentKey which has a set of lifecycleNames.

![image](https://user-images.githubusercontent.com/1844269/130232182-87ef8a5e-f3a7-4bdf-b169-bed1fa1f941b.png)

Additionally, I rewrote `forEachRenderedComponent()` as `getRenderedEmberViews()` to make it more generally usable. Now you can get all rendered ember views for a specific component.