### PR TITLE
#2793 hook different class for confetti

### DIFF
--- a/src/extension/features/accounts/reconcile-confetti/index.js
+++ b/src/extension/features/accounts/reconcile-confetti/index.js
@@ -13,13 +13,17 @@ export class ReconcileConfetti extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (changedNodes.has(RECONCILE_SUCCESS_MODAL_CLASS)) {
+    if (changedNodes.has('ynab-grid-body')) {
       this.throwConfetti();
     }
   }
 
   throwConfetti() {
-    const container = $(`.${RECONCILE_SUCCESS_MODAL_CLASS}`).parent();
+    const container = $(`.${RECONCILE_SUCCESS_MODAL_CLASS}`);
+    if (container.length === 0) {
+      return;
+    }
+    const parentNode = container.parent();
     for (let i = 0; i < NUM_CONFETTI; i++) {
       const xPos = Math.random() * 300 - 150;
       const yPos = Math.random() * 150 - 150;
@@ -31,7 +35,7 @@ export class ReconcileConfetti extends Feature {
       e.style.cssText = `transform: translate3d(${xPos}px, ${yPos}px, 0) rotate(${rot}deg);
         background: hsla(${color}, 100%, 50%, 1.0);
         animation: confetti 800ms cubic-bezier(.15, .75, .50, 1) forwards, falldown 400ms ease-in 600ms forwards;`;
-      container.append(e);
+      parentNode.append(e);
     }
   }
 


### PR DESCRIPTION
GitHub Issue (if applicable): #2793

**Explanation of Bugfix/Feature/Modification:**
The mutation observer changedNodes list no longer contains the modal node for the confetti to trigger on. Swapped this to `ynab-grid-body`, with a check to see if the reconciled modal does exist. 

This does cause it to check for this reconciled node every time the grid is updated (with confetti active), so a solution to get this modal back in the MO would be better, but I can't imagine that a computer that can render 100 animated confetti nodes would have any noticeable side effects from just checking that jQuery selector.