### PR TITLE
fix: Hide Edit Account Button feature

### DIFF
--- a/src/extension/features/general/edit-account-button/hide.css
+++ b/src/extension/features/general/edit-account-button/hide.css
@@ -1,4 +1,4 @@
-.nav-accounts svg.ember-view.edit {
+.nav-accounts svg.ynab-new-icon.edit {
   visibility: hidden;
 }
 


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
The selector used for the edit account icon must have changed in a recent YNAB update. This fixes the **Hide Edit Account Button** feature.