### PR TITLE
fix: Update Transfer category colors

### DIFF
--- a/src/extension/features/accounts/reconciled-text-color/darkgray.css
+++ b/src/extension/features/accounts/reconciled-text-color/darkgray.css
@@ -16,3 +16,7 @@ body.theme-dark {
 .tk-is-reconciled .ynab-grid-cell-payeeName svg rect {
   fill: var(--tk-reconciled-font-color);
 }
+
+.tk-is-reconciled .ynab-grid-cell-subCategoryName .category-not-needed {
+  color: var(--tk-reconciled-font-color) !important;
+}

--- a/src/extension/features/accounts/reconciled-text-color/darkgraybg.css
+++ b/src/extension/features/accounts/reconciled-text-color/darkgraybg.css
@@ -19,3 +19,7 @@ body.theme-dark {
 .tk-is-reconciled .ynab-grid-cell-payeeName svg rect {
   fill: var(--tk-reconciled-font-color);
 }
+
+.tk-is-reconciled .ynab-grid-cell-subCategoryName .category-not-needed {
+  color: var(--tk-reconciled-font-color) !important;
+}

--- a/src/extension/features/accounts/reconciled-text-color/green.css
+++ b/src/extension/features/accounts/reconciled-text-color/green.css
@@ -5,3 +5,7 @@
 .tk-is-reconciled .ynab-grid-cell-payeeName svg rect {
   fill: #00661d;
 }
+
+.tk-is-reconciled .ynab-grid-cell-subCategoryName .category-not-needed {
+  color: var(--tk-reconciled-font-color) !important;
+}

--- a/src/extension/features/accounts/reconciled-text-color/lightgray.css
+++ b/src/extension/features/accounts/reconciled-text-color/lightgray.css
@@ -16,3 +16,7 @@ body.theme-dark {
 .tk-is-reconciled .ynab-grid-cell-payeeName svg rect {
   fill: var(--tk-reconciled-font-color);
 }
+
+.tk-is-reconciled .ynab-grid-cell-subCategoryName .category-not-needed {
+  color: var(--tk-reconciled-font-color) !important;
+}


### PR DESCRIPTION
GitHub Issue (if applicable): #2780

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Override Transfer category text colors to match the rest of the reconciled transaction colors.

Fixes #2780