### PR TITLE
Added category target goal totals to header rows

### DIFF
--- a/src/extension/features/budget/display-target-goal-amount/emphasis-green.css
+++ b/src/extension/features/budget/display-target-goal-amount/emphasis-green.css
@@ -1,3 +1,7 @@
 .tk-goal-emphasis {
   color: var(--label_positive);
 }
+
+.category-goal-toal {
+  color: var(--tk-color-goal-warning-underfunded);
+}

--- a/src/extension/features/budget/display-target-goal-amount/emphasis-red.css
+++ b/src/extension/features/budget/display-target-goal-amount/emphasis-red.css
@@ -1,3 +1,7 @@
 .tk-goal-emphasis {
   color: var(--label_negative);
 }
+
+.category-goal-toal {
+  color: var(--tk-color-goal-warning-underfunded);
+}


### PR DESCRIPTION
Added a total of the goals that are set for each category to the category header.  Pretty small change but I think the information is useful and it makes sense to have it given that all other columns have totals.  

Screenshot of the current state (Only showing the column with the change as I dont want to show my whole budget):
![image](https://user-images.githubusercontent.com/16846767/132106356-f2c53168-855f-4cfc-ba43-3014996631ff.png)
The changed column headers are shown in blue.  
