### PR TITLE
fix: css selector for LargerClickableIcons

### DIFF
--- a/src/extension/features/accounts/larger-cleared-icons/index.css
+++ b/src/extension/features/accounts/larger-cleared-icons/index.css
@@ -1,4 +1,4 @@
-.ynab-grid-body-row .ynab-grid-cell-cleared .flaticon {
+.ynab-grid-body-row .ynab-grid-cell-cleared .svg-icon {
   width: 100%;
   height: 22px;
 }


### PR DESCRIPTION
`.flaticon` no longer exists on the relevant elements. We can select `.svg-icon` instead.