### PR TITLE
fix right-click bug

### DIFF
--- a/src/extension/features/accounts/right-click-to-edit/index.js
+++ b/src/extension/features/accounts/right-click-to-edit/index.js
@@ -29,7 +29,9 @@ export class RightClickToEdit extends Feature {
     }
 
     const areChecked = componentLookup('top-accounts').areChecked;
-    const { visibleTransactionDisplayItems } = controllerLookup('accounts');
+    const {
+      transactionEditorService: { visibleTransactionDisplayItems },
+    } = controllerLookup('accounts');
     const clickedTransactionId = $row.data().rowId;
     const clickedTransaction = visibleTransactionDisplayItems.find(
       ({ entityId }) => entityId === clickedTransactionId


### PR DESCRIPTION
GitHub Issue (if applicable): #2874

Trello Link (if applicable): n/a

**Explanation of Bugfix/Feature/Modification:**
It seems YNAB's nested the `visibleTransactionDisplayItems` property inside a "service" called `transactionEditorService`. This PR handles destructuring `visibleTransactionDisplayItems` properly from that property on the accounts controller.
