### PR TITLE
fix: loan history broken when toolkit reports enabled

### DIFF
--- a/src/extension/features/toolkit-reports/index.js
+++ b/src/extension/features/toolkit-reports/index.js
@@ -37,7 +37,6 @@ export class ToolkitReports extends Feature {
       $(YNAB_CONTENT_CONTAINER_SELECTOR).append(
         $('<div>', {
           id: TOOLKIT_REPORTS_CONTAINER_ID,
-          css: { height: '100%' },
         })
       );
     }
@@ -87,6 +86,7 @@ export class ToolkitReports extends Feature {
     const container = document.getElementById(TOOLKIT_REPORTS_CONTAINER_ID);
     if (container) {
       ReactDOM.unmountComponentAtNode(container);
+      $(container).css('height', '');
     }
 
     // Update the nav with the active indicator
@@ -106,6 +106,7 @@ export class ToolkitReports extends Feature {
       // Display the toolkit's report
       const container = document.getElementById(TOOLKIT_REPORTS_CONTAINER_ID);
       if (container) {
+        $(container).css('height', '100%');
         ReactDOM.render(React.createElement(Root), container);
       }
     }, 50);


### PR DESCRIPTION
GitHub Issue (if applicable): #2606 #2623 #2631 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The toolkit report container element was causing issues with layout after the new loan history feature was used.
I've changed the container to only set its height when the toolkit reports are active.