### PR TITLE
fix: split-transaction-tab-expand missing shouldInvoke method (#2554)

### DIFF
--- a/src/extension/features/accounts/split-transaction-tab-expand/index.js
+++ b/src/extension/features/accounts/split-transaction-tab-expand/index.js
@@ -1,6 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class SplitTransactionTabExpand extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage();
+  }
+
   invoke() {
     this.addToolkitEmberHook('register/grid-split', 'didRender', this.addEventListeners);
   }


### PR DESCRIPTION
GitHub Issue (if applicable): #2554 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The method shouldInvoke was missing in split-transaction-tab-expand causing it to never invoke.
