### PR TITLE
fix: shared debounce timers in budget-progress-bars (#2548)

### DIFF
--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -4,18 +4,6 @@ import { getEmberView } from 'toolkit/extension/utils/ember';
 
 const PROGRESS_INDICATOR_WIDTH = 0.001; // Current month progress indicator width
 
-function debounce(fn, timeout = 50) {
-  let timer;
-
-  return (...args) => {
-    clearTimeout(timer);
-
-    timer = setTimeout(() => {
-      fn.apply(this, args);
-    }, timeout);
-  };
-}
-
 export class BudgetProgressBars extends Feature {
   injectCSS() {
     return require('./index.css');
@@ -39,7 +27,7 @@ export class BudgetProgressBars extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('budget-table-row', 'didRender', debounce(this.addProgressBars));
+    this.addToolkitEmberHook('budget-table-row', 'didRender', this.addProgressBars);
   }
 
   addGoalProgress = (element) => {

--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -27,7 +27,9 @@ export class BudgetProgressBars extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('budget-table-row', 'didRender', this.addProgressBars);
+    this.addToolkitEmberHook('budget-table-row', 'didRender', this.addProgressBars, {
+      debounce: 50,
+    });
   }
 
   addGoalProgress = (element) => {

--- a/src/extension/features/feature.ts
+++ b/src/extension/features/feature.ts
@@ -66,11 +66,32 @@ export class Feature {
     routeChangeListener.removeFeature(this);
   }
 
+  debounce(fn: (element: HTMLElement) => void, timeout: number): (element: HTMLElement) => void {
+    const timers = new Map<string, number>();
+    return (element: HTMLElement) => {
+      if (timers.has(element.id)) {
+        window.clearTimeout(timers.get(element.id));
+      }
+
+      timers.set(
+        element.id,
+        window.setTimeout(() => {
+          fn.call(this, element);
+        }, timeout)
+      );
+    };
+  }
+
   addToolkitEmberHook(
     componentKey: string,
     lifecycleHook: SupportedEmberHook,
-    fn: (element: HTMLElement) => void
+    fn: (element: HTMLElement) => void,
+    options?: { debounce: number }
   ): void {
+    if (options && options.debounce) {
+      fn = this.debounce(fn, options.debounce);
+    }
+
     addToolkitEmberHook(this, componentKey, lifecycleHook, fn);
     this.__hooks.set(`${componentKey}:${lifecycleHook}`, fn);
 


### PR DESCRIPTION
GitHub Issue (if applicable): #2548 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Budget Rows Progress Bars wasn't functioning correctly - on page load only the last category rendered would show its progress bar. This was due to all the budget rows sharing a single debounce timer. I've removed the debounce for now - in the future, we could add a system to track which element is being rendered and debounce them separately, but this feature doesn't do any particularly heavy processing so I don't think it's necessary at the moment.
