### PR TITLE
fix: add scrollable-edit-menu css when auto-enabling

### DIFF
--- a/src/extension/features/accounts/right-click-to-edit/index.js
+++ b/src/extension/features/accounts/right-click-to-edit/index.js
@@ -6,7 +6,12 @@ export class RightClickToEdit extends Feature {
   isCurrentlyRunning = false;
 
   injectCSS() {
-    return require('./index.css');
+    let css = require('./index.css');
+    if (!ynabToolKit.options.ScrollableEditMenu) {
+      css += `\n${require('../scrollable-edit-menu/index.css')}`;
+    }
+
+    return css;
   }
 
   shouldInvoke() {


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
We were auto-enabling Scrollable Edit Menu for Right-Click to Edit but weren't adding the css :/
