### PR TITLE
improve label readability in income-breakdown report

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
@@ -365,6 +365,15 @@ export class IncomeBreakdownComponent extends React.Component {
               },
             },
           },
+          dataLabels: {
+            backgroundColor: '#00000080',
+            borderRadius: 5,
+            padding: 3,
+            style: {
+              color: '#FFF',
+              textOutline: 'none',
+            },
+          },
           tooltip: {
             headerFormat: '',
             pointFormatter: function () {


### PR DESCRIPTION
GitHub Issue (if applicable): #2143
Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Highcharts does its best but the readability of the category labels in the Income Breakdown report is a bit hit and miss.
I've updated the configuration to use a dark background and white text for all labels instead of the contrast outlines used currently.

![income-breakdown](https://user-images.githubusercontent.com/83871143/131430609-9ee479c1-f242-4a7e-988f-caf772360aa1.PNG)
![income-breakdown-2](https://user-images.githubusercontent.com/83871143/131430615-7878ecf7-af44-406e-baac-4e543c06faa6.PNG)

![income-breakdown-3](https://user-images.githubusercontent.com/83871143/131430904-086aaf6f-ef7e-4236-b305-8da617d81b64.PNG)
![income-breakdown-4](https://user-images.githubusercontent.com/83871143/131430907-a202282f-5313-47fa-8683-4553c5bba318.PNG)

