### PR TITLE
Fix forecast net worth using all transctions

### DIFF
--- a/src/extension/features/toolkit-reports/pages/forecast/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/forecast/component.jsx
@@ -4,7 +4,7 @@ import { generateForecasts } from './functions';
 import Highcharts from 'highcharts';
 import moment from 'moment';
 
-export function ForecastComponent({ filteredTransactions }) {
+export function ForecastComponent({ filteredTransactions, allReportableTransactions, filters }) {
   const [netWorth, setNetWorth] = useState();
   const [forecasts, setForecasts] = useState([]);
   const [chart, setChart] = useState();
@@ -14,7 +14,11 @@ export function ForecastComponent({ filteredTransactions }) {
 
   useEffect(() => {
     console.log({ filteredTransactions });
-    const newForecasts = generateForecasts(filteredTransactions);
+    const newForecasts = generateForecasts(
+      filteredTransactions,
+      allReportableTransactions,
+      filters
+    );
     setForecasts(newForecasts);
     setNetWorth(newForecasts[0][0]);
   }, [filteredTransactions]);

--- a/src/extension/features/toolkit-reports/pages/forecast/container.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/container.js
@@ -4,6 +4,8 @@ import { ForecastComponent } from './component';
 function mapReportContextToProps(context) {
   return {
     filteredTransactions: context.filteredTransactions,
+    allReportableTransactions: context.allReportableTransactions,
+    filters: context.filters,
   };
 }
 

--- a/src/extension/features/toolkit-reports/pages/forecast/functions.js
+++ b/src/extension/features/toolkit-reports/pages/forecast/functions.js
@@ -46,9 +46,11 @@ function generateForecast(weeks, netWorth) {
   }, []);
 }
 
-export function generateForecasts(transactions) {
+export function generateForecasts(transactions, allReportableTransactions, filters) {
   const weeks = makeWeeks(transactions);
-  const netWorth = calculateNetWorth(transactions);
+  const netWorth = calculateNetWorth(
+    allReportableTransactions.filter((t) => !filters.accountFilterIds.has(t.accountId))
+  );
 
   return range(0, 99)
     .map(() => generateForecast(weeks, netWorth))


### PR DESCRIPTION
GitHub Issue (if applicable): n/a

Trello Link (if applicable): n/a

**Explanation of Bugfix/Feature/Modification:**
The current forecast report bases the starting net worth off only the filtered transactions. This updates uses all transactions to calculate the net worth, but keeps the filtered transactions for running the simulation.
