### PR TITLE
fix(pacing): Invoke rerender on row add

### DIFF
--- a/src/extension/features/budget/pacing/index.js
+++ b/src/extension/features/budget/pacing/index.js
@@ -18,23 +18,16 @@ export class Pacing extends Feature {
     return isCurrentRouteBudgetPage();
   }
 
-  observe(changedNodes) {
-    if (!this.shouldInvoke()) return;
-
-    if (
-      changedNodes.has(
-        'budget-table-row js-budget-table-row is-sub-category is-debt-payment-category'
-      )
-    ) {
-      this.invoke();
-    }
-  }
-
   destroy() {
     $('.tk-budget-table-cell-pacing').remove();
   }
 
   invoke() {
+    this.addToolkitEmberHook('budget-table', 'didRender', this.addPacing);
+    this.addToolkitEmberHook('budget-table', 'didUpdate', this.addPacing);
+  }
+
+  addPacing() {
     if (!isCurrentMonthSelected()) {
       $('.tk-budget-table-cell-pacing').remove();
       return;

--- a/src/extension/features/budget/pacing/index.js
+++ b/src/extension/features/budget/pacing/index.js
@@ -18,6 +18,18 @@ export class Pacing extends Feature {
     return isCurrentRouteBudgetPage();
   }
 
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (
+      changedNodes.has(
+        'budget-table-row js-budget-table-row is-sub-category is-debt-payment-category'
+      )
+    ) {
+      this.invoke();
+    }
+  }
+
   destroy() {
     $('.tk-budget-table-cell-pacing').remove();
   }


### PR DESCRIPTION
GitHub Issue (if applicable): #2731 

Trello Link (if applicable): N/A

The Pacing feature was originally designed to render once when the budget route was navigated to. This commit allows re-rendering of the pacing column whenever a change in the DOM is made by utilizing the observe method in the feature class.
