### PR TITLE
fix: Improve Forecast Legend label visibility

### DIFF
--- a/src/extension/features/toolkit-reports/pages/forecast/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/forecast/component.jsx
@@ -35,6 +35,15 @@ export function ForecastComponent({ filteredTransactions }) {
           backgroundColor: 'transparent',
           renderTo: 'tk-forecast-chart',
         },
+        legend: {
+          itemStyle: {
+            color: '#888888',
+            cursor: 'pointer',
+            fontSize: '12px',
+            fontWeight: 'bold',
+            textOverflow: 'ellipsis',
+          },
+        },
         title: { text: '' },
         xAxis: {
           labels: {


### PR DESCRIPTION
GitHub Issue (if applicable): #2712 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**

- Forecast Report Legend Visibility in dark mode was impacted by
  Highchart defaults. Setting these explicitly to a setting that will
  work in both standard and dark mode.

- Setting changed from Highchart default label color of #333333
  to #888888
