### PR TITLE
:lipstick: feat: add system dark mode to settings page

### DIFF
--- a/src/core/options/index.tsx
+++ b/src/core/options/index.tsx
@@ -8,8 +8,8 @@ import { getUserSettings } from '../settings';
 getUserSettings().then(() => {
   localToolkitStorage.getStorageItem('toolkit-feature:options.dark-mode').then((darkMode) => {
     // backwards compatible migration from on/off dark mode
-    if (typeof darkMode == 'boolean' && darkMode) {
-      darkMode = 'dark';
+    if (typeof darkMode == 'boolean') {
+      darkMode = darkMode ? 'dark' : 'light';
     }
 
     document.querySelector('html').dataset['theme'] = darkMode;

--- a/src/core/options/index.tsx
+++ b/src/core/options/index.tsx
@@ -6,13 +6,14 @@ import { localToolkitStorage } from '../common/storage';
 import { getUserSettings } from '../settings';
 
 getUserSettings().then(() => {
-  localToolkitStorage
-    .getStorageItem('toolkit-feature:options.dark-mode')
-    .then((isDarkModeEnabled) => {
-      if (isDarkModeEnabled) {
-        document.querySelector('html').dataset['theme'] = 'dark';
-      }
+  localToolkitStorage.getStorageItem('toolkit-feature:options.dark-mode').then((darkMode) => {
+    // backwards compatible migration from on/off dark mode
+    if (typeof darkMode == 'boolean' && darkMode) {
+      darkMode = 'dark';
+    }
 
-      ReactDOM.render(<ToolkitOptions />, document.getElementById('root'));
-    });
+    document.querySelector('html').dataset['theme'] = darkMode;
+
+    ReactDOM.render(<ToolkitOptions />, document.getElementById('root'));
+  });
 });

--- a/src/core/options/toolkit-options/component.tsx
+++ b/src/core/options/toolkit-options/component.tsx
@@ -10,6 +10,7 @@ import {
   faEyeDropper,
   faUndoAlt,
   faTimes,
+  faSlash,
 } from '@fortawesome/free-solid-svg-icons';
 import { Toggle } from 'toolkit/components/toggle';
 import { RadioGroup } from 'toolkit/components/radio-group';
@@ -167,36 +168,41 @@ function SettingsList({ settings }: { settings: FeatureSettingConfig[] }) {
 }
 
 function DarkModeToggle() {
-  const [isDarkModeEnabled, setIsDarkModeEnabled] = React.useState(
-    document.querySelector('html').dataset['theme'] === 'dark'
+  // default is light mode
+  // toggle goes light -> dark -> auto -> light ....
+
+  const [darkMode, setDarkMode] = React.useState(
+    document.querySelector('html').dataset['theme'] || 'light'
   );
 
-  function handleDarkModeClicked() {
-    localToolkitStorage
-      .setStorageItem('toolkit-feature:options.dark-mode', !isDarkModeEnabled)
-      .then(() => {
-        setIsDarkModeEnabled(!isDarkModeEnabled);
-      });
+  function setMode(mode: string) {
+    localToolkitStorage.setStorageItem('toolkit-feature:options.dark-mode', mode).then(() => {
+      setDarkMode(mode);
+    });
   }
 
   return (
-    <div className="dark-mode-toggle nav-bar__action-icon" onClick={handleDarkModeClicked}>
+    <div className="dark-mode-toggle nav-bar__action-icon">
       <FontAwesomeIcon
-        className={classNames('dark-mode-toggle__icon', {
-          'dark-mode-toggle__icon--active': isDarkModeEnabled,
-        })}
-        icon={faMoon}
-        size="lg"
-      />
-      <FontAwesomeIcon
-        className={classNames('dark-mode-toggle__icon', {
-          'dark-mode-toggle__icon--active': !isDarkModeEnabled,
-        })}
+        className={classNames({ active: darkMode == 'light' })}
         icon={faSun}
         size="lg"
-        onClick={() => setIsDarkModeEnabled(true)}
-        title="Toggle Dark Mode"
+        onClick={() => setMode('dark')}
       />
+      <FontAwesomeIcon
+        className={classNames({ active: darkMode == 'dark' })}
+        icon={faMoon}
+        size="lg"
+        onClick={() => setMode('auto')}
+      />
+      <span
+        onClick={() => setMode('light')}
+        className={classNames('fa-layers', 'fa-lg', { active: darkMode == 'auto' })}
+      >
+        <FontAwesomeIcon icon={faSun} transform="shrink-6 up-4 right-8" />
+        <FontAwesomeIcon icon={faSlash} transform="shrink-2" />
+        <FontAwesomeIcon icon={faMoon} transform="shrink-8 down-3 left-3" />
+      </span>
     </div>
   );
 }

--- a/src/core/options/toolkit-options/styles.scss
+++ b/src/core/options/toolkit-options/styles.scss
@@ -28,7 +28,7 @@
   --tk-alert-danger: #e26136;
 }
 
-html[data-theme='dark'] {
+@mixin dark-mode {
   // base colors
   --tk-text-color: #f1f1f1;
   --tk-header-color: #1b1b1d;
@@ -65,6 +65,16 @@ html[data-theme='dark'] {
       }
     }
   }
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-theme='auto'] {
+    @include dark-mode();
+  }
+}
+
+html[data-theme='dark'] {
+  @include dark-mode();
 }
 
 body {
@@ -234,16 +244,20 @@ body {
 
 .dark-mode-toggle {
   position: relative;
+  height: 24px;
+  width: 24px;
 
-  &__icon {
+  > * {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
     opacity: 0;
     transition: opacity 200ms ease-out;
 
-    &--active {
-      position: absolute;
-      left: 0;
-      top: 0;
+    &.active {
       opacity: 1;
+      pointer-events: unset;
     }
   }
 }

--- a/src/core/popup/index.tsx
+++ b/src/core/popup/index.tsx
@@ -3,12 +3,13 @@ import * as ReactDOM from 'react-dom';
 import { localToolkitStorage } from 'toolkit/core/common/storage';
 import { ToolkitPopup } from './toolkit-popup';
 
-localToolkitStorage
-  .getStorageItem('toolkit-feature:options.dark-mode')
-  .then((isDarkModeEnabled) => {
-    if (isDarkModeEnabled) {
-      document.querySelector('html').dataset['theme'] = 'dark';
-    }
+localToolkitStorage.getStorageItem('toolkit-feature:options.dark-mode').then((darkMode) => {
+  // backwards compatible migration from on/off dark mode
+  if (typeof darkMode == 'boolean' && darkMode) {
+    darkMode = 'dark';
+  }
 
-    ReactDOM.render(<ToolkitPopup />, document.getElementById('root'));
-  });
+  document.querySelector('html').dataset['theme'] = darkMode;
+
+  ReactDOM.render(<ToolkitPopup />, document.getElementById('root'));
+});

--- a/src/core/popup/index.tsx
+++ b/src/core/popup/index.tsx
@@ -5,8 +5,8 @@ import { ToolkitPopup } from './toolkit-popup';
 
 localToolkitStorage.getStorageItem('toolkit-feature:options.dark-mode').then((darkMode) => {
   // backwards compatible migration from on/off dark mode
-  if (typeof darkMode == 'boolean' && darkMode) {
-    darkMode = 'dark';
+  if (typeof darkMode == 'boolean') {
+    darkMode = darkMode ? 'dark' : 'light';
   }
 
   document.querySelector('html').dataset['theme'] = darkMode;

--- a/src/core/popup/toolkit-popup/styles.scss
+++ b/src/core/popup/toolkit-popup/styles.scss
@@ -16,7 +16,7 @@
   --tk-button-primary-hover-color: var(--tk-action-primary-hover);
 }
 
-html[data-theme='dark'] {
+@mixin dark-mode {
   // base colors
   --tk-text-color: #f1f1f1;
   --tk-background-color: #232325;
@@ -30,6 +30,16 @@ html[data-theme='dark'] {
     -webkit-filter: invert(1) hue-rotate(180deg) brightness(1.2);
     filter: invert(1) hue-rotate(180deg) brightness(1.2);
   }
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-theme='auto'] {
+    @include dark-mode();
+  }
+}
+
+html[data-theme='dark'] {
+  @include dark-mode();
 }
 
 .logo {

--- a/src/hooks/useDarkModeSetter.tsx
+++ b/src/hooks/useDarkModeSetter.tsx
@@ -2,12 +2,8 @@ import * as React from 'react';
 import { localToolkitStorage } from 'toolkit/core/common/storage';
 
 export function useDarkModeSetter() {
-  function handleDarkModeChanged(_: string, newDarkMode: boolean) {
-    if (newDarkMode) {
-      document.querySelector('html').dataset['theme'] = 'dark';
-    } else {
-      document.querySelector('html').dataset['theme'] = '';
-    }
+  function handleDarkModeChanged(_: string, newDarkMode: string) {
+    document.querySelector('html').dataset['theme'] = newDarkMode;
   }
 
   React.useEffect(() => {


### PR DESCRIPTION
GitHub Issue (if applicable): #2742

**Explanation of Bugfix/Feature/Modification:**
1. Add icon to day/night toggle that indicates auto (day and night with a \)
2. Update styles for the toggle to support icon while maintaining animation without common double click bug
3. Add backwards compatible state reader to toggle between "light", "dark" and "auto" themes
4. Move dark theme to a mixin and support it on both dark modes as well as auto if the user's system is set to dark mode\

This does not:
1. Change the default setting from "light"
2. Break existing users settings
