### PR TITLE
Fix: Total Monthly Goals not displaying Debt Target Type

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -97,7 +97,7 @@ export class DisplayTotalMonthlyGoals extends Feature {
       }
 
       categoryGoals.total += goalData.goal;
-      if (['MF', 'TBD'].includes(goalData.type)) {
+      if (['MF', 'TBD', 'DEBT'].includes(goalData.type)) {
         categoryGoals.totalGoalsAmount.savings += goalData.goal;
         if (goalData.isChecked) {
           categoryGoals.checkedTotalGoalsAmount.savings += goalData.goal;

--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -97,12 +97,12 @@ export class DisplayTotalMonthlyGoals extends Feature {
       }
 
       categoryGoals.total += goalData.goal;
-      if (['MF', 'TBD', 'DEBT'].includes(goalData.type)) {
+      if (['MF', 'TBD'].includes(goalData.type)) {
         categoryGoals.totalGoalsAmount.savings += goalData.goal;
         if (goalData.isChecked) {
           categoryGoals.checkedTotalGoalsAmount.savings += goalData.goal;
         }
-      } else if (goalData.type === 'NEED') {
+      } else if (goalData.type === 'NEED' || goalData.type === 'DEBT') {
         categoryGoals.totalGoalsAmount.spending += goalData.goal;
         if (goalData.isChecked) {
           categoryGoals.checkedTotalGoalsAmount.spending += goalData.goal;


### PR DESCRIPTION
GitHub Issue (if applicable): #2704 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The Total Monthly Goals did not include the new Debt Target type. Added the type "DEBT" to the Spending category to have it included in the calculations.
