### PR TITLE
Monte Carlo forecasts report

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "publish:desktop": "node scripts/publishForDesktop.js",
     "prettier": "prettier --write \"{src,scripts}/**/*.{js,jsx,ts,tsx}\"",
     "test": "yarn && yarn gen && jest",
+    "test:watch": "yarn && yarn gen && jest --watch",
     "watch": "yarn && node scripts/watch.js",
     "gen": "yarn gen:settings && yarn gen:featureIndex",
     "gen:featureIndex": "node scripts/generateFeatureIndex",
@@ -106,7 +107,6 @@
     "regression": "^2.0.1"
   },
   "devDependencies": {
-    "@types/chrome": "^0.0.154",
     "@babel/cli": "^7.14.3",
     "@babel/core": "^7.14.3",
     "@babel/eslint-parser": "^7.14.4",
@@ -114,6 +114,7 @@
     "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
     "@babel/preset-env": "^7.14.4",
     "@babel/preset-react": "^7.13.13",
+    "@types/chrome": "^0.0.154",
     "@types/ember": "^3.16.0",
     "@types/jest": "^26.0.23",
     "@types/jquery": "^3.5.5",

--- a/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
@@ -15,6 +15,7 @@ import {
   storeDateFilters,
 } from 'toolkit-reports/utils/storage';
 import { IncomeBreakdown } from '../../../pages/income-breakdown/container';
+import { Forecast } from '../../../pages/forecast';
 
 export const SelectedReportContextPropType = {
   component: PropTypes.func.isRequired,
@@ -92,6 +93,14 @@ const REPORT_COMPONENTS = [
     filterSettings: {
       disableTrackingAccounts: true,
       includeTrackingAccounts: false,
+    },
+  },
+  {
+    component: Forecast,
+    key: ReportKeys.Forecast,
+    filterSettings: {
+      disableTrackingAccounts: false,
+      includeTrackingAccounts: true,
     },
   },
 ];

--- a/src/extension/features/toolkit-reports/common/constants/report-types.js
+++ b/src/extension/features/toolkit-reports/common/constants/report-types.js
@@ -6,6 +6,7 @@ export const ReportKeys = {
   IncomeVsExpense: 'income-vs-expense',
   IncomeBreakdown: 'income-breakdown',
   BalanceOverTime: 'balance-over-time',
+  Forecast: 'forecast',
 };
 
 export const ReportNames = {
@@ -16,6 +17,7 @@ export const ReportNames = {
   IncomeVsExpense: 'Income vs. Expense',
   IncomeBreakdown: 'Income Breakdown',
   BalanceOverTime: 'Balance Over Time',
+  Forecast: 'Forecast',
 };
 
 export const REPORT_TYPES = [
@@ -46,5 +48,9 @@ export const REPORT_TYPES = [
   {
     key: ReportKeys.BalanceOverTime,
     name: ReportNames.BalanceOverTime,
+  },
+  {
+    key: ReportKeys.Forecast,
+    name: ReportNames.Forecast,
   },
 ];

--- a/src/extension/features/toolkit-reports/pages/forecast/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/forecast/component.jsx
@@ -25,11 +25,6 @@ export function ForecastComponent({ filteredTransactions }) {
 
     const now = moment();
 
-    // function prepareData(data) {
-    //   if (!data?.length) return [];
-    //   return data.map((d, i) => [now.clone().add(i + 1, 'w'), d]);
-    // }
-
     setChart(
       new Highcharts.Chart({
         credits: false,
@@ -51,14 +46,14 @@ export function ForecastComponent({ filteredTransactions }) {
         yAxis: {
           labels: {
             formatter: function () {
-              return `$${Number(this.value / 100).toLocaleString()}`;
+              return `$${Number(this.value / 1000).toLocaleString()}`;
             },
           },
         },
         tooltip: {
           formatter: function () {
             return `${this.series.name}: <b>$${Number(
-              this.point.y / 100
+              this.point.y / 1000
             ).toLocaleString()}</b><br />${now
               .clone()
               .add(this.point.x + 1, 'w')

--- a/src/extension/features/toolkit-reports/pages/forecast/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/forecast/component.jsx
@@ -1,6 +1,83 @@
 import * as React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { generateForecasts } from './functions';
+import Highcharts from 'highcharts';
+import moment from 'moment';
 
-export function ForecastComponent({ allReportableTransactions }) {
-  console.log({ allReportableTransactions });
-  return <p>Hello World</p>;
+export function ForecastComponent({ filteredTransactions }) {
+  const [forecasts, setForecasts] = useState([]);
+  const [chart, setChart] = useState();
+  const chartRef = useRef();
+
+  const confidences = [10, 25, 50, 75, 90];
+
+  useEffect(() => {
+    console.log({ filteredTransactions });
+    setForecasts(generateForecasts(filteredTransactions));
+  }, [filteredTransactions]);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+
+    if (chart) {
+      chart.destroy();
+    }
+
+    const now = moment();
+
+    // function prepareData(data) {
+    //   if (!data?.length) return [];
+    //   return data.map((d, i) => [now.clone().add(i + 1, 'w'), d]);
+    // }
+
+    setChart(
+      new Highcharts.Chart({
+        credits: false,
+        chart: {
+          backgroundColor: 'transparent',
+          renderTo: 'tk-forecast-chart',
+        },
+        title: { text: '' },
+        xAxis: {
+          labels: {
+            formatter: function () {
+              return now
+                .clone()
+                .add(this.value + 1, 'w')
+                .format('YYYY-MM-DD');
+            },
+          },
+        },
+        yAxis: {
+          labels: {
+            formatter: function () {
+              return `$${Number(this.value / 100).toLocaleString()}`;
+            },
+          },
+        },
+        tooltip: {
+          formatter: function () {
+            return `${this.series.name}: <b>$${Number(
+              this.point.y / 100
+            ).toLocaleString()}</b><br />${now
+              .clone()
+              .add(this.point.x + 1, 'w')
+              .format('YYYY-MM-DD')}`;
+          },
+        },
+        series: confidences.map((c) => ({
+          id: c.toString(),
+          type: 'line',
+          name: `${c}%`,
+          data: forecasts[c - 1],
+        })),
+      })
+    );
+  }, [chartRef, forecasts]);
+
+  return (
+    <>
+      <div className={'tk-highcharts-report-container'} id={'tk-forecast-chart'} ref={chartRef} />
+    </>
+  );
 }

--- a/src/extension/features/toolkit-reports/pages/forecast/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/forecast/component.jsx
@@ -5,6 +5,7 @@ import Highcharts from 'highcharts';
 import moment from 'moment';
 
 export function ForecastComponent({ filteredTransactions }) {
+  const [netWorth, setNetWorth] = useState();
   const [forecasts, setForecasts] = useState([]);
   const [chart, setChart] = useState();
   const chartRef = useRef();
@@ -13,7 +14,9 @@ export function ForecastComponent({ filteredTransactions }) {
 
   useEffect(() => {
     console.log({ filteredTransactions });
-    setForecasts(generateForecasts(filteredTransactions));
+    const newForecasts = generateForecasts(filteredTransactions);
+    setForecasts(newForecasts);
+    setNetWorth(newForecasts[0][0]);
   }, [filteredTransactions]);
 
   useEffect(() => {
@@ -39,11 +42,12 @@ export function ForecastComponent({ filteredTransactions }) {
               return now
                 .clone()
                 .add(this.value + 1, 'w')
-                .format('YYYY-MM-DD');
+                .format('MMM YYYY');
             },
           },
         },
         yAxis: {
+          title: { text: '' },
           labels: {
             formatter: function () {
               return `$${Number(this.value / 1000).toLocaleString()}`;
@@ -52,12 +56,18 @@ export function ForecastComponent({ filteredTransactions }) {
         },
         tooltip: {
           formatter: function () {
-            return `${this.series.name}: <b>$${Number(
-              this.point.y / 1000
-            ).toLocaleString()}</b><br />${now
+            const series = this.series.name;
+            const years = this.point.x / 52;
+            const dollars = this.point.y / 1000;
+            const dollarString = Number(dollars).toLocaleString();
+            const apy = Math.log(dollars / (netWorth / 1000)) / years;
+            const apyString = `${(apy * 100).toFixed(1)}%`;
+            const date = now
               .clone()
               .add(this.point.x + 1, 'w')
-              .format('YYYY-MM-DD')}`;
+              .format('YYYY-MM-DD');
+
+            return `${series}: <b>$${dollarString}</b><br />APY: ${apyString}<br />${date}`;
           },
         },
         series: confidences.map((c) => ({

--- a/src/extension/features/toolkit-reports/pages/forecast/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/forecast/component.jsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export function ForecastComponent(props) {
+  console.log({ props });
+  return <p>Hello World</p>;
+}

--- a/src/extension/features/toolkit-reports/pages/forecast/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/forecast/component.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export function ForecastComponent(props) {
-  console.log({ props });
+export function ForecastComponent({ allReportableTransactions }) {
+  console.log({ allReportableTransactions });
   return <p>Hello World</p>;
 }

--- a/src/extension/features/toolkit-reports/pages/forecast/container.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/container.js
@@ -1,0 +1,11 @@
+import { withReportContext } from 'toolkit-reports/common/components/report-context';
+import { ForecastComponent } from './component';
+
+function mapReportContextToProps(context) {
+  return {
+    filters: context.filters,
+    allReportableTransactions: context.allReportableTransactions,
+  };
+}
+
+export const Forecast = withReportContext(mapReportContextToProps)(ForecastComponent);

--- a/src/extension/features/toolkit-reports/pages/forecast/container.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/container.js
@@ -3,7 +3,7 @@ import { ForecastComponent } from './component';
 
 function mapReportContextToProps(context) {
   return {
-    allReportableTransactions: context.allReportableTransactions,
+    filteredTransactions: context.filteredTransactions,
   };
 }
 

--- a/src/extension/features/toolkit-reports/pages/forecast/container.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/container.js
@@ -3,7 +3,6 @@ import { ForecastComponent } from './component';
 
 function mapReportContextToProps(context) {
   return {
-    filters: context.filters,
     allReportableTransactions: context.allReportableTransactions,
   };
 }

--- a/src/extension/features/toolkit-reports/pages/forecast/functions.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/functions.js
@@ -27,13 +27,17 @@ function makeWeeks(transactions) {
   }, {});
 }
 
-function generateForecast(weeks) {
+function calculateNetWorth(transactions) {
+  return transactions?.reduce((acc, t) => acc + t.inflow - t.outflow, 0) || 0;
+}
+
+function generateForecast(weeks, netWorth) {
   const weekKeys = Object.keys(weeks);
   const tenYears = Array.from({ length: 10 * 52 }, () => null);
 
   return tenYears.reduce((accumulator, current, i) => {
     if (!weekKeys.length) return [...accumulator, 0];
-    const prev = i > 0 ? accumulator[i - 1] : 0;
+    const prev = i > 0 ? accumulator[i - 1] : netWorth;
     if (Number.isNaN(prev)) {
       throw new Error('Not a number');
     }
@@ -44,8 +48,9 @@ function generateForecast(weeks) {
 
 export function generateForecasts(transactions) {
   const weeks = makeWeeks(transactions);
+  const netWorth = calculateNetWorth(transactions);
 
   return range(0, 99)
-    .map(() => generateForecast(weeks))
+    .map(() => generateForecast(weeks, netWorth))
     .sort((a, b) => b[b.length - 1] - a[a.length - 1]);
 }

--- a/src/extension/features/toolkit-reports/pages/forecast/functions.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/functions.js
@@ -1,0 +1,45 @@
+import random from './random';
+
+function range(start, end) {
+  // https://jasonwatmore.com/post/2021/10/02/vanilla-js-create-an-array-with-a-range-of-numbers-in-a-javascript
+  return [...Array(end - start + 1).keys()].map((x) => x + start);
+}
+
+function makeWeeks(transactions) {
+  const pool = transactions?.flat() || [];
+
+  if (!pool.length) return [];
+
+  const firstDateNumber = pool[0].date.isoWeek();
+  const lastDateNumber = pool[pool.length - 1].date.isoWeek();
+
+  return range(firstDateNumber, lastDateNumber).reduce((accumulator, current) => {
+    const matches = pool.filter((t) => t.date.isoWeek() === current);
+    return {
+      ...accumulator,
+      [current]: matches.reduce((acc, cur) => acc + cur.inflow - cur.outflow, 0),
+    };
+  }, {});
+}
+
+function generateForecast(weeks) {
+  const weekKeys = Object.keys(weeks);
+  const tenYears = Array.from({ length: 10 * 52 }, () => null);
+
+  return tenYears.reduce((accumulator, current, i) => {
+    const prev = i > 0 ? accumulator[i - 1] : 0;
+    return [...accumulator, prev + weeks[random(weekKeys)]];
+  }, []);
+}
+
+export function generateForecasts(transactions) {
+  const weeks = makeWeeks(transactions);
+
+  return {
+    10: generateForecast(weeks),
+    25: generateForecast(weeks),
+    50: generateForecast(weeks),
+    75: generateForecast(weeks),
+    90: generateForecast(weeks),
+  };
+}

--- a/src/extension/features/toolkit-reports/pages/forecast/functions.spec.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/functions.spec.js
@@ -31,7 +31,8 @@ describe('forecast page functions', () => {
   it('generates forecasts using transactions', async () => {
     const result = getForecastsResult([{ inflow: 1 }]);
 
-    const expected = Array.from({ length: 10 * 52 }, (v, i) => i + 1);
+    // i+2: i is zero-based; 2 adjusts for this and adds initial networth
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => i + 2);
 
     expect(result).toHaveProperty('10', expected);
   });
@@ -39,7 +40,7 @@ describe('forecast page functions', () => {
   it('uses transactions', async () => {
     const result = getForecastsResult([{ inflow: 2 }]);
 
-    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2);
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2 + 2);
 
     expect(result).toHaveProperty('10', expected);
   });
@@ -47,7 +48,7 @@ describe('forecast page functions', () => {
   it('supports outflows', async () => {
     const result = getForecastsResult([{ outflow: 1 }]);
 
-    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * -1);
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * -1 - 1);
 
     expect(result).toHaveProperty('10', expected);
   });
@@ -55,7 +56,7 @@ describe('forecast page functions', () => {
   it('generates forecasts for all confidences', async () => {
     const result = getForecastsResult([{ inflow: 1 }]);
 
-    const expected = Array.from({ length: 10 * 52 }, (v, i) => i + 1);
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => i + 2);
 
     Object.keys(result).forEach((k) => expect(result).toHaveProperty(k, expected));
   });
@@ -68,7 +69,7 @@ describe('forecast page functions', () => {
       { inflow: 2, date: '1995-11-27' },
     ]);
 
-    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2);
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2 + 3);
 
     expect(result).toHaveProperty('10', expected);
   });
@@ -85,7 +86,7 @@ describe('forecast page functions', () => {
       },
     ]);
 
-    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2);
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2 + 2);
 
     expect(result).toHaveProperty('10', expected);
   });
@@ -109,7 +110,7 @@ describe('forecast page functions', () => {
       },
     ]);
 
-    const expected = [1, 3, 4, 6, 7, 9];
+    const expected = [4, 6, 7, 9, 10, 12];
 
     expect(result[10].slice(0, 6)).toEqual(expected);
   });
@@ -128,7 +129,7 @@ describe('forecast page functions', () => {
       },
     ]);
 
-    expect(result[10][0]).toEqual(0);
+    expect(result[10][0]).toEqual(3);
   });
 
   it('sorts forecasts', async () => {
@@ -166,7 +167,7 @@ describe('forecast page functions', () => {
       { inflow: 2, date: '1995-11-27' },
     ]);
 
-    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2);
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2 + 3);
 
     expect(result).toHaveProperty('10', expected);
   });
@@ -178,11 +179,7 @@ describe('forecast page functions', () => {
       { inflow: 1, date: '1995-11-20', payeeName: 'Starting Balance' },
     ]);
 
-    expect(result[0][0]).toEqual(0);
+    // but not initial net worth
+    expect(result[0][0]).toEqual(1);
   });
 });
-
-// TODO
-// Add current net worth to all numbers
-// Divide by 100 so forecasts are in dollars, round to cents
-// Add x-axis dates

--- a/src/extension/features/toolkit-reports/pages/forecast/functions.spec.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/functions.spec.js
@@ -1,0 +1,158 @@
+import { generateForecasts } from './functions';
+import random from './random';
+import moment from 'moment';
+
+jest.mock('./random');
+
+function makeTransactions(inputGroups) {
+  return inputGroups.map((inputs) =>
+    inputs.map((input) => ({
+      inflow: 0,
+      outflow: 0,
+      date: moment('1995-12-25').utc(),
+      ...input,
+    }))
+  );
+}
+
+function getForecastsResult(inputGroups) {
+  return generateForecasts(makeTransactions(inputGroups));
+}
+
+describe('forecast page functions', () => {
+  beforeEach(() => random.mockImplementation((list) => list[0]));
+
+  it('returns various confidences', async () => {
+    const result = generateForecasts();
+
+    expect(result).toHaveProperty('10');
+    expect(result).toHaveProperty('25');
+    expect(result).toHaveProperty('50');
+    expect(result).toHaveProperty('75');
+    expect(result).toHaveProperty('90');
+  });
+
+  it('generates forecasts using transactions', async () => {
+    const result = getForecastsResult([[{ inflow: 1 }]]);
+
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => i + 1);
+
+    expect(result).toHaveProperty('10', expected);
+  });
+
+  it('uses transactions', async () => {
+    const result = getForecastsResult([[{ inflow: 2 }]]);
+
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2);
+
+    expect(result).toHaveProperty('10', expected);
+  });
+
+  it('supports outflows', async () => {
+    const result = getForecastsResult([[{ outflow: 1 }]]);
+
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * -1);
+
+    expect(result).toHaveProperty('10', expected);
+  });
+
+  it('generates forecasts for all confidences', async () => {
+    const result = getForecastsResult([[{ inflow: 1 }]]);
+
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => i + 1);
+
+    Object.keys(result).forEach((k) => expect(result).toHaveProperty(k, expected));
+  });
+
+  it('selects weeks at random', async () => {
+    random.mockImplementation((list) => list[1]);
+
+    const result = getForecastsResult([
+      [
+        { inflow: 1, date: moment('1995-11-20').utc() },
+        { inflow: 2, date: moment('1995-11-27').utc() },
+      ],
+    ]);
+
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2);
+
+    expect(result).toHaveProperty('10', expected);
+  });
+
+  it('uses transactions from all groups', async () => {
+    random.mockImplementation((list) => list[0]);
+
+    const result = getForecastsResult([[{ inflow: 1 }], [{ inflow: 1 }]]);
+
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2);
+
+    expect(result).toHaveProperty('10', expected);
+  });
+
+  it('sums weeks', async () => {
+    const result = getForecastsResult([
+      [
+        {
+          inflow: 1,
+          date: moment('1995-12-25').utc(),
+        },
+        {
+          inflow: 1,
+          date: moment('1995-12-26').utc(),
+        },
+      ],
+    ]);
+
+    const expected = Array.from({ length: 10 * 52 }, (v, i) => (i + 1) * 2);
+
+    expect(result).toHaveProperty('10', expected);
+  });
+
+  it('uses multiple random weeks in a forecast', async () => {
+    let lastCall = 1;
+
+    random.mockImplementation((list) => {
+      lastCall = lastCall ? 0 : 1;
+      return list[lastCall];
+    });
+
+    const result = getForecastsResult([
+      [
+        {
+          inflow: 1,
+          date: moment('1995-11-20').utc(),
+        },
+        {
+          inflow: 2,
+          date: moment('1995-11-27').utc(),
+        },
+      ],
+    ]);
+
+    const expected = [1, 3, 4, 6, 7, 9];
+
+    expect(result[10].slice(0, 6)).toEqual(expected);
+  });
+
+  it('includes weeks with no transactions', async () => {
+    random.mockImplementation((list) => list[1]);
+
+    const result = getForecastsResult([
+      [
+        {
+          inflow: 1,
+          date: moment('1995-11-25').utc(),
+        },
+        {
+          inflow: 2,
+          date: moment('1995-12-25').utc(),
+        },
+      ],
+    ]);
+
+    expect(result[10][0]).toEqual(0);
+  });
+});
+
+// TODO
+// Only include last 52 weeks in pool

--- a/src/extension/features/toolkit-reports/pages/forecast/index.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/index.js
@@ -1,0 +1,1 @@
+export * from './container';

--- a/src/extension/features/toolkit-reports/pages/forecast/random.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/random.js
@@ -1,0 +1,3 @@
+export default function random(list) {
+  return [Math.floor(Math.random() * list.length)];
+}

--- a/src/extension/features/toolkit-reports/pages/forecast/random.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/random.js
@@ -1,3 +1,3 @@
 export default function random(list) {
-  return [Math.floor(Math.random() * list.length)];
+  return list[Math.floor(Math.random() * list.length)];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,9 +2795,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
+  version "1.0.30001292"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz"
+  integrity sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
GitHub Issue: #2647

This pull requests adds a toolkit report that generates Monte Carlo forecasts based on the user's historical inflows and outflows.

The chart displays five forecasts, each corresponding with confidence levels 10%, 25%, 50%, 75%, and 90% respectively.

The algorithm generates 100 scenarios, each 10 years in length, by randomly selecting one-week periods from the user's transaction history, thereby creating 100 unique potential futures for the user based on their past behavior. 

It then sorts these scenarios based on the final net worth descending. In this way, by taking the 10th returned scenario, only 10% of generated scenarios resulted in that net worth or higher, corresponding to a 10% confidence level.
