### PR TITLE
fix check-credit-balances

### DIFF
--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -45,6 +45,12 @@ export class CheckCreditBalances extends Feature {
       changedNodes.has(
         'budget-table-row js-budget-table-row is-sub-category is-debt-payment-category'
       ) ||
+      changedNodes.has(
+        'budget-table-row js-budget-table-row budget-table-row-ul is-sub-category is-debt-payment-category is-checked'
+      ) ||
+      changedNodes.has(
+        'budget-table-row js-budget-table-row budget-table-row-ul is-sub-category is-debt-payment-category'
+      ) ||
       changedNodes.has('to-be-budgeted-amount')
     ) {
       this.invoke();
@@ -245,5 +251,15 @@ export class CheckCreditBalances extends Feature {
         }
       }
     });
+
+    $('#tk-rectify-difference')
+      .attr('disabled', true)
+      .empty()
+      .append(l10n('toolkit.checkCreditBalances', 'Rectify Difference'))
+      .append(
+        $('<strong>', { class: 'user-data', title: '$0.00' }).append(
+          $('<span>', { class: 'user-data currency zero' }).text(`+$0.00`)
+        )
+      );
   }
 }


### PR DESCRIPTION
Fixes #2805

There's an extra class (`budget-table-row-ul`) on `budget-table-row` now, so the feature was not being invoked. Added the proper check to `observe()`.

Also, I wasn't able to figure out why (believe me I tried), but when the rectify difference button is clicked, the values in YNAB don't update, so the button never gets disabled. Best workaround I could figure out is to just manually disable the button when it's clicked and set the appropriate text.