### PR TITLE
add new ready to assign button to customize-colour-scheme rules

### DIFF
--- a/src/extension/features/general/customize-colour-scheme/index.css
+++ b/src/extension/features/general/customize-colour-scheme/index.css
@@ -16,6 +16,10 @@ body.tk-custom-colours-enabled {
     themer.html in this folder is a tool that can be used to convert CSS rules from
     the YNAB stylesheet automatically into accent variables
 
+    To build the themes copy the base colours below into the themer along with YNAB
+    CSS rules - then standardise the LC colours across the positive/negative/warning
+    rules - some manual tweaking will be required
+
     If a new accent variable is referenced it needs to be added to the
     TK_CUSTOMIZE_COLOUR_ACCENTS at the top of index.js to be defined and updated
 

--- a/src/extension/features/general/customize-colour-scheme/index.css
+++ b/src/extension/features/general/customize-colour-scheme/index.css
@@ -5,21 +5,6 @@ body {
   --tk-custom-colours-warning: #797dec;
 }
 
-body.tk-custom-colours-enabled {
-  /* Inspector messages - recently replaced with general messages but still in YNAB stylesheet */
-  --inspector_message_negative_background: var(--message_negative_background) !important;
-  --inspector_message_negative_border: var(--message_negative_accent) !important;
-  --inspector_message_negative_label: var(--message_negative_label) !important;
-
-  --inspector_message_positive_background: var(--message_positive_background) !important;
-  --inspector_message_positive_border: var(--message_positive_accent) !important;
-  --inspector_message_positive_label: var(--message_positive_label) !important;
-
-  --inspector_message_warning_background: var(--message_warning_background) !important;
-  --inspector_message_warning_border: var(--message_warning_accent) !important;
-  --inspector_message_warning_label: var(--message_warning_label) !important;
-}
-
 /* Default theme */
 body.tk-custom-colours-enabled {
   /*
@@ -33,9 +18,16 @@ body.tk-custom-colours-enabled {
 
     If a new accent variable is referenced it needs to be added to the
     TK_CUSTOMIZE_COLOUR_ACCENTS at the top of index.js to be defined and updated
+
+    Base colours:
+    Positive: #6d9f38
+    Warning: #e0a41a
+    Negative: #ca481d
   */
 
   /* Negative */
+  --banner_negative_button_background: var(--tk-custom-colours-negative) !important;
+  --banner_negative_button_background_active: var(--tk-custom-colours-negative-l045c055) !important;
   --budget_balance_negative_background: var(--tk-custom-colours-negative-l150c060) !important;
   --budget_balance_negative_background_active: var(
     --tk-custom-colours-negative-l140c075
@@ -55,6 +47,8 @@ body.tk-custom-colours-enabled {
   --status_negative: var(--tk-custom-colours-negative) !important;
 
   /* Positive */
+  --banner_positive_button_background: var(--tk-custom-colours-positive) !important;
+  --banner_positive_button_background_active: var(--tk-custom-colours-positive-l045c055) !important;
   --budget_balance_positive_background: var(--tk-custom-colours-positive-l150c060) !important;
   --budget_balance_positive_background_active: var(
     --tk-custom-colours-positive-l140c075
@@ -74,6 +68,8 @@ body.tk-custom-colours-enabled {
   --status_positive: var(--tk-custom-colours-positive) !important;
 
   /* Warning */
+  --banner_warning_button_background: var(--tk-custom-colours-warning) !important;
+  --banner_warning_button_background_active: var(--tk-custom-colours-warning-l045c055) !important;
   --budget_balance_warning_background: var(--tk-custom-colours-warning-l150c060) !important;
   --budget_balance_warning_background_active: var(--tk-custom-colours-warning-l140c075) !important;
   --budget_balance_warning_icon: var(--tk-custom-colours-warning-l030c045) !important;
@@ -91,6 +87,9 @@ body.tk-custom-colours-enabled {
 /* Dark theme */
 body.tk-custom-colours-enabled.theme-dark {
   /* Negative */
+  --banner_negative_button_background: var(--tk-custom-colours-negative-l140c075) !important;
+  --banner_negative_button_background_active: var(--tk-custom-colours-negative-l120c100) !important;
+  --banner_negative_button_label: var(--tk-custom-colours-negative-l025c020) !important;
   --budget_balance_negative_background: var(--tk-custom-colours-negative) !important;
   --budget_balance_negative_background_active: var(
     --tk-custom-colours-negative-l110c100
@@ -110,6 +109,9 @@ body.tk-custom-colours-enabled.theme-dark {
   --status_negative: var(--tk-custom-colours-negative-l055c090);
 
   /* Positive */
+  --banner_positive_button_background: var(--tk-custom-colours-positive-l140c075) !important;
+  --banner_positive_button_background_active: var(--tk-custom-colours-positive-l120c100) !important;
+  --banner_positive_button_label: var(--tk-custom-colours-positive-l025c020) !important;
   --budget_balance_positive_background: var(--tk-custom-colours-positive) !important;
   --budget_balance_positive_background_active: var(
     --tk-custom-colours-positive-l110c100
@@ -129,6 +131,9 @@ body.tk-custom-colours-enabled.theme-dark {
   --status_positive: var(--tk-custom-colours-positive) !important;
 
   /* Warning */
+  --banner_warning_button_background: var(--tk-custom-colours-warning-l140c075) !important;
+  --banner_warning_button_background_active: var(--tk-custom-colours-warning-l120c100) !important;
+  --banner_warning_button_label: var(--tk-custom-colours-warning-l025c020) !important;
   --budget_balance_warning_background: var(--tk-custom-colours-warning) !important;
   --budget_balance_warning_background_active: var(--tk-custom-colours-warning-l110c100) !important;
   --budget_balance_warning_icon: #232325 !important;
@@ -146,6 +151,9 @@ body.tk-custom-colours-enabled.theme-dark {
 /* Classic theme */
 body.tk-custom-colours-enabled.theme-classic {
   /* Negative */
+  --banner_negative_button_background: #fff !important;
+  --banner_negative_button_background_active: var(--tk-custom-colours-negative-l160c015) !important;
+  --banner_negative_button_label: var(--tk-custom-colours-negative) !important;
   --budget_balance_negative_background: var(--tk-custom-colours-negative) !important;
   --budget_balance_negative_background_active: var(
     --tk-custom-colours-negative-l090c090
@@ -165,6 +173,9 @@ body.tk-custom-colours-enabled.theme-classic {
   --status_negative: var(--tk-custom-colours-negative) !important;
 
   /* Positive */
+  --banner_positive_button_background: #fff !important;
+  --banner_positive_button_background_active: var(--tk-custom-colours-positive-l160c015) !important;
+  --banner_positive_button_label: var(--tk-custom-colours-positive) !important;
   --budget_balance_positive_background: var(--tk-custom-colours-positive) !important;
   --budget_balance_positive_background_active: var(
     --tk-custom-colours-positive-l090c090
@@ -184,6 +195,9 @@ body.tk-custom-colours-enabled.theme-classic {
   --status_positive: var(--tk-custom-colours-positive) !important;
 
   /* Warning */
+  --banner_warning_button_background: #fff !important;
+  --banner_warning_button_background_active: var(--tk-custom-colours-warning-l160c015) !important;
+  --banner_warning_button_label: var(--tk-custom-colours-warning) !important;
   --budget_balance_warning_background: var(--tk-custom-colours-warning) !important;
   --budget_balance_warning_background_active: var(--tk-custom-colours-warning-l090c090) !important;
   --budget_balance_warning_icon: #fff !important;

--- a/src/extension/features/general/customize-colour-scheme/index.js
+++ b/src/extension/features/general/customize-colour-scheme/index.js
@@ -11,6 +11,7 @@ const TK_CUSTOMIZE_COLOUR_ACCENTS = [
   'l100c100',
   'l110c100',
   'l120c050',
+  'l120c100',
   'l125c065',
   'l140c060',
   'l140c075',

--- a/src/extension/features/general/customize-colour-scheme/themer.html
+++ b/src/extension/features/general/customize-colour-scheme/themer.html
@@ -1,6 +1,9 @@
 <html>
   <head>
     <style type="text/css">
+      input {
+        width: 15em;
+      }
       textarea {
         width: 50%;
         height: 30%;
@@ -184,9 +187,11 @@ SOFTWARE.
     ><input type="text" id="base" value="#ca481d" autocomplete="off" /><br />
     <label for="granularity">Round to nearest: </label
     ><input type="number" min="0" max="100" step="1" id="granularity" value="5" /><br />
-    <label for="prefix">Prefix: </label
+    <label for="prefix">Variable prefix: </label
     ><input type="text" id="prefix" value="tk-custom-colours-negative-" /><br />
-    <textarea id="rulesIn" autocomplete="off">
+    <p>
+      <label for="rulesIn">Rules in: </label><br />
+      <textarea id="rulesIn" autocomplete="off">
             --budget_balance_negative_icon: #4a190d;
             --budget_balance_negative_text: #4a190d;
             --message_negative_label: #4a190d;
@@ -202,9 +207,16 @@ SOFTWARE.
             --budget_bar_overspending_stripe: #f49e8b;
             --message_negative_background: #fcece8;
         </textarea
-    ><br />
+      >
+    </p>
     <button onclick="convert();">Convert</button><br />
-    <textarea id="rulesOut" autocomplete="off"> </textarea>
-    <textarea id="accentsOut" autocomplete="off"> </textarea>
+    <p>
+      <label for="rulesOut">Rules out:</label><br />
+      <textarea id="rulesOut" autocomplete="off"> </textarea>
+    </p>
+    <p>
+      <label for="accentsOut">Accents out:</label><br />
+      <textarea id="accentsOut" autocomplete="off"> </textarea>
+    </p>
   </body>
 </html>


### PR DESCRIPTION
GitHub Issue (if applicable): N/A
Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
The new Ready to Assign button uses new colour variables. I've added rules to customize-colour-scheme to support them.
I've also expanded the instructions on updating the colour rules.
