### PR TITLE
Enable DisplayTargetGoalAmount feature (#2747)

### DIFF
--- a/src/extension/features/budget/display-target-goal-amount/index.js
+++ b/src/extension/features/budget/display-target-goal-amount/index.js
@@ -28,7 +28,15 @@ export class DisplayTargetGoalAmount extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('budget-table-row', 'didRender', this.addTargetGoalAmount);
+    this.onElements('.budget-table-row', this.addTargetGoalAmount, {
+      guard: '.tk-target-goal-amount',
+    });
+  }
+
+  observe() {
+    this.onElements('.budget-table-row', this.addTargetGoalAmount, {
+      guard: '.tk-target-goal-amount',
+    });
   }
 
   destroy() {

--- a/src/extension/features/budget/display-target-goal-amount/settings.js
+++ b/src/extension/features/budget/display-target-goal-amount/settings.js
@@ -1,5 +1,4 @@
 module.exports = {
-  disabled: true,
   name: 'DisplayTargetGoalAmount',
   type: 'select',
   default: false,


### PR DESCRIPTION
Hi!

Thanks a lot for the quick fix to the issue with the current version of YNAB (as referenced in #2747)!

I really rely on a couple of features that have been disabled and I took the liberty to make them work without the addToolkitEmberHook method. I did not modify anything other than the call to add the hook to ensure that nothing else changes.

This one reenables the Display Target Goal feature.

Let me know if there is anything you think I should modify and you think it is worth it to re-enable them since I imagine that, eventually, a different way of handling this might be developed.

Thanks!