### PR TITLE
Fix total spent value shown when using Add Total Monthly Goals

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -66,10 +66,11 @@ export class DisplayTotalMonthlyGoals extends Feature {
       );
     });
 
+    // For information about the total spent value see https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2828
     return [
       budgetedCalculation?.immediateIncome || 0,
       budgetedCalculation?.budgeted || 0,
-      budgetedCalculation?.cashOutflows + budgetedCalculation?.creditOutflows || 0,
+      budgetedCalculation?.cashOutflows + 2 * (budgetedCalculation?.creditOutflows || 0),
     ];
   }
 


### PR DESCRIPTION
GitHub Issue (if applicable): #2828

**Explanation of Bugfix/Feature/Modification:**
The total spent amount shown when the _Add Total Monthly Goals_ feature is active is wrong when both cash and credit transactions appear in the budget page.

An explanation of the fix can be found in issue #2828. But in summary, the value of `cashOutflows` includes the value of credit expenses which means we need to overcompensate for credit expenses twice.