### PR TITLE
fix(auto-mark-as-cleared): Update selector

### DIFF
--- a/src/extension/features/accounts/auto-mark-as-cleared/index.js
+++ b/src/extension/features/accounts/auto-mark-as-cleared/index.js
@@ -6,20 +6,23 @@ export class AutomaticallyMarkAsCleared extends Feature {
     return isCurrentRouteAccountsPage();
   }
 
-  observe(changedNodes) {
-    if (!changedNodes.has('ynab-grid-cell js-ynab-grid-cell ynab-grid-cell-accountName user-data'))
-      return;
+  invoke() {
+    let eventKeys = ['register/grid-edit', 'register/grid-split'];
 
-    if (this.shouldInvoke()) {
-      this.invoke();
-    }
+    eventKeys.forEach((key) => {
+      this.addToolkitEmberHook(key, 'didInsertElement', (element) => this.triggerCleared(element));
+    });
+
+    // Calling click at DOM node and not jQuery because jQuery sometimes doesn't work properly
   }
 
-  invoke() {
-    // Calling click at DOM node and not jQuery because jQuery sometimes doesn't work properly
-    let $markClearedButton = $('.ember-view .ynab-cleared:not(.is-cleared)');
-    if ($markClearedButton.length !== 0) {
-      $markClearedButton[0].click();
+  triggerCleared(element) {
+    const $buttons = $(element).children('.ynab-grid-cell-cleared').children('button');
+    if ($buttons.length !== 0) {
+      if ($($buttons[0]).hasClass('is-cleared')) {
+        return;
+      }
+      $buttons[0].click();
     }
   }
 }

--- a/src/extension/features/accounts/auto-mark-as-cleared/index.js
+++ b/src/extension/features/accounts/auto-mark-as-cleared/index.js
@@ -17,7 +17,7 @@ export class AutomaticallyMarkAsCleared extends Feature {
 
   invoke() {
     // Calling click at DOM node and not jQuery because jQuery sometimes doesn't work properly
-    let $markClearedButton = $('.is-adding .ynab-cleared:not(.is-cleared)');
+    let $markClearedButton = $('.ember-view .ynab-cleared:not(.is-cleared)');
     if ($markClearedButton.length !== 0) {
       $markClearedButton[0].click();
     }


### PR DESCRIPTION
GitHub Issue (if applicable): #2799

Trello Link (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
YNAB recently changed the classes and that broke this feature. Fix is to
update the selector utilized in the invoke function to keep up to date
with the current CSS classes of the cleared button.

Closes #2799
