### PR TITLE
fix(pacing): Improve Pacing Column Styling

### DIFF
--- a/src/extension/features/budget/pacing/index.css
+++ b/src/extension/features/budget/pacing/index.css
@@ -1,6 +1,6 @@
 .tk-budget-table-cell-pacing {
-  width: 15%;
-  justify-content: flex-end !important;
+  width: 9%;
+  justify-content: center !important;
   padding: 0 0 0 1rem !important;
   text-align: right !important;
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2680

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Improve the styling of the pacing column and remove the large amount of
whitespace on the left side of the pacing column.

Fixes #2680
