### PR TITLE
fix: re-fetch settings when opening export modal

### DIFF
--- a/src/core/options/toolkit-options/component.tsx
+++ b/src/core/options/toolkit-options/component.tsx
@@ -213,6 +213,10 @@ function ImportExportModal({
   const [allToolkitSettings, setAllToolkitSettings] = React.useState('');
 
   React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
     localToolkitStorage.getStoredFeatureSettings().then((keys) =>
       Promise.all(
         keys.map((settingKey) =>
@@ -225,7 +229,7 @@ function ImportExportModal({
         setIsLoading(false);
       })
     );
-  }, []);
+  }, [isOpen]);
 
   function handleSubmit() {
     let parsedSettings: ImportExportSettings = [];


### PR DESCRIPTION
GitHub Issue (if applicable): #2518

**Explanation of Bugfix/Feature/Modification:**
Re-fetch settings when the modal opens.
