### PR TITLE
fix: align reports icon

### DIFF
--- a/src/extension/features/toolkit-reports/index.css
+++ b/src/extension/features/toolkit-reports/index.css
@@ -2,7 +2,3 @@
   cursor: pointer;
   display: 'flex';
 }
-
-.nav-main .tk-react-reports-link.active a .flaticon {
-  color: #fed168;
-}

--- a/src/extension/features/toolkit-reports/index.css
+++ b/src/extension/features/toolkit-reports/index.css
@@ -1,5 +1,6 @@
 .nav-main .tk-react-reports-link {
   cursor: pointer;
+  display: 'flex';
 }
 
 .nav-main .tk-react-reports-link.active a .flaticon {


### PR DESCRIPTION
GitHub Issue (if applicable): #2590

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Wrapped the Reports icon with display flex so it will be centered when the sidebar is collapsed

After the changes
![Screen Shot 2021-10-25 at 9 27 39 AM](https://user-images.githubusercontent.com/169723/138714568-66e3ac16-ba7a-4485-9302-10fdf001dede.png)
![Screen Shot 2021-10-25 at 9 27 56 AM](https://user-images.githubusercontent.com/169723/138714571-776bcace-0397-425b-a321-a1545799d5b4.png)

