### PR TITLE
#2794 add variable background color to button

### DIFF
--- a/src/extension/features/budget/collapse-inspector/index.css
+++ b/src/extension/features/budget/collapse-inspector/index.css
@@ -9,12 +9,16 @@
   position: relative;
   left: 7px;
   margin: 0px;
+  background: var(--sidebar_background);
+  border-radius: 4px;
 }
 
 .tk-collapse-inspector .sidebar-collapse {
   position: relative;
   left: -5px;
   margin: 0px;
+  background: var(--sidebar_background);
+  border-radius: 4px;
 }
 
 .budget-inspector[tk-collapse-inspector] {


### PR DESCRIPTION
GitHub Issue (if applicable): #2794


**Explanation of Bugfix/Feature/Modification:**
The button is near invisible unless you use the dark mode in YNAB, because it uses the `--sidebar_label_primary` variable which is white.
This change adds a background color based on `--sidebar_background`, which should always contrast nicely with the label.

![image](https://user-images.githubusercontent.com/1075598/173763097-8dbd6682-b0d8-43a5-a4b3-d95ff9c17307.png)

