### PR TITLE
fix: rewrite striped-rows to remember row status (#1490)

### DIFF
--- a/src/extension/features/accounts/striped-rows/index.css
+++ b/src/extension/features/accounts/striped-rows/index.css
@@ -8,7 +8,6 @@ body.theme-dark {
   --tk-striped-transaction-row-color: #1e1e1f;
 }
 
-.ynab-grid
-  .ynab-grid-body-row:nth-of-type(even):not(.is-scheduled):not(.is-checked):not(.is-editing):not(.ynab-grid-body-empty):not(.ynab-grid-actions) {
-  background-color: var(--tk-striped-transaction-row-color);
+.tk-striped-transaction-row:not(.is-scheduled):not(.is-checked):not(.is-editing):not(.ynab-grid-body-empty):not(.ynab-grid-actions) {
+  background-color: var(--tk-striped-transaction-row-color) !important;
 }

--- a/src/extension/features/accounts/striped-rows/index.css
+++ b/src/extension/features/accounts/striped-rows/index.css
@@ -8,6 +8,6 @@ body.theme-dark {
   --tk-striped-transaction-row-color: #1e1e1f;
 }
 
-.tk-striped-transaction-row:not(.is-scheduled):not(.is-checked):not(.is-editing):not(.ynab-grid-body-empty):not(.ynab-grid-actions) {
+.tk-striped-transaction-row:not(.is-checked):not(.is-editing):not(.ynab-grid-body-empty):not(.ynab-grid-actions) {
   background-color: var(--tk-striped-transaction-row-color) !important;
 }

--- a/src/extension/features/accounts/striped-rows/index.js
+++ b/src/extension/features/accounts/striped-rows/index.js
@@ -1,6 +1,13 @@
 import { Feature } from 'toolkit/extension/features/feature';
 
 const STRIPED_ROW_CLASS = 'tk-striped-transaction-row';
+const EXCLUDED_ROW_CLASSES = [
+  'ynab-grid-collapsible-transactions-toggle',
+  'is-scheduled',
+  'ynab-grid-spacer',
+];
+
+const EXCLUDED_ROW_CLASSES_SELECTOR = `:not(.${EXCLUDED_ROW_CLASSES.join('):not(.')})`;
 
 export class AccountsStripedRows extends Feature {
   injectCSS() {
@@ -12,43 +19,42 @@ export class AccountsStripedRows extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('register/grid-row', 'didRender', this.addStripes);
-    this.addToolkitEmberHook('register/grid-sub', 'didRender', this.addStripes);
+    this.addToolkitEmberHook('register/grid-row', 'didRender', this.setTimeout);
+    this.addToolkitEmberHook('register/grid-sub', 'didRender', this.setTimeout);
   }
 
   destroy() {
     $(`.${STRIPED_ROW_CLASS}`).removeClass(STRIPED_ROW_CLASS);
   }
 
-  isStriped(row) {
-    let offset = 0;
-    let currentRow = row;
-    while (currentRow.previousElementSibling) {
-      offset++;
-      if (currentRow.previousElementSibling.classList.contains(STRIPED_ROW_CLASS)) {
-        return offset % 2 === 0;
-      }
-      currentRow = currentRow.previousElementSibling;
+  setTimeout() {
+    if (this.timeoutHandle != null) {
+      return;
     }
 
-    offset = 0;
-    currentRow = row;
-    while (currentRow.nextElementSibling) {
-      offset++;
-      if (currentRow.nextElementSibling.classList.contains(STRIPED_ROW_CLASS)) {
-        return offset % 2 === 0;
-      }
-      currentRow = currentRow.nextElementSibling;
-    }
-
-    return true;
+    this.timeoutHandle = setTimeout(this.updateStripes.bind(this), 0);
   }
 
-  addStripes(row) {
-    if (this.isStriped(row)) {
-      row.classList.add(STRIPED_ROW_CLASS);
-    } else {
-      row.classList.remove(STRIPED_ROW_CLASS);
-    }
+  updateStripes() {
+    this.timeoutHandle = null;
+
+    const rows = $(`div.ynab-grid-body-row${EXCLUDED_ROW_CLASSES_SELECTOR}`);
+
+    let stripeEvenRows = true;
+    rows.each(function (index) {
+      if (this.classList.contains(STRIPED_ROW_CLASS)) {
+        stripeEvenRows = index % 2 === 0;
+        return false;
+      }
+    });
+
+    rows.each(function (index) {
+      const isEvenRow = index % 2 === 0;
+      if (isEvenRow !== stripeEvenRows && this.classList.contains(STRIPED_ROW_CLASS)) {
+        this.classList.remove(STRIPED_ROW_CLASS);
+      } else if (isEvenRow === stripeEvenRows && !this.classList.contains(STRIPED_ROW_CLASS)) {
+        this.classList.add(STRIPED_ROW_CLASS);
+      }
+    });
   }
 }

--- a/src/extension/features/accounts/striped-rows/index.js
+++ b/src/extension/features/accounts/striped-rows/index.js
@@ -1,19 +1,54 @@
 import { Feature } from 'toolkit/extension/features/feature';
 
+const STRIPED_ROW_CLASS = 'tk-striped-transaction-row';
+
 export class AccountsStripedRows extends Feature {
   injectCSS() {
-    const css = require('./index.css');
-    const defaultThemeColor = ynabToolKit.options.AccountsStripedRowsColor;
-    const darkThemeColor = ynabToolKit.options.AccountsStripedRowsDarkColor;
+    return require('./index.css');
+  }
 
-    let defaultThemePatched = false;
-    const patchedCSS = css.replace(/#[A-Fa-f0-9]{6}/gi, (match) => {
-      if (!defaultThemePatched) {
-        defaultThemePatched = true;
-        return defaultThemeColor || match;
+  shouldInvoke() {
+    return true;
+  }
+
+  invoke() {
+    this.addToolkitEmberHook('register/grid-row', 'didRender', this.addStripes);
+    this.addToolkitEmberHook('register/grid-sub', 'didRender', this.addStripes);
+  }
+
+  destroy() {
+    $(`.${STRIPED_ROW_CLASS}`).removeClass(STRIPED_ROW_CLASS);
+  }
+
+  isStriped(row) {
+    let offset = 0;
+    let currentRow = row;
+    while (currentRow.previousElementSibling) {
+      offset++;
+      if (currentRow.previousElementSibling.classList.contains(STRIPED_ROW_CLASS)) {
+        return offset % 2 === 0;
       }
-      return darkThemeColor || match;
-    });
-    return patchedCSS;
+      currentRow = currentRow.previousElementSibling;
+    }
+
+    offset = 0;
+    currentRow = row;
+    while (currentRow.nextElementSibling) {
+      offset++;
+      if (currentRow.nextElementSibling.classList.contains(STRIPED_ROW_CLASS)) {
+        return offset % 2 === 0;
+      }
+      currentRow = currentRow.nextElementSibling;
+    }
+
+    return true;
+  }
+
+  addStripes(row) {
+    if (this.isStriped(row)) {
+      row.classList.add(STRIPED_ROW_CLASS);
+    } else {
+      row.classList.remove(STRIPED_ROW_CLASS);
+    }
   }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #1490 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The striped rows feature in the account screen was previously entirely CSS, based on whether the row was odd or even. This meant as the row elements were created and destroyed when scrolling, the colour of any single row could alternate. I've rewritten the feature to manually set row colour and base the stripe pattern on any existing rows when scrolling.