### PR TITLE
fix: split-transaction-tab-expand activated with shift+tab

### DIFF
--- a/src/extension/features/accounts/split-transaction-tab-expand/index.js
+++ b/src/extension/features/accounts/split-transaction-tab-expand/index.js
@@ -1,33 +1,29 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class SplitTransactionTabExpand extends Feature {
-  shouldInvoke() {
-    return isCurrentRouteAccountsPage() && !!$('.ynab-grid-split-add-sub-transaction').length;
+  invoke() {
+    this.addToolkitEmberHook('register/grid-split', 'didRender', this.addEventListeners);
   }
 
-  invoke() {}
+  addEventListeners() {
+    const previousInputs = $('input[data-toolkit-tab-expand]');
+    previousInputs.removeAttr('data-toolkit-tab-expand');
+    previousInputs.off('keydown', this.applyNewTabBehavior);
+
+    const lastInput = $('.ynab-grid-body-row.is-editing input').last();
+    lastInput.attr('data-toolkit-tab-expand', true);
+    lastInput.on('keydown', this.applyNewTabBehavior);
+  }
 
   applyNewTabBehavior(event) {
     // If tab was pressed, simulate a mouse click on the "Add another split" button
-    if (event.keyCode === 9) {
+    if (event.keyCode === 9 && !event.shiftKey) {
       let addSplitButton = $('.ynab-grid-split-add-sub-transaction');
       if (addSplitButton.length !== 0) {
         // The YNAB app checks the detail property isn't 0, so .click() won't work
         const clickEvent = new jQuery.Event('click', { detail: 1 });
         addSplitButton.trigger(clickEvent);
       }
-    }
-  }
-
-  observe() {
-    if (!this.shouldInvoke()) return;
-
-    const lastInput = $('.ynab-grid-body-row.is-editing input').last();
-
-    if (!lastInput.attr('data-toolkit-tab-expand')) {
-      lastInput.attr('data-toolkit-tab-expand', true);
-      lastInput.on('keydown', this.applyNewTabBehavior);
     }
   }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): N/A
Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
split-transaction-tab-expand would activate with a shift+tab (focus previous element). Old listeners weren't cleared so tabbing past previous rows would expand the transaction. Changed from using observe to an ember hook.