### PR TITLE
fix: edit-account-button feature

### DIFF
--- a/src/extension/features/general/edit-account-button/hide.css
+++ b/src/extension/features/general/edit-account-button/hide.css
@@ -1,4 +1,4 @@
-svg.ember-view.svg-icon.edit {
+.nav-accounts svg.ember-view.edit {
   visibility: hidden;
 }
 

--- a/src/extension/features/general/edit-account-button/index.js
+++ b/src/extension/features/general/edit-account-button/index.js
@@ -1,13 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 
-const Settings = {
-  Hidden: '2',
-};
-
 export class EditAccountButton extends Feature {
   injectCSS() {
-    if (this.settings.enabled === Settings.Hidden) {
-      return require('./hide.css');
-    }
+    return require('./hide.css');
   }
 }


### PR DESCRIPTION
The "Hide Edit Account Button" feature is currently not functioning. I removed some code relating to what I assume was an old way of handling feature settings, and I fixed the CSS selectors (.svg-icon no longer exists on the edit button svg).
