### PR TITLE
fix: save on enter not persisting changes (#2688)

### DIFF
--- a/src/extension/features/accounts/change-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-enter-behavior/index.js
@@ -35,6 +35,9 @@ export class ChangeEnterBehavior extends Feature {
       event.preventDefault();
       event.stopPropagation();
 
+      // Remove focus to the input so ynab can apply value
+      $(this).trigger('blur');
+
       // Added to support CtrlEnterCleared when ChangeEnterBehavior is enabled
       if (ynabToolKit.options.CtrlEnterCleared === true && (event.metaKey || event.ctrlKey)) {
         let $markClearedButton = $('.is-editing .ynab-cleared:not(.is-cleared)');


### PR DESCRIPTION
GitHub Issue (if applicable): https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2688

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
When the "Save Transaction on Enter" setting is enabled, the toolkit no longer saves the last changes you make with the enter key. While debugging the latest release, I noticed if entered my value, clicked away first, then hit enter, the value would be persisted. Seems like vanilla ynab has added some processing layer in between hitting enter and accepting the value.

This PR simulates what I did by calling `blur` on the input, so the value takes effect when enter is hit.