### PR TITLE
Add change of net worth per month

### DIFF
--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -58,6 +58,7 @@ export class NetWorthComponent extends React.Component {
                 debts={this.state.hoveredData.debts}
                 debtRatio={this.state.hoveredData.debtRatio}
                 netWorth={this.state.hoveredData.netWorth}
+                changePreviousMonth={this.state.hoveredData.netWorth - (this.state.hoveredData.previousWorth || 0)}
               />
             )}
           </div>
@@ -90,6 +91,7 @@ export class NetWorthComponent extends React.Component {
               debts: debts[this.index],
               debtRatio: debtRatios[this.index],
               netWorth: netWorths[this.index],
+              previousWorth: netWorths[this.index - 1],
             },
           });
         },

--- a/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/components/legend/component.jsx
@@ -40,13 +40,22 @@ export const Legend = (props) => (
         </div>
       </div>
     )}
-    <div className="tk-mg-05 tk-pd-r-1">
+    <div className="tk-mg-05 tk-pd-r-1 tk-border-r">
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-net-worth-legend__icon-net-worths" />
         <div className="tk-mg-l-05">Net Worth</div>
       </div>
       <div>
         <Currency value={props.netWorth} />
+      </div>
+    </div>
+    <div className="tk-mg-05 tk-pd-r-1">
+      <div className="tk-flex tk-mg-b-05 tk-align-items-center">
+        <div className="tk-net-worth-legend__icon-net-worths" />
+        <div className="tk-mg-l-05">Change</div>
+      </div>
+      <div>
+        <Currency value={props.changePreviousMonth} />
       </div>
     </div>
   </React.Fragment>
@@ -56,4 +65,5 @@ Legend.propTypes = {
   assets: PropTypes.number.isRequired,
   debts: PropTypes.number.isRequired,
   netWorth: PropTypes.number.isRequired,
+  changePreviousMonth: PropTypes.number.isRequired
 };


### PR DESCRIPTION
GitHub Issue: #2643

**Explanation of Bugfix/Feature/Modification:**
Add to Toolkit reports the change of net worth compared to the previous month.
