### PR TITLE
fix: error when live enabling features

### DIFF
--- a/src/extension/ynab-toolkit.tsx
+++ b/src/extension/ynab-toolkit.tsx
@@ -97,7 +97,7 @@ export class YNABToolkit {
     const wrappedShouldInvoke = feature.shouldInvoke.bind(feature);
     const wrappedInvoke = feature.invoke.bind(feature);
     const isEnabled = isFeatureEnabled(feature.settings.enabled);
-    if ((options.force || isEnabled) && wrappedShouldInvoke()) {
+    if ((isEnabled || (options && options.force)) && wrappedShouldInvoke()) {
       wrappedInvoke();
     }
   };


### PR DESCRIPTION
GitHub Issue (if applicable): N/A
Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
Live enabling features caused an error in YNABToolkit.invokeFeature as it assumed options were present.
