### PR TITLE
Fixed small typo for missing "to"

### DIFF
--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -197,7 +197,7 @@ Ensure all negative balances are highlighted red instead of yellow, even with cr
 
 ## Live on Last Month's Income
 
-Add a section the budget inspector showing your variance between last month's income and this month's assigned budget for users who still live by the old Rule #4.
+Add a section to the budget inspector showing your variance between last month's income and this month's assigned budget for users who still live by the old Rule #4.
 
 ## Paid in Full Credit Card Assist
 

--- a/src/extension/features/budget/live-on-last-months-income/settings.js
+++ b/src/extension/features/budget/live-on-last-months-income/settings.js
@@ -5,7 +5,7 @@ module.exports = {
   section: 'budget',
   title: "Live on Last Month's Income",
   description:
-    "Add a section the budget inspector showing your variance between last month's income and this month's assigned budget for users who still live by the old Rule #4.",
+    "Add a section to the budget inspector showing your variance between last month's income and this month's assigned budget for users who still live by the old Rule #4.",
   options: [
     { name: 'Use previous month', value: '1' },
     { name: 'Use month before last', value: '2' },


### PR DESCRIPTION
GitHub Issue: #2925 

**Explanation of Bugfix/Feature/Modification:**
Fixed small typo. Added missing "to".