### PR TITLE
fix: update highlight-negatives css for new color scheme feature (#2615)

### DIFF
--- a/src/extension/features/budget/highlight-negatives/index.css
+++ b/src/extension/features/budget/highlight-negatives/index.css
@@ -3,8 +3,8 @@
   color: var(--budget_balance_negative_text) !important;
 }
 
-body[data--square-negative-mode]
-  .budget-table-row
+body.tk-custom-colours-enabled[tk-custom-colours-negative-square]
   .ynab-new-budget-available-number.cautious.credit {
-  border-radius: 0rem;
+  border-radius: 0em !important;
+  -webkit-border-radius: 0em !important;
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2615 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
"Highlight all Negative Category Balances Red" wasn't applying square corners when selected in "Modify Currency Colors".
Updated the style sheet to reflect the current method of enabling square corners.