### PR TITLE
#2785 observe budget table

### DIFF
--- a/src/extension/features/budget/filter-categories/index.jsx
+++ b/src/extension/features/budget/filter-categories/index.jsx
@@ -89,7 +89,30 @@ export class FilterCategories extends Feature {
     });
   };
 
-  handleTableRender = () => {
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    let budgetClasses = [
+      'budget-table-row js-budget-table-row is-sub-category budget-table-last-row',
+      'budget-header-flexbox',
+      'budget-header-item budget-header-days tk-days-of-buffering',
+      'budget-header-days-age',
+      'budget-table-cell-activity budget-table-cell-flexed tk-activity-upcoming',
+      'budget-table-cell-collapse',
+    ];
+
+    let found = false;
+    for (let i = 0; i < budgetClasses.length; i++) {
+      if (changedNodes.has(budgetClasses[i])) {
+        found = true;
+      }
+    }
+    if (found) {
+      this.invoke();
+    }
+  }
+
+  handleTableRender = (e) => {
     if (document.querySelector('#tk-categories-filter') === null) {
       componentPrepend(
         <CategorySearchInput applySearch={this.applySearch} />,

--- a/src/extension/utils/ember.js
+++ b/src/extension/utils/ember.js
@@ -33,6 +33,10 @@ export function forEachRenderedComponent(key, fn) {
 
 export function containerLookup(containerName) {
   let container;
+
+  if (__ynabapp__.__container__?.cache[containerName]) {
+    return __ynabapp__.__container__?.cache[containerName];
+  }
   try {
     container = __ynabapp__.__container__.lookup(containerName, { instantiate: false });
   } catch (e) {
@@ -43,5 +47,6 @@ export function containerLookup(containerName) {
 }
 
 export function getViewRegistry() {
-  return __ynabapp__.__container__.lookup('-view-registry:main');
+  var containerName = '-view-registry:main';
+  return __ynabapp__.__container__.lookup(containerName, { instantiate: false });
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2785

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
This change modifies the behavior of `containerLookup()` to check the cache first, then do a look up without instantiating. If that fails, we pretty much just cause a crash(?)

Then also uses an observe to invoke the feature when the table is re-rendered, instead of using the Ember hook. The Ember hook seems to be failing because the Ember object lifecycle is immediately ended (the destroy events are triggered before we even get our hands on the object properly), and isn't re-attached to the new object.