### PR TITLE
Fix calendar shifts when First day of the week is enabled ( #2761)

### DIFF
--- a/src/extension/features/accounts/calendar-first-day/index.js
+++ b/src/extension/features/accounts/calendar-first-day/index.js
@@ -3,13 +3,13 @@ import { Feature } from 'toolkit/extension/features/feature';
 export class CalendarFirstDay extends Feature {
   invoke() {
     this.onElement('.modal-account-calendar', this.adjustDays, {
-      guard: '.modal-account-calendar[data-tk-shifted]',
+      guard: '.accounts-calendar-grid[data-tk-shifted]',
     });
   }
 
   observe() {
     this.onElement('.modal-account-calendar', this.adjustDays, {
-      guard: '.modal-account-calendar[data-tk-shifted]',
+      guard: '.accounts-calendar-grid[data-tk-shifted]',
     });
   }
 
@@ -25,6 +25,6 @@ export class CalendarFirstDay extends Feature {
       $('.accounts-calendar-grid', element).prepend($('<li class="accounts-calendar-empty"></li>'));
     }
 
-    element.dataset.tkShifted = true;
+    $('.accounts-calendar-grid', element).dataset.tkShifted = true;
   }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2761

**Explanation of Bugfix/Feature/Modification:**
I modified where the `tkShifted` data attribute is added to allow the guard supplied to the `onElement` method to work since the `querySelector` will return null if the attribute is in the same element where we are querying.
