### PR TITLE
fix(budget): Change vis. of card in privacy mode

### DIFF
--- a/src/extension/features/budget/live-on-last-months-income/index.js
+++ b/src/extension/features/budget/live-on-last-months-income/index.js
@@ -70,17 +70,17 @@ export class LiveOnLastMonthsIncome extends Feature {
                 .append(
                   $('<div>', { id: 'tk-income-in-month' })
                     .append($('<div>', { class: 'tk-title' }))
-                    .append($('<div>', { class: 'tk-value' }))
+                    .append($('<div>', { class: 'tk-value currency' }))
                 )
                 .append(
                   $('<div>', { id: 'tk-assigned-in-month' })
                     .append($('<div>', { class: 'tk-title' }))
-                    .append($('<div>', { class: 'tk-value' }))
+                    .append($('<div>', { class: 'tk-value currency' }))
                 )
                 .append(
                   $('<div>', { id: 'tk-variance-in-month' })
                     .append($('<div>').text(l10n('toolkit.varianceIn', 'Variance')))
-                    .append($('<div>', { class: 'tk-value' }))
+                    .append($('<div>', { class: 'tk-value currency' }))
                 )
             )
           )


### PR DESCRIPTION
GitHub Issue (if applicable): #2686

Trello Link (if applicable): N/A

- Change visibiltiy of currency numbers in the Live on last month's
income while in privacy mode.

The values in the "Live on last month's income" Card on the budget
screen did not have the global currency class attached.
Therefore, when privacy mode is enabled, the changes made for privacy
mode could not be applied to the values in the card.

This fix is to add the global currency CSS class to the values in the
card to allow privacy mode to properly work.

