### PR TITLE
fix:  Fix saving transactions on enter (#2744)

### DIFF
--- a/src/extension/features/accounts/change-enter-behavior/index.js
+++ b/src/extension/features/accounts/change-enter-behavior/index.js
@@ -35,8 +35,9 @@ export class ChangeEnterBehavior extends Feature {
       event.preventDefault();
       event.stopPropagation();
 
-      // Remove focus to the input so ynab can apply value
-      $(this).trigger('blur');
+      // Trigger a down arrow keypress so YNAB can apply the value
+      const downArrowKeyPress = jQuery.Event('keydown', { keyCode: 40 });
+      $(this).trigger(downArrowKeyPress);
 
       // Added to support CtrlEnterCleared when ChangeEnterBehavior is enabled
       if (ynabToolKit.options.CtrlEnterCleared === true && (event.metaKey || event.ctrlKey)) {


### PR DESCRIPTION
GitHub Issue: #2744

**Explanation of Bugfix/Feature/Modification:**
This fixes both the original bug, along with the comment by @Numex106 described in the issue. Currently, these are how you can reproduce them.

1. While adding a new transaction, if you don't tab through each input and instead manually click on an Outflow/Inflow input, skipping the Memo completely, the value will not be saved after pressing `Enter`
2. While editing a transaction, if you do anything more than double-click an Outflow/Input value, (remove the entire value before adding a new one, use arrow keys to adjust a number, click additionally while the value is selected) the previous value will be kept after pressing `Enter`

The bug stems from the input value not being formatted by YNAB before saving. A fix was initially introduced in #2695 that removed focus from the input element. While triggering a blur event to remove focus works in some cases, the proposed solution is to instead trigger a down arrow keypress to allow YNAB to format the value.

This PR also relates to #2688 and may assist others who are having issues with this feature.