### PR TITLE
Fix: goal target column to include DebtPayment goal amounts

### DIFF
--- a/src/extension/features/budget/display-target-goal-amount/index.js
+++ b/src/extension/features/budget/display-target-goal-amount/index.js
@@ -73,6 +73,7 @@ export class DisplayTargetGoalAmount extends Feature {
         case ynab.constants.SubCategoryGoalType.MonthlyFunding:
         case ynab.constants.SubCategoryGoalType.Needed:
         case ynab.constants.SubCategoryGoalType.TargetBalanceOnDate:
+        case ynab.constants.SubCategoryGoalType.DebtPayment:
           goalAmount = goalTarget;
           goalFundedThreshold = goalTarget;
           break;


### PR DESCRIPTION
GitHub Issue (if applicable): #2599 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The Goal Target column did not include the amounts for the new Debt Payment type. This fix now includes the amount by including it type comparison in the switch statement. The amount is treated like Needed for Spending category.
