### PR TITLE
allow custom colors for MasterCategoryRowColor

### DIFF
--- a/src/extension/features/budget/color-master-category-row/index.css
+++ b/src/extension/features/budget/color-master-category-row/index.css
@@ -1,13 +1,11 @@
 body,
+body.theme-classic,
 body.theme-new-default {
-  --tk-master-category-row-color: var(--primary300);
-}
-body.theme-classic {
-  --tk-master-category-row-color: var(--inspector_background);
+  --tk-master-category-row-color: var(--neutral300);
 }
 
 body.theme-dark {
-  --tk-master-category-row-color: var(--primary1000);
+  --tk-master-category-row-color: var(--neutral700);
 }
 
 .budget-table-row.is-master-category {

--- a/src/extension/features/budget/color-master-category-row/index.js
+++ b/src/extension/features/budget/color-master-category-row/index.js
@@ -2,6 +2,12 @@ import { Feature } from 'toolkit/extension/features/feature';
 
 export class MasterCategoryRowColor extends Feature {
   injectCSS() {
-    return require('./index.css');
+    const css = require('./index.css');
+    const defaultThemeColor = ynabToolKit.options.MasterCategoryRowColorSelect;
+    const darkThemeColor = ynabToolKit.options.MasterCategoryRowDarkColorSelect;
+
+    let patchedCSS = css.replace('var(--neutral300)', defaultThemeColor);
+    patchedCSS = patchedCSS.replace('var(--neutral700)', darkThemeColor);
+    return patchedCSS;
   }
 }

--- a/src/extension/features/budget/color-master-category-row/settings.js
+++ b/src/extension/features/budget/color-master-category-row/settings.js
@@ -1,8 +1,27 @@
-module.exports = {
-  name: 'MasterCategoryRowColor',
-  type: 'checkbox',
-  default: false,
-  section: 'budget',
-  title: 'Colored Master Category Row',
-  description: 'Adds Color to Master Category Row.',
-};
+module.exports = [
+  {
+    name: 'MasterCategoryRowColor',
+    type: 'checkbox',
+    default: false,
+    section: 'budget',
+    title: 'Colored Master Category Row',
+    description: 'Adds Color to Master Category Row.',
+  },
+  {
+    name: 'MasterCategoryRowColorSelect',
+    type: 'color',
+    default: '#d1d1d6',
+    section: 'budget',
+    title: 'Colored Master Category Row - Default/Classic Theme Color',
+    description:
+      'The color which will be used for the Default and Classic YNAB Themes. The default is #d1d1d6.',
+  },
+  {
+    name: 'MasterCategoryRowDarkColorSelect',
+    type: 'color',
+    default: '#636366',
+    section: 'budget',
+    title: 'Colored Master Category Row - Dark Theme Color',
+    description: 'The color which will be used for the Dark YNAB Theme. The default is #636366.',
+  },
+];


### PR DESCRIPTION
I added additional options for MasterCategoryRowColor to allow for selecting custom colors. I picked new default colors that I think go well with the default and dark themes (`--neutral300` and `--neutral700`, respectively). I'm of course completely open to changing the colors or using the original color for the option.

![image](https://user-images.githubusercontent.com/1844269/131777581-77790f08-b3b2-4831-9d46-2d17c84a9a25.png)
![image](https://user-images.githubusercontent.com/1844269/131777614-9caf3728-5524-497f-a66e-a90db6ea5183.png)