### PR TITLE
fix: forecast: format values using local currency

### DIFF
--- a/src/extension/features/toolkit-reports/pages/forecast/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/forecast/component.jsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { generateForecasts } from './functions';
 import Highcharts from 'highcharts';
 import moment from 'moment';
+import { formatCurrency } from 'toolkit/extension/utils/currency';
 
 export function ForecastComponent({ filteredTransactions }) {
   const [netWorth, setNetWorth] = useState();
@@ -50,7 +51,7 @@ export function ForecastComponent({ filteredTransactions }) {
           title: { text: '' },
           labels: {
             formatter: function () {
-              return `$${Number(this.value / 1000).toLocaleString()}`;
+              return formatCurrency(this.value);
             },
           },
         },
@@ -58,16 +59,14 @@ export function ForecastComponent({ filteredTransactions }) {
           formatter: function () {
             const series = this.series.name;
             const years = this.point.x / 52;
-            const dollars = this.point.y / 1000;
-            const dollarString = Number(dollars).toLocaleString();
-            const apy = Math.log(dollars / (netWorth / 1000)) / years;
+            const apy = Math.log(this.point.y / netWorth) / years;
             const apyString = `${(apy * 100).toFixed(1)}%`;
             const date = now
               .clone()
               .add(this.point.x + 1, 'w')
               .format('YYYY-MM-DD');
 
-            return `${series}: <b>$${dollarString}</b><br />APY: ${apyString}<br />${date}`;
+            return `${series}: <b>${formatCurrency(this.point.y)}</b><br />APY: ${apyString}<br />${date}`;
           },
         },
         series: confidences.map((c) => ({


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**

Currently the forecast report hard-codes dollars. Rework it to format as the user's local currency.
As a consequence, remove some pointless division while we are here too.

NOTE: this is untested as I don't really know how to, but I hope someone can help here ;-)