### PR TITLE
fix(docs): update required Node.js version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This extension uses three main things in its build process:
   content scripts) into single files and manages most of the build process.
 
 1. Clone the repository.
-2. Install Node.js (>= v8.12.0 and <= v14.17.0) and Yarn (>= v1.10.0).
+2. Install Node.js (>= v14.17.0 and <= v16) and Yarn (>= v1.10.0).
 
    - On **macOS** both prerequisites can be setup using `brew`. Ensure command line developer tools (`xcode-select --install`) are also installed.
    - On **Windows** `node` and `yarn` can be installed via Chocolatey (`choco`) package manager.


### PR DESCRIPTION
GitHub Issue (if applicable): -

Trello Link (if applicable): -

**Explanation of Bugfix:**
Update the docs so the required Node.js version is up to date to the range in `package.json`.
