### PR TITLE
Outflow over time

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
@@ -5,6 +5,7 @@ import { IncomeVsExpense } from 'toolkit-reports/pages/income-vs-expense';
 import { NetWorth } from 'toolkit-reports/pages/net-worth';
 import { InflowOutflow } from 'toolkit-reports/pages/inflow-outflow';
 import { BalanceOverTime } from 'toolkit-reports/pages/balance-over-time';
+import { OutflowOverTime } from 'toolkit-reports/pages/outflow-over-time';
 import { SpendingByPayee } from 'toolkit-reports/pages/spending-by-payee';
 import { SpendingByCategory } from 'toolkit-reports/pages/spending-by-category';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
@@ -42,6 +43,14 @@ const REPORT_COMPONENTS = [
   {
     component: BalanceOverTime,
     key: ReportKeys.BalanceOverTime,
+    filterSettings: {
+      disableCategoryFilter: true,
+      includeTrackingAccounts: true,
+    },
+  },
+  {
+    component: OutflowOverTime,
+    key: ReportKeys.OutflowOverTime,
     filterSettings: {
       disableCategoryFilter: true,
       includeTrackingAccounts: true,

--- a/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
@@ -52,7 +52,7 @@ const REPORT_COMPONENTS = [
     component: OutflowOverTime,
     key: ReportKeys.OutflowOverTime,
     filterSettings: {
-      disableCategoryFilter: true,
+      disableCategoryFilter: false,
       includeTrackingAccounts: true,
     },
   },

--- a/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.jsx
@@ -52,7 +52,7 @@ const REPORT_COMPONENTS = [
     component: OutflowOverTime,
     key: ReportKeys.OutflowOverTime,
     filterSettings: {
-      disableCategoryFilter: false,
+      disableCategoryFilter: true,
       includeTrackingAccounts: true,
     },
   },

--- a/src/extension/features/toolkit-reports/common/constants/report-types.js
+++ b/src/extension/features/toolkit-reports/common/constants/report-types.js
@@ -6,6 +6,7 @@ export const ReportKeys = {
   IncomeVsExpense: 'income-vs-expense',
   IncomeBreakdown: 'income-breakdown',
   BalanceOverTime: 'balance-over-time',
+  OutflowOverTime: 'outflow-over-time',
   Forecast: 'forecast',
 };
 
@@ -17,6 +18,7 @@ export const ReportNames = {
   IncomeVsExpense: 'Income vs. Expense',
   IncomeBreakdown: 'Income Breakdown',
   BalanceOverTime: 'Balance Over Time',
+  OutflowOverTime: 'Outflow Over Time',
   Forecast: 'Forecast',
 };
 
@@ -48,6 +50,10 @@ export const REPORT_TYPES = [
   {
     key: ReportKeys.BalanceOverTime,
     name: ReportNames.BalanceOverTime,
+  },
+  {
+    key: ReportKeys.OutflowOverTime,
+    name: ReportNames.OutflowOverTime,
   },
   {
     key: ReportKeys.Forecast,

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowGraph.jsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowGraph.jsx
@@ -1,0 +1,105 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { showTransactionModal } from 'toolkit-reports/utils/show-transaction-modal';
+import Highcharts from 'highcharts';
+import { formatCurrency } from 'toolkit/extension/utils/currency';
+
+export const OutflowGraph = ({ series }) => {
+  const GRAPH_ID = 'tk-outflow-over-time-report-graph';
+
+  useEffect(() => {
+    let textColor = 'var(--label_primary)';
+    Highcharts.chart(GRAPH_ID, {
+      title: {
+        text: 'Outflow Over Time',
+        style: { color: textColor },
+      },
+      series: series,
+      yAxis: {
+        title: {
+          text: 'Balance',
+          style: { color: textColor },
+        },
+        labels: {
+          formatter: (e) => {
+            return formatCurrency(e.value, false);
+          },
+          style: { color: textColor },
+        },
+      },
+      chart: {
+        backgroundColor: 'transparent',
+      },
+      xAxis: {
+        title: {
+          text: 'Date',
+          style: { color: textColor },
+        },
+        type: 'linear',
+        min: 1,
+        max: 31,
+        labels: {
+          style: { color: textColor },
+        },
+      },
+      legend: {
+        layout: 'vertical',
+        align: 'right',
+        verticalAlign: 'middle',
+        itemStyle: {
+          color: textColor,
+        },
+      },
+      tooltip: {
+        useHTML: true,
+        pointFormatter: function () {
+          let coloredPoint = `<span style="color:${this.color}">\u25CF</span>`;
+          let totalAmount = formatCurrency(this.y, false);
+          return `${coloredPoint} ${this.series.name}: <b>${totalAmount}</b><br/>`;
+        },
+      },
+      plotOptions: {
+        line: {
+          marker: { enabled: false },
+        },
+        series: {
+          cursor: 'pointer',
+          events: {
+            click: (event) => {
+              if (event.point.transactions && event.point.transactions.length > 0) {
+                let date = new Date(event.point.x);
+                let formattedDate = ynab.YNABSharedLib.dateFormatter.formatDate(date);
+                showTransactionModal(formattedDate, event.point.transactions);
+              }
+            },
+          },
+          states: {
+            inactive: {
+              enabled: false,
+            },
+          },
+        },
+      },
+      responsive: {
+        rules: [
+          {
+            condition: { maxWidth: 500 },
+            chartOptions: {
+              legend: {
+                layout: 'horizontal',
+                align: 'center',
+                verticalAlign: 'bottom',
+              },
+            },
+          },
+        ],
+      },
+    });
+  }, [series]);
+
+  return <div className="tk-highcharts-report-container" id={GRAPH_ID} />;
+};
+
+OutflowGraph.propTypes = {
+  series: PropTypes.array.isRequired,
+};

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.jsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { FiltersPropType } from 'toolkit-reports/common/components/report-context/component';
+import {
+  calculateCumulativeOutflowPerDate,
+  filterTransactions,
+  groupTransactions,
+  toHighchartsSeries,
+} from './utils';
+import { OutflowGraph } from './OutflowGraph';
+
+export const OutflowOverTimeComponent = ({ allReportableTransactions, filters }) => {
+  const [outflowSeries, setOutflowSeries] = useState([]);
+
+  useEffect(() => {
+    const filterOutAccounts = filters.accountFilterIds;
+    setOutflowSeries(
+      toHighchartsSeries(
+        calculateCumulativeOutflowPerDate(
+          groupTransactions(filterTransactions(allReportableTransactions, filterOutAccounts))
+        )
+      )
+    );
+  }, [allReportableTransactions, filters]);
+
+  return <OutflowGraph series={outflowSeries} />;
+};
+
+OutflowOverTimeComponent.propTypes = {
+  filters: PropTypes.shape(FiltersPropType).isRequired,
+  allReportableTransactions: PropTypes.array.isRequired,
+};

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.jsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.jsx
@@ -3,27 +3,52 @@ import PropTypes from 'prop-types';
 import { FiltersPropType } from 'toolkit-reports/common/components/report-context/component';
 import {
   calculateCumulativeOutflowPerDate,
+  calculateOutflowPerDate,
   filterTransactions,
   groupTransactions,
   toHighchartsSeries,
 } from './utils';
 import { OutflowGraph } from './OutflowGraph';
+import { useLocalStorage } from 'toolkit/extension/hooks/useLocalStorage';
+import { LabeledCheckbox } from 'toolkit/extension/features/toolkit-reports/common/components/labeled-checkbox';
 
 export const OutflowOverTimeComponent = ({ allReportableTransactions, filters }) => {
   const [outflowSeries, setOutflowSeries] = useState([]);
+  const [cumulativeSum, setCumulativeSum] = useLocalStorage(
+    'outflow-over-time-useCumulativeSum',
+    true
+  );
 
   useEffect(() => {
     const filterOutAccounts = filters.accountFilterIds;
+    const calculateOutflow = cumulativeSum
+      ? calculateCumulativeOutflowPerDate
+      : calculateOutflowPerDate;
+
     setOutflowSeries(
       toHighchartsSeries(
-        calculateCumulativeOutflowPerDate(
+        calculateOutflow(
           groupTransactions(filterTransactions(allReportableTransactions, filterOutAccounts))
         )
       )
     );
-  }, [allReportableTransactions, filters]);
+  }, [allReportableTransactions, filters, cumulativeSum]);
 
-  return <OutflowGraph series={outflowSeries} />;
+  return (
+    <div className="tk-flex tk-flex-column tk-flex-grow">
+      <div className="tk-flex tk-pd-05 tk-border-b">
+        <div className="tk-pd-x-1">
+          <LabeledCheckbox
+            id="tk-balance-over-time-stepgraph-option"
+            checked={cumulativeSum}
+            label="Cumulative sum"
+            onChange={() => setCumulativeSum(!cumulativeSum)}
+          />
+        </div>
+      </div>
+      <OutflowGraph series={outflowSeries} />
+    </div>
+  );
 };
 
 OutflowOverTimeComponent.propTypes = {

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/container.js
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/container.js
@@ -1,0 +1,10 @@
+import { withReportContext } from 'toolkit-reports/common/components/report-context';
+import { OutflowOverTimeComponent } from './OutflowOverTime';
+
+const mapReportContextToProps = (context) => {
+  return {
+    filters: context.filters,
+    allReportableTransactions: context.allReportableTransactions,
+  };
+};
+export const OutflowOverTime = withReportContext(mapReportContextToProps)(OutflowOverTimeComponent);

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/index.js
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/index.js
@@ -1,0 +1,1 @@
+export * from './container';

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.js
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.js
@@ -1,0 +1,69 @@
+import lodash from 'lodash';
+
+export const filterTransactions = (transactions, filterOutAccounts) => {
+  return transactions
+    .filter((transaction) => {
+      return (
+        transaction.outflow !== undefined &&
+        transaction.outflow !== 0 &&
+        (transaction.inflow === undefined || transaction.inflow === 0)
+      );
+    })
+    .filter((transactionsWithoutInflow) => {
+      return !filterOutAccounts.has(transactionsWithoutInflow.accountId);
+    });
+};
+
+export const groupTransactions = (transactions) => {
+  const groupedByMonth = lodash.groupBy(transactions, 'month');
+  const groupedByMonthAndDate = {};
+
+  Object.keys(groupedByMonth).forEach((key) => {
+    groupedByMonthAndDate[key] = lodash.groupBy(groupedByMonth[key], (transaction) =>
+      transaction.date.toUTCMoment().date()
+    );
+  });
+
+  return groupedByMonthAndDate;
+};
+
+export const calculateOutflowPerDate = (transactions) => {
+  return lodash.mapValues(transactions, (monthData) => {
+    return lodash.mapValues(monthData, (dateData) => {
+      return dateData.reduce((s, a) => s + a.outflow, 0);
+    });
+  });
+};
+
+export const calculateCumulativeOutflowPerDate = (transactions) => {
+  return lodash.mapValues(calculateOutflowPerDate(transactions), (monthData) => {
+    const pairs = lodash.toPairs(monthData);
+    const dates = pairs.map((d) => d[0]);
+    const outflows = pairs.map((d) => d[1]);
+    const cumulativeSum = lodash.reduce(
+      outflows,
+      (acc, n) => {
+        acc.push((acc.length > 0 ? acc[acc.length - 1] : 0) + n);
+        return acc;
+      },
+      []
+    );
+    return Object.fromEntries(lodash.zip(dates, cumulativeSum));
+  });
+};
+
+export const toHighchartsSeries = (transactions) => {
+  return lodash.toPairs(transactions).map((monthData) => {
+    const [month, data] = monthData;
+    return {
+      name: month,
+      data: lodash.toPairs(data).map((dateData) => {
+        const [date, amount] = dateData;
+        return {
+          x: parseInt(date),
+          y: amount,
+        };
+      }),
+    };
+  });
+};

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.test.js
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.test.js
@@ -1,0 +1,212 @@
+import {
+  filterTransactions,
+  groupTransactions,
+  calculateOutflowPerDate,
+  calculateCumulativeOutflowPerDate,
+  toHighchartsSeries,
+} from './utils';
+import moment from 'moment';
+
+describe('Utils', () => {
+  describe('filterTransactions', () => {
+    it('should do nothing, when there is nothing to be done', () => {
+      expect(filterTransactions([])).toEqual([]);
+    });
+
+    it('should filter out inflow transactions', () => {
+      const transactions = [{ outflow: 1 }, { inflow: 2 }, { outflow: 3 }];
+      const expected = [{ outflow: 1 }, { outflow: 3 }];
+      expect(filterTransactions(transactions, new Set())).toEqual(expected);
+    });
+
+    it('should filter out transactions to filtered accounts', () => {
+      const transactions = [
+        { outflow: 1, accountId: 1 },
+        { outflow: 2, accountId: 2 },
+        { outflow: 3, accountId: 3 },
+      ];
+      const expected = [{ outflow: 2, accountId: 2 }];
+      const filteredAccounts = new Set();
+      filteredAccounts.add(1);
+      filteredAccounts.add(3);
+      expect(filterTransactions(transactions, filteredAccounts)).toEqual(expected);
+    });
+  });
+
+  describe('groupTransactions', () => {
+    it('should do nothing, when there is nothing to be done', () => {
+      expect(groupTransactions([])).toEqual({});
+    });
+
+    it('should group transactions first by year-month, then date in month', () => {
+      const t1 = {
+        outflow: 1,
+        month: '2022-01',
+        date: { toUTCMoment: () => moment('2022-01-07T13:00:00.000Z') },
+      };
+      const t2 = {
+        outflow: 2,
+        month: '2022-01',
+        date: { toUTCMoment: () => moment('2022-01-04T13:00:00.000Z') },
+      };
+      const t3 = {
+        outflow: 3,
+        month: '2022-01',
+        date: { toUTCMoment: () => moment('2022-01-07T13:00:00.000Z') },
+      };
+      const t4 = {
+        outflow: 4,
+        month: '2022-02',
+        date: { toUTCMoment: () => moment('2022-02-13T13:00:00.000Z') },
+      };
+      const t5 = {
+        outflow: 5,
+        month: '2022-02',
+        date: { toUTCMoment: () => moment('2022-02-19T13:00:00.000Z') },
+      };
+      const t6 = {
+        outflow: 6,
+        month: '2022-03',
+        date: { toUTCMoment: () => moment('2022-03-24T13:00:00.000Z') },
+      };
+
+      const transactions = [t1, t2, t3, t4, t5, t6];
+
+      const expected = {
+        '2022-01': {
+          4: [t2],
+          7: [t1, t3],
+        },
+        '2022-02': {
+          13: [t4],
+          19: [t5],
+        },
+        '2022-03': {
+          24: [t6],
+        },
+      };
+
+      expect(groupTransactions(transactions)).toEqual(expected);
+    });
+  });
+
+  describe('calculateOutflowPerDate', () => {
+    it('should do nothing, when there is nothing to be done', () => {
+      expect(calculateOutflowPerDate({})).toEqual({});
+    });
+
+    it('should calculate outflow per date', () => {
+      const transactions = {
+        '2022-01': {
+          4: [{ outflow: 100 }],
+          7: [{ outflow: 200 }, { outflow: 300 }],
+          8: [{ outflow: 300 }],
+          12: [{ outflow: 200 }, { outflow: 600 }, { outflow: 700 }],
+          19: [{ outflow: 100 }],
+        },
+        '2022-02': {
+          13: [{ outflow: 200 }],
+          19: [{ outflow: 700 }],
+        },
+      };
+
+      const expected = {
+        '2022-01': {
+          4: 100,
+          7: 500,
+          8: 300,
+          12: 1500,
+          19: 100,
+        },
+        '2022-02': {
+          13: 200,
+          19: 700,
+        },
+      };
+
+      expect(calculateOutflowPerDate(transactions)).toEqual(expected);
+    });
+  });
+
+  describe('calculateCumulativeOutflowPerDate', () => {
+    it('should do nothing, when there is nothing to be done', () => {
+      expect(calculateCumulativeOutflowPerDate({})).toEqual({});
+    });
+
+    it('should calculate the cumulative outflow per date', () => {
+      const transactions = {
+        '2022-01': {
+          4: [{ outflow: 100 }],
+          7: [{ outflow: 200 }, { outflow: 300 }],
+          8: [{ outflow: 300 }],
+          12: [{ outflow: 200 }, { outflow: 600 }, { outflow: 700 }],
+          19: [{ outflow: 100 }],
+        },
+        '2022-02': {
+          13: [{ outflow: 200 }],
+          19: [{ outflow: 700 }],
+        },
+      };
+
+      const expected = {
+        '2022-01': {
+          4: 100,
+          7: 600,
+          8: 900,
+          12: 2400,
+          19: 2500,
+        },
+        '2022-02': {
+          13: 200,
+          19: 900,
+        },
+      };
+
+      expect(calculateCumulativeOutflowPerDate(transactions)).toEqual(expected);
+    });
+  });
+
+  describe('toHighchartsSeries', () => {
+    it('should do nothing, when there is nothing to be done', () => {
+      expect(toHighchartsSeries({})).toEqual([]);
+    });
+
+    it('should transform the transactions to Highcharts Series', () => {
+      const transactions = {
+        '2022-01': {
+          4: 100,
+          7: 600,
+          8: 900,
+          12: 2400,
+          19: 2500,
+        },
+        '2022-02': {
+          13: 200,
+          19: 900,
+        },
+      };
+
+      const excpected = [
+        {
+          name: '2022-01',
+          data: [
+            { x: 4, y: 100 },
+            { x: 7, y: 600 },
+            { x: 8, y: 900 },
+            { x: 12, y: 2400 },
+            { x: 19, y: 2500 },
+          ],
+        },
+        {
+          name: '2022-02',
+          data: [
+            { x: 13, y: 200 },
+            { x: 19, y: 900 },
+          ],
+        },
+      ];
+
+      expect(toHighchartsSeries(transactions)).toEqual(excpected);
+    });
+  });
+});


### PR DESCRIPTION
GitHub Issue (if applicable): Nope
Trello Link (if applicable): Nope

Hello! And thanks for a great plugin.

As a newish YNAB user I want to see how I spend across the month and I found myself using the `Balance Over Time` report and doing some manual maths to workout "by the xth last month I had spent y euro from the start of that month. Have I spent more or less on the xth this month?" which got tedious so I spiked up this today.

Let me know if this is something y'all think would be useful for other people and I can clean up and add support for filtering on dates etc.

![Screenshot 2022-06-21 at 19 41 59](https://user-images.githubusercontent.com/736248/174866305-2a933b58-afa1-4176-85c5-a87c69cd5a73.png)
![Screenshot 2022-06-21 at 19 42 07](https://user-images.githubusercontent.com/736248/174866324-15a5b527-12e8-40ce-b20e-7fe7306a6fa4.png)



