### PR TITLE
feature expansion: Monthly goals dashboard 

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.css
+++ b/src/extension/features/budget/display-total-monthly-goals/index.css
@@ -1,30 +1,3 @@
-.tk-budget-table-cell-pacing {
-  width: 15%;
-  justify-content: flex-end !important;
-  padding: 0 0 0 1rem !important;
-  text-align: right !important;
-}
-
-.tk-budget-table-cell-pacing .deemphasized,
-.tk-budget-table-cell-pacing .deemphasized:hover {
-  color: #cfd5d7 !important;
-  background-color: transparent !important;
-}
-
-.tk-budget-table-cell-pacing .indicator {
-  border-radius: 0.5em;
-  height: 1em;
-  width: 1em;
-  margin-right: 0.5em;
-  overflow: hidden;
-  text-indent: -9999px;
-  text-align: left;
-}
-
-.tk-budget-table-cell-pacing .indicator.deemphasized {
-  background-color: #cfd5d7 !important;
-}
-
 .card-roll-up-total-goals {
   padding: 16px;
 }

--- a/src/extension/features/budget/display-total-monthly-goals/index.css
+++ b/src/extension/features/budget/display-total-monthly-goals/index.css
@@ -1,0 +1,51 @@
+.tk-budget-table-cell-pacing {
+  width: 15%;
+  justify-content: flex-end !important;
+  padding: 0 0 0 1rem !important;
+  text-align: right !important;
+}
+
+.tk-budget-table-cell-pacing .deemphasized,
+.tk-budget-table-cell-pacing .deemphasized:hover {
+  color: #cfd5d7 !important;
+  background-color: transparent !important;
+}
+
+.tk-budget-table-cell-pacing .indicator {
+  border-radius: 0.5em;
+  height: 1em;
+  width: 1em;
+  margin-right: 0.5em;
+  overflow: hidden;
+  text-indent: -9999px;
+  text-align: left;
+}
+
+.tk-budget-table-cell-pacing .indicator.deemphasized {
+  background-color: #cfd5d7 !important;
+}
+
+.card-roll-up-total-goals {
+  padding: 16px;
+}
+
+.goals-row {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.card-roll-up-total-goals > h2 > span {
+  padding: 0 0.2em !important;
+}
+
+.card-roll-up-total-goals > div > .positive {
+  color: var(--budget_balance_positive_background);
+}
+
+.card-roll-up-total-goals > div > .negative {
+  color: var(--budget_balance_negative_background);
+}
+
+.card-roll-up-total-goals > div > .zero {
+  color: var(--tk-color-goal-warning-underfunded);
+}


### PR DESCRIPTION
GitHub Issue: Implements Issue #2545

Trello Link (if applicable): Dont believe I have permissions to create a trello ticket

**Explanation of Bugfix/Feature/Modification:**
I implemented an expansion of the "Total Monthly Goals" panel to present monthly goal progress in a format that allows for quick understanding of your current situation. Have been looking for a total of the amount assigned to goals, and the amount that still needs to be assigned / budgeted for. I currently have the following items being shown in this panel:

-    Total Monthly Goals - Total budgeted amount for goals
-    Budgeted For Goals - Total assigned to goals
-    Needed For Goals - Amount still needing to be assigned
-    Total Income - Total amount of income gained in the current month
-    Total Spent - Total spent during the current month

I would definitely agree if the argument was made that total income / total spent may not be applicable to this panel - and are likely covered elsewhere. For my application, having one panel with a sort of "heads up display" is nice, but I'm open to changing it to remove certain details or separate them out into a separate panel if that makes sense.

**Screenshot of the current state of this panel:**

![image](https://user-images.githubusercontent.com/16846767/131957986-e569b6a6-9f19-4076-9306-8d9427ea59e9.png)
