### PR TITLE
fix: fix features that try to access areChecked on the accounts controller

### DIFF
--- a/src/extension/features/accounts/bulk-edit-memo/index.jsx
+++ b/src/extension/features/accounts/bulk-edit-memo/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Feature } from 'toolkit/extension/features/feature';
-import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { componentLookup, controllerLookup } from 'toolkit/extension/utils/ember';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 import { componentAfter } from 'toolkit/extension/utils/react';
 import { getEntityManager } from 'toolkit/extension/utils/ynab';
@@ -10,7 +10,7 @@ const EditMemo = () => {
   const [memoInputValue, setMemoInputValue] = useState('');
 
   const handleConfirm = () => {
-    const checkedRows = controllerLookup('accounts').get('areChecked');
+    const checkedRows = componentLookup('top-accounts').areChecked;
     const { transactionsCollection } = getEntityManager();
     getEntityManager().performAsSingleChangeSet(() => {
       checkedRows.forEach((transaction) => {
@@ -51,7 +51,7 @@ const EditMemo = () => {
         {!isEditMode && (
           <button onClick={() => setIsEditMode(true)}>
             <i className="flaticon stroke document-1 ynab-new-icon"></i>
-            {controllerLookup('accounts').get('areChecked').length === 1
+            {componentLookup('top-accounts').areChecked.length === 1
               ? l10n('toolkit.editMemo', 'Edit Memo')
               : l10n('toolkit.editMemoOther', 'Edit Memos')}
           </button>

--- a/src/extension/features/accounts/clear-selection/index.js
+++ b/src/extension/features/accounts/clear-selection/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { controllerLookup, componentLookup } from 'toolkit/extension/utils/ember';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 
 export class ClearSelection extends Feature {
@@ -8,7 +8,7 @@ export class ClearSelection extends Feature {
 
     try {
       accountsController.set('areAllTransactionsSet', false);
-      accountsController.get('areChecked').setEach('isChecked', 0);
+      componentLookup('top-accounts').areChecked.setEach('isChecked', false);
       accountsController.send('closeModal');
     } catch (exception) {
       accountsController.send('closeModal');

--- a/src/extension/features/accounts/deselect-transactions-on-save/index.js
+++ b/src/extension/features/accounts/deselect-transactions-on-save/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
-import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { componentLookup } from 'toolkit/extension/utils/ember';
 
 export class DeselectTransactionsOnSave extends Feature {
   shouldInvoke() {
@@ -32,7 +32,7 @@ export class DeselectTransactionsOnSave extends Feature {
 
   handleSaveButtonClicked = () => {
     setTimeout(() => {
-      controllerLookup('accounts').areChecked.setEach('isChecked', false);
+      componentLookup('top-accounts').areChecked.setEach('isChecked', false);
     }, 0);
   };
 }

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { componentLookup } from 'toolkit/extension/utils/ember';
 import { getEntityManager } from 'toolkit/extension/utils/ynab';
 
 export class EasyTransactionApproval extends Feature {
@@ -29,7 +29,7 @@ export class EasyTransactionApproval extends Feature {
     if (event.code === 'KeyA' || event.code === 'Enter') {
       const { transactionsCollection } = getEntityManager();
       getEntityManager().batchChangeProperties(() => {
-        controllerLookup('accounts').areChecked.forEach((transaction) => {
+        componentLookup('top-accounts').areChecked.forEach((transaction) => {
           const entity = transactionsCollection.findItemByEntityId(transaction.get('entityId'));
           if (entity) {
             entity.set('accepted', true);

--- a/src/extension/features/accounts/right-click-to-edit/index.js
+++ b/src/extension/features/accounts/right-click-to-edit/index.js
@@ -1,5 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { controllerLookup, serviceLookup } from 'toolkit/extension/utils/ember';
+import { controllerLookup, componentLookup, serviceLookup } from 'toolkit/extension/utils/ember';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class RightClickToEdit extends Feature {
@@ -28,7 +28,8 @@ export class RightClickToEdit extends Feature {
       $row = $row.prevAll('.ynab-grid-body-parent:first');
     }
 
-    const { areChecked, visibleTransactionDisplayItems } = controllerLookup('accounts');
+    const areChecked = componentLookup('top-accounts').areChecked;
+    const { visibleTransactionDisplayItems } = controllerLookup('accounts');
     const clickedTransactionId = $row.data().rowId;
     const clickedTransaction = visibleTransactionDisplayItems.find(
       ({ entityId }) => entityId === clickedTransactionId

--- a/src/extension/features/accounts/spare-change/index.js
+++ b/src/extension/features/accounts/spare-change/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
-import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { componentLookup } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 
 export class SpareChange extends Feature {
@@ -15,18 +15,18 @@ export class SpareChange extends Feature {
   // invoke has potential of being pretty processing heavy (needing to sort content, then update calculation for every row)
   // wrapping it in a debounce means that if the user continuously scrolls down we won't clog up the event loop.
   invoke() {
-    controllerLookup('accounts').addObserver('areChecked', this.calculateSpareChange);
+    componentLookup('top-accounts').addObserver('areChecked', this.calculateSpareChange);
   }
 
   destroy() {
-    controllerLookup('accounts').removeObserver('areChecked', this.calculateSpareChange);
+    componentLookup('top-accounts').removeObserver('areChecked', this.calculateSpareChange);
     $('#tk-spare-change').remove();
   }
 
   calculateSpareChange() {
     // Running this code straight away in the callback seems to break some YNAB features - schedule it to run later
     Ember.run.once(this, () => {
-      const { areChecked } = controllerLookup('accounts');
+      const areChecked = componentLookup('top-accounts').areChecked;
       if (!areChecked.length) {
         $('#tk-spare-change').remove();
         return;


### PR DESCRIPTION
`areChecked` was removed from the accounts controller in the latest YNAB update. This can be accessed on the `top-accounts` component instead.

Fixes #2848, #2849, #2850