### PR TITLE
Fix: Total Monthly Goals uses text colors with poor visibility

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.css
+++ b/src/extension/features/budget/display-total-monthly-goals/index.css
@@ -1,21 +1,21 @@
 .tk-monthly-goals-overview .colorize-currency .currency.positive {
-  color: var(--budget_balance_positive_background);
+  color: var(--label_positive);
 }
 
 .tk-monthly-goals-overview .colorize-currency .currency.negative {
-  color: var(--budget_balance_negative_background);
+  color: var(--label_negative);
 }
 
 .tk-monthly-goals-overview .total-income.warning .currency {
-  color: var(--budget_balance_warning_background);
+  color: var(--status_cautious);
 }
 
 .tk-monthly-goals-overview .goal-remaining-balance.positive .currency {
-  color: var(--budget_balance_positive_background);
+  color: var(--label_positive);
 }
 
 .tk-monthly-goals-overview .goal-remaining-balance.negative .currency {
-  color: var(--budget_balance_negative_background);
+  color: var(--label_negative);
 }
 
 .tk-monthly-goals-overview .extra-bottom-space {


### PR DESCRIPTION
GitHub Issue (if applicable): #2715

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
The "Total Monthly Goals" feature uses red, yellow, and green text colors that are not intended for text and are too light to be fully legible. This fix uses more appropriate and visible colors instead.

**Before:**
<img width="371" alt="Screen Shot 2022-04-02 at 9 58 25 PM" src="https://user-images.githubusercontent.com/11161002/161412773-63d1e4ff-501c-4201-9949-2c72e496126e.png">

**After:**
<img width="371" alt="Screen Shot 2022-04-02 at 9 53 16 PM" src="https://user-images.githubusercontent.com/11161002/161412739-2b9ae45a-6696-4feb-a2e7-8fcc67cb4f1e.png">
