### PR TITLE
feature: resizable budget columns

### DIFF
--- a/src/extension/features/budget/display-target-goal-amount/index.js
+++ b/src/extension/features/budget/display-target-goal-amount/index.js
@@ -29,6 +29,8 @@ export class DisplayTargetGoalAmount extends Feature {
 
   invoke() {
     this.addToolkitEmberHook('budget-table-row', 'didRender', this.addTargetGoalAmount);
+    // Add goal column to hidden categories row to allow for accurate column resizing
+    this.addToolkitEmberHook('budget/hidden-row', 'didRender', ensureGoalColumn);
   }
 
   destroy() {

--- a/src/extension/features/budget/goal-indicator/index.js
+++ b/src/extension/features/budget/goal-indicator/index.js
@@ -20,6 +20,8 @@ export class GoalIndicator extends Feature {
 
   invoke() {
     this.addToolkitEmberHook('budget-table-row', 'didRender', this.addGoalIndicator);
+    // Add goal column to hidden categories row to allow for accurate column resizing
+    this.addToolkitEmberHook('budget/hidden-row', 'didRender', ensureGoalColumn);
   }
 
   addGoalIndicator(element) {

--- a/src/extension/features/budget/resizable-columns/index.css
+++ b/src/extension/features/budget/resizable-columns/index.css
@@ -1,11 +1,36 @@
-.budget-table-header-labels li {
-  cursor: pointer;
-  user-select: none;
+.tk-resizable-column {
+  position: relative;
 }
 
-.budget-table-header-labels li.budget-table-cell-checkbox,
-.budget-table-header-labels li.budget-table-cell-collapse,
-.budget-table-header-labels li.budget-table-cell-margin,
-.budget-table-header-labels li.budget-table-cell-name {
-  cursor: auto;
+.tk-resizable-column:hover {
+  padding-right: 1.35rem !important;
+}
+
+.tk-resizable-column-plus,
+.tk-resizable-column-minus {
+  position: absolute;
+  right: 0;
+  height: 46%;
+  aspect-ratio: 1 / 1;
+  border: 1px solid var(--sidebar_button_background_active);
+  border-radius: 30%;
+  opacity: 0;
+}
+
+.tk-resizable-column-plus {
+  top: 3%;
+}
+.tk-resizable-column-minus {
+  bottom: 3%;
+}
+
+.tk-resizable-column:hover .tk-resizable-column-plus,
+.tk-resizable-column:hover .tk-resizable-column-minus {
+  opacity: 1;
+}
+
+.tk-resizable-column-plus:hover,
+.tk-resizable-column-minus:hover {
+  color: var(--sidebar_label_primary);
+  background-color: var(--sidebar_button_background_active);
 }

--- a/src/extension/features/budget/resizable-columns/index.css
+++ b/src/extension/features/budget/resizable-columns/index.css
@@ -1,0 +1,14 @@
+.budget-table-header-labels li {
+  border-left: 1px solid var(--divider_standard);
+  cursor: pointer;
+  flex-basis: content;
+  user-select: none;
+}
+
+.budget-table-header-labels li.budget-table-cell-checkbox,
+.budget-table-header-labels li.budget-table-cell-collapse,
+.budget-table-header-labels li.budget-table-cell-margin,
+.budget-table-header-labels li.budget-table-cell-name {
+  border-left: 0;
+  cursor: auto;
+}

--- a/src/extension/features/budget/resizable-columns/index.css
+++ b/src/extension/features/budget/resizable-columns/index.css
@@ -24,13 +24,18 @@
   bottom: 3%;
 }
 
-.tk-resizable-column:hover .tk-resizable-column-plus,
-.tk-resizable-column:hover .tk-resizable-column-minus {
+.tk-resizable-column:hover .tk-resizable-column-plus:disabled,
+.tk-resizable-column:hover .tk-resizable-column-minus:disabled {
+  opacity: 0.5;
+}
+
+.tk-resizable-column:hover .tk-resizable-column-plus:enabled,
+.tk-resizable-column:hover .tk-resizable-column-minus:enabled {
   opacity: 1;
 }
 
-.tk-resizable-column-plus:hover,
-.tk-resizable-column-minus:hover {
+.tk-resizable-column-plus:enabled:hover,
+.tk-resizable-column-minus:enabled:hover {
   color: var(--sidebar_label_primary);
   background-color: var(--sidebar_button_background_active);
 }

--- a/src/extension/features/budget/resizable-columns/index.css
+++ b/src/extension/features/budget/resizable-columns/index.css
@@ -1,7 +1,5 @@
 .budget-table-header-labels li {
-  border-left: 1px solid var(--divider_standard);
   cursor: pointer;
-  flex-basis: content;
   user-select: none;
 }
 
@@ -9,6 +7,5 @@
 .budget-table-header-labels li.budget-table-cell-collapse,
 .budget-table-header-labels li.budget-table-cell-margin,
 .budget-table-header-labels li.budget-table-cell-name {
-  border-left: 0;
   cursor: auto;
 }

--- a/src/extension/features/budget/resizable-columns/index.js
+++ b/src/extension/features/budget/resizable-columns/index.js
@@ -1,0 +1,100 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
+
+const IGNORE_COLUMNS = [
+  'budget-table-cell-checkbox',
+  'budget-table-cell-collapse',
+  'budget-table-cell-margin',
+  'budget-table-cell-name',
+];
+
+const GROW_STEP = 0.1;
+
+export class ResizableColumns extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteBudgetPage();
+  }
+
+  injectCSS() {
+    return require('./index.css');
+  }
+
+  getFlexSize(column) {
+    let colClass;
+    column.classList.forEach((className) => {
+      if (className !== 'tk-resizable-column') colClass = className;
+    });
+    if (!colClass) return;
+
+    const allCols = $(`.${colClass}`);
+
+    let grow = parseFloat($(column).css('flex-grow'));
+    if (!grow) grow = 0;
+
+    return {
+      class: colClass,
+      elements: allCols,
+      grow: grow,
+    };
+  }
+
+  loadColumnSize(className) {
+    return getToolkitStorageKey(`resizable-columns-${className}`, 0);
+  }
+
+  saveColumnSize(className, grow) {
+    setToolkitStorageKey(`resizable-columns-${className}`, grow);
+  }
+
+  expandColumn(e, column) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const size = this.getFlexSize(column);
+    if (!size) return;
+
+    size.elements.css('flex-grow', size.grow + GROW_STEP);
+
+    this.saveColumnSize(size.class, size.grow + GROW_STEP);
+  }
+
+  shrinkColumn(e, column) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const size = this.getFlexSize(column);
+    if (!size) return;
+
+    size.elements.css('flex-grow', size.grow - GROW_STEP);
+
+    this.saveColumnSize(size.class, size.grow - GROW_STEP);
+  }
+
+  invoke() {
+    let columns = $('.budget-table-header-labels li');
+    IGNORE_COLUMNS.forEach((ignoreClass) => {
+      columns = columns.filter(`:not(.${ignoreClass})`);
+    });
+
+    columns.each((index, colEl) => {
+      const col = $(colEl);
+      if (!col.hasClass('tk-resizable-column')) {
+        col.on('click', (e) => this.expandColumn(e, e.target));
+        col.on('contextmenu', (e) => this.shrinkColumn(e, e.target));
+
+        // If the header text is encased in an element, add handlers for that too
+        col.children().each((id, el) => {
+          const child = $(el);
+          child.on('click', (e) => this.expandColumn(e, e.target.parentElement));
+          child.on('contextmenu', (e) => this.shrinkColumn(e, e.target.parentElement));
+        });
+
+        const grow = this.loadColumnSize(colEl.className);
+        col.css('flex-grow', grow);
+
+        col.addClass('tk-resizable-column');
+      }
+    });
+  }
+}

--- a/src/extension/features/budget/resizable-columns/index.js
+++ b/src/extension/features/budget/resizable-columns/index.js
@@ -53,6 +53,8 @@ export class ResizableColumns extends Feature {
   setColumnSize(columnClass, size) {
     const cells = $(`.${columnClass}`);
     cells.css('flex-grow', size);
+
+    $('.tk-resizable-column-minus', cells).prop('disabled', size <= 0);
   }
 
   preventContextMenu(e) {
@@ -108,6 +110,10 @@ export class ResizableColumns extends Feature {
 
         col.append(plus, minus);
         col.addClass(HEADER_CLASS);
+
+        const columnClass = this.getColumnClass(col);
+        const size = this.loadColumnSize(columnClass);
+        this.setColumnSize(columnClass, size);
       }
     });
   }

--- a/src/extension/features/budget/resizable-columns/settings.js
+++ b/src/extension/features/budget/resizable-columns/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'ResizableColumns',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Resizable Columns',
+  description: `Allows clicking/right-clicking the budget headers to grow/shrink the width of the columns.`,
+};

--- a/src/extension/features/budget/resizable-columns/settings.js
+++ b/src/extension/features/budget/resizable-columns/settings.js
@@ -4,5 +4,5 @@ module.exports = {
   default: false,
   section: 'budget',
   title: 'Resizable Columns',
-  description: `Allows clicking/right-clicking the budget table headers to grow/shrink the width of the number columns. Middle-click to reset.`,
+  description: `Adds buttons in budget table headers to grow/shrink the width of the number columns. Right-click to reset.`,
 };

--- a/src/extension/features/budget/resizable-columns/settings.js
+++ b/src/extension/features/budget/resizable-columns/settings.js
@@ -4,5 +4,5 @@ module.exports = {
   default: false,
   section: 'budget',
   title: 'Resizable Columns',
-  description: `Allows clicking/right-clicking the budget table headers to grow/shrink the width of the number columns.`,
+  description: `Allows clicking/right-clicking the budget table headers to grow/shrink the width of the number columns. Middle-click to reset.`,
 };

--- a/src/extension/features/budget/resizable-columns/settings.js
+++ b/src/extension/features/budget/resizable-columns/settings.js
@@ -4,5 +4,5 @@ module.exports = {
   default: false,
   section: 'budget',
   title: 'Resizable Columns',
-  description: `Allows clicking/right-clicking the budget headers to grow/shrink the width of the columns.`,
+  description: `Allows clicking/right-clicking the budget table headers to grow/shrink the width of the number columns.`,
 };


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
At small screen resolutions the number columns in the budget can be crushed. This feature allows clicking on the column headers to force the columns wider at the expense of category name width. It will remember the width set between visits.

![resizable-columns](https://user-images.githubusercontent.com/83871143/130369890-3761aa6e-e5b9-4302-b298-bdea5f65e2eb.png)
![resizable-columns-2](https://user-images.githubusercontent.com/83871143/130369892-7573f95a-00cf-47ab-9b12-f95530d5c584.png)

