### PR TITLE
fix: CSS selector for Update Enlarge Small Icons feature

### DIFF
--- a/src/extension/features/accounts/larger-cleared-icons/index.css
+++ b/src/extension/features/accounts/larger-cleared-icons/index.css
@@ -1,4 +1,4 @@
-.ynab-grid-body-row .ynab-grid-cell-cleared .svg-icon {
+.ynab-grid-body-row .ynab-grid-cell-cleared .ynab-new-icon {
   width: 100%;
   height: 22px;
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2781 

**Explanation of Bugfix/Feature/Modification:**
Updates the selector to use the `ynab-new-icon` class that was recently introduced to YNAB.