### PR TITLE
fix: master category toggle breaks on alternate months (#2528)

### DIFF
--- a/src/extension/features/budget/toggle-master-categories/index.js
+++ b/src/extension/features/budget/toggle-master-categories/index.js
@@ -40,6 +40,8 @@ export class ToggleMasterCategories extends Feature {
     const headerToggle = document.querySelector('.budget-table-header .budget-table-cell-collapse');
     headerToggle.dataset.tkCategoryToggle = this.settings.enabled;
 
+    $(headerToggle).off('click', this.handleToggleCategories);
+    $(headerToggle).off('contextmenu', this.handleToggleSoloMode);
     $(headerToggle).on('click', this.handleToggleCategories);
     $(headerToggle).on('contextmenu', this.handleToggleSoloMode);
 


### PR DESCRIPTION
GitHub Issue (if applicable): #2528 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The master category toggle feature would break on alternate budget months. This was due to the event listener being repeatedly added when the month was changed. Even numbers of listeners would cause the event to toggle back to the initial state. Removed previous event listeners before adding to prevent this.