### PR TITLE
Fix report rendering and custom average budget feature

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/component.jsx
@@ -50,41 +50,21 @@ export class IncomeVsExpenseComponent extends React.Component {
 
   _localStorageKey = 'income-vs-expense-collapse-state';
 
-  constructor() {
-    super();
-
-    this.state = {
-      collapsedSources: this._parseState(getToolkitStorageKey(this._localStorageKey)),
-    };
-  }
+  state = {
+    collapsedSources: new Set(getToolkitStorageKey(this._localStorageKey, [])),
+  };
 
   static propTypes = {
     filters: PropTypes.shape(FiltersPropType),
     filteredTransactions: PropTypes.array.isRequired,
   };
 
-  state = {
-    collapsedSources: new Set(),
-  };
-
-  _saveState(state) {
-    return JSON.stringify(Array.from([...state.collapsedSources]));
-  }
-
-  _parseState(storage) {
-    if (storage === null) {
-      return new Set();
-    }
-
-    return new Set(JSON.parse(storage));
-  }
-
   componentDidMount() {
     this._calculateData();
   }
 
   componentWillUnmount() {
-    setToolkitStorageKey(this._localStorageKey, this._saveState(this.state));
+    setToolkitStorageKey(this._localStorageKey, [...this.state.collapsedSources]);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/test/utils/storage.js
+++ b/src/test/utils/storage.js
@@ -1,2 +1,0 @@
-const FEATURE_SETTING_PREFIX = 'toolkit-feature:';
-export const featureSettingKey = (featureName) => `${FEATURE_SETTING_PREFIX}${featureName}`;

--- a/src/test/utils/storage.ts
+++ b/src/test/utils/storage.ts
@@ -1,0 +1,2 @@
+const FEATURE_SETTING_PREFIX = 'toolkit-feature:';
+export const featureSettingKey = (featureName: string) => `${FEATURE_SETTING_PREFIX}${featureName}`;

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -42,10 +42,23 @@ declare global {
     };
   }
 
+  interface YNABTransactionViewModel {
+    visibleTransactionDisplayItems: Transaction[];
+  }
+
+  interface YNABGlobal {
+    YNABSharedLib: {
+      dateFormatter: {
+        formatDate(date: DateWithoutTime): string;
+      };
+      getBudgetViewModel_AllAccountsViewModel(): Promise<YNABTransactionViewModel>;
+    };
+  }
+
   type FeatureSetting = boolean | string;
 
   const Ember: Ember;
   const ynabToolKit: YNABToolkitObject;
-  const ynab: any;
+  const ynab: YNABGlobal;
   const YNABFEATURES: any;
 }

--- a/src/types/ynab-data.ts
+++ b/src/types/ynab-data.ts
@@ -1,3 +1,31 @@
+interface DateWithoutTime {
+  addMonths(count: number): DateWithoutTime;
+  clone(): DateWithoutTime;
+  getMonth(): number;
+  getYear(): number;
+  isAfter(date: DateWithoutTime): boolean;
+  isBefore(date: DateWithoutTime): boolean;
+  startOfMonth(): DateWithoutTime;
+  toISOString(): string;
+}
+
+interface MasterCategory {
+  entityId: string;
+  sortableIndex: number;
+}
+
+interface SubCategory {
+  entityId?: string;
+  masterCategoryId?: string;
+  sortableIndex: number;
+}
+
+interface Payee {
+  entityId?: string;
+  isStartingBalancePayee(): boolean;
+  name: string;
+}
+
 interface Transaction {
   accepted?: boolean;
   account?: any;
@@ -10,28 +38,33 @@ interface Transaction {
   cleared?: string;
   creditAmount?: any;
   creditAmountAdjusted?: any;
-  date?: any;
+  date?: DateWithoutTime;
   dateEnteredFromSchedule?: any;
   entityId?: string;
   flag?: any;
   importedDate?: any;
   importedPayee?: string;
+  isScheduledSubTransaction?: boolean;
+  isScheduledTransaction?: boolean;
+  isSplit?: boolean;
   isTombstone?: boolean;
   matchedTransaction?: any;
   matchedTransactionId?: any;
   memo?: string;
   month?: any;
   originalImportedPayee?: string;
+  parentTransaction?: Transaction;
   payee?: any;
   payeeId?: string;
-  scheduledTransactions?: any;
   scheduledTransactionId?: string;
+  scheduledTransactions?: any;
   source?: string;
   subCategory?: any;
   subCategoryCreditAmountPreceding?: any;
+  subCategoryId?: string;
   subTransactions?: any;
-  transferAccounts?: any;
   transferAccountId?: string;
+  transferAccounts?: any;
   transferSubTransaction?: any;
   transferSubTransactionId?: string;
   transferTransaction?: any;


### PR DESCRIPTION
GitHub Issue (if applicable): #2822 and #2821 

**Explanation of Bugfix/Feature/Modification:**
#2822: We were double parsing `collapsedSources` which was causing a throw to happen from `JSON.parse`
#2821: Made sure to always put the button after the other "Average Spent" button and also fixed some broken logic with the arithmetic and stuff. I think my changes made `_calculateAverage()` return a string instead of a number which broke some stuff. Also, we were subtracting too many months from start month.  
