### PR TITLE
fix: get monthString from budgetService

### DIFF
--- a/src/extension/utils/ynab.ts
+++ b/src/extension/utils/ynab.ts
@@ -21,7 +21,7 @@ export function getEntityManager() {
 }
 
 export function getCurrentBudgetDate() {
-  const date = getBudgetController()?.monthString;
+  const date = getBudgetService()?.monthString;
   return { year: date?.slice(0, 4), month: date?.slice(4, 6) };
 }
 
@@ -65,7 +65,7 @@ export function getBudgetViewModel() {
 }
 
 export function getSelectedMonth() {
-  const monthString = getBudgetController()?.monthString;
+  const monthString = getBudgetService()?.monthString;
   if (monthString) {
     return ynab.utilities.DateWithoutTime.createFromString(monthString, 'YYYYMM');
   }
@@ -75,6 +75,10 @@ export function getSelectedMonth() {
 
 export function getApplicationService() {
   return getApplicationController()?.applicationService;
+}
+
+export function getBudgetService() {
+  return getBudgetController()?.budgetService;
 }
 
 export function isCurrentMonthSelected() {

--- a/src/types/ynab/controllers/YNABBudgetController.d.ts
+++ b/src/types/ynab/controllers/YNABBudgetController.d.ts
@@ -5,10 +5,10 @@ interface YNABBudgetMonthDisplayItem {
 
 interface YNABBudgetController {
   applicationService: YNABApplicationService;
+  budgetService: YNABBudgetService;
   budgetViewModel?: {
     allBudgetMonthsViewModel: {};
   };
   checkedRowsCount: number;
   checkedRows: YNABBudgetMonthDisplayItem[];
-  monthString: string;
 }

--- a/src/types/ynab/services/YNABBudgetService.d.ts
+++ b/src/types/ynab/services/YNABBudgetService.d.ts
@@ -1,0 +1,3 @@
+interface YNABBudgetService {
+  monthString: string;
+}


### PR DESCRIPTION
`monthString` no longer exists on the budget controller. This breaks features that use `getSelectedMonth` and such. We can get it from the budget service instead.

Also added a `getBudgetService` function and appropriate types.

Probably fixes #2847 