### PR TITLE
fix: make sure observer is on filters for ToggleTransactionFilters

### DIFF
--- a/src/extension/features/accounts/toggle-transaction-filters/index.js
+++ b/src/extension/features/accounts/toggle-transaction-filters/index.js
@@ -9,7 +9,7 @@ const ToggleButton = ({ stateField }) => {
   const [isShown, setIsShown] = React.useState(accountsController.get(`filters.${stateField}`));
 
   React.useEffect(() => {
-    accountsController.get('filters').addObserver(stateField, () => {
+    accountsController.addObserver(`filters.${stateField}`, () => {
       setIsShown(accountsController.get(`filters.${stateField}`));
     });
   }, []);


### PR DESCRIPTION
ToggleTransactionFilters has an issue where the correct style isn't being applied to the buttons when toggled. This is because the observer on `filters` gets removed on route change. We can just check if `filters` has the observer on button click and add it back if it doesn't.