### PR TITLE
fix: scrollable edit menu submenus not scrolling when overflowed

### DIFF
--- a/src/extension/features/accounts/scrollable-edit-menu/index.css
+++ b/src/extension/features/accounts/scrollable-edit-menu/index.css
@@ -16,6 +16,6 @@
   position: static !important;
   display: block !important;
   margin: 0;
-  height: 100%;
-  overflow: hidden;
+  max-height: 100%;
+  overflow-y: auto;
 }


### PR DESCRIPTION
GitHub Issue (if applicable): N/A
Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
With scrollable-edit-menu enabled, sub menus with too many items would not scroll - the overflow would be hidden. I've edited the styles to correct this.