### PR TITLE
feat: Update Ember Toolkit Hook

### DIFF
--- a/src/extension/features/feature.ts
+++ b/src/extension/features/feature.ts
@@ -5,7 +5,7 @@ import { addToolkitEmberHook, removeToolkitEmberHook } from '../utils/toolkit';
 import { forEachRenderedComponent } from '../utils/ember';
 
 export class Feature {
-  private __hooks = new Map<string, (element: Element) => void>();
+  private __hooks = new Map<string, (element: HTMLElement) => void>();
   featureName = this.constructor.name as FeatureName;
 
   settings = {
@@ -66,9 +66,9 @@ export class Feature {
     routeChangeListener.removeFeature(this);
   }
 
-  debounce(fn: (element: Element) => void, timeout: number): (element: Element) => void {
+  debounce(fn: (element: HTMLElement) => void, timeout: number): (element: HTMLElement) => void {
     const timers = new Map<string, number>();
-    return (element: Element) => {
+    return (element: HTMLElement) => {
       if (timers.has(element.id)) {
         window.clearTimeout(timers.get(element.id));
       }
@@ -85,8 +85,8 @@ export class Feature {
   addToolkitEmberHook(
     componentKey: string,
     lifecycleHook: SupportedEmberHook,
-    fn: (element: Element) => void,
-    options?: { debounce?: number; guard?: (element: Element) => boolean }
+    fn: (element: HTMLElement) => void,
+    options?: { debounce?: number; guard?: (element: HTMLElement) => boolean }
   ): void {
     const wrappedAddToolkitEmberHook = withToolkitError(() => {
       if (options?.debounce != null) {
@@ -97,7 +97,7 @@ export class Feature {
 
       this.__hooks.set(`${componentKey}:${lifecycleHook}`, fn);
 
-      forEachRenderedComponent(componentKey, (view: { element: Element }) => {
+      forEachRenderedComponent(componentKey, (view: { element: HTMLElement }) => {
         if (view.element) {
           if (options?.guard && !options.guard(view.element)) {
             return;
@@ -114,7 +114,7 @@ export class Feature {
   removeToolkitEmberHook(
     componentKey: string,
     lifecycleHook: SupportedEmberHook,
-    fn: (element: Element) => void
+    fn: (element: HTMLElement) => void
   ): void {
     const wrappedRemoveToolkitEmberHook = withToolkitError(() => {
       removeToolkitEmberHook(componentKey, lifecycleHook, fn);

--- a/src/extension/utils/toolkit.ts
+++ b/src/extension/utils/toolkit.ts
@@ -111,8 +111,8 @@ export function addToolkitEmberHook(
   context: Feature,
   componentKey: string,
   lifecycleHook: SupportedEmberHook,
-  fn: (element: Element) => void,
-  guard?: (element: Element) => boolean
+  fn: (element: HTMLElement) => void,
+  guard?: (element: HTMLElement) => boolean
 ) {
   const componentPrototype = factoryLookup<EmberComponent>(componentKey)?.class?.prototype;
   if (!componentPrototype) {
@@ -137,7 +137,7 @@ export function addToolkitEmberHook(
 export function removeToolkitEmberHook(
   componentKey: string,
   lifecycleHook: SupportedEmberHook,
-  fn: (element: Element) => void
+  fn: (element: HTMLElement) => void
 ) {
   const componentPrototype = factoryLookup<EmberComponent>(componentKey)?.class?.prototype;
   if (!componentPrototype) {

--- a/src/extension/ynab-toolkit.tsx
+++ b/src/extension/ynab-toolkit.tsx
@@ -216,11 +216,11 @@ export class YNABToolkit {
         const hooks = self[emberComponentToolkitHookKey(lifecycleName)];
         if (hooks) {
           hooks.forEach(({ context, fn, guard }) => {
-            if (guard && !guard(self.element)) {
+            if (guard && !guard(self.element as HTMLElement)) {
               return;
             }
 
-            fn.call(context, self.element);
+            fn.call(context, self.element as HTMLElement);
           });
         }
       };

--- a/src/types/ynab/ember/ember-view.d.ts
+++ b/src/types/ynab/ember/ember-view.d.ts
@@ -1,5 +1,5 @@
 interface EmberView {
-  element: Element;
+  element: HTMLElement;
   _debugContainerKey: boolean | string;
 
   get(key: keyof EmberView): EmberView[];

--- a/src/types/ynab/ember/index.d.ts
+++ b/src/types/ynab/ember/index.d.ts
@@ -5,8 +5,8 @@ import { Feature } from 'toolkit/extension/features/feature';
 declare global {
   interface ToolkitEmberHook {
     context: Feature;
-    fn(element: Element): void;
-    guard?: (element: Element) => boolean;
+    fn(element: HTMLElement): void;
+    guard?: (element: HTMLElement) => boolean;
   }
 
   interface EmberComponentPrototype {


### PR DESCRIPTION
Updating the ember toolkit hook to use `HTMLElement` vs. `Element`. Some typecasting was needed in the YNABToolkit class due to Ember's usage of Element in their core view class.
