### PR TITLE
browser_action is now action in v3 manifest

### DIFF
--- a/src/manifest.development.json
+++ b/src/manifest.development.json
@@ -1,6 +1,6 @@
 {
   "name": "Toolkit for YNAB (Development)",
-  "browser_action": {
+  "action": {
     "default_icon": "assets/images/icons/button.png",
     "default_title": "Toolkit for YNAB (Development)",
     "default_popup": "popup/index.html"


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
I noticed errors when loading the extension on Chrome (Developer mode) related to manifest version changes from V2 to V3.  See https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#action-api-unification

I updated the chrome manifest per the V3 documentation and the extension now loads clean with no errors.  I did not change the other manifests (firefox) as I do not have those environments, but I expect the fix is similar.

