### PR TITLE
fix: observe accounts toolbar instead of hooking it

### DIFF
--- a/src/extension/features/accounts/toggle-transaction-filters/index.js
+++ b/src/extension/features/accounts/toggle-transaction-filters/index.js
@@ -40,8 +40,12 @@ export class ToggleTransactionFilters extends Feature {
     return true;
   }
 
-  invoke() {
-    this.addToolkitEmberHook('accounts/account-header', 'didRender', this.injectButtons);
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (changedNodes.has('accounts-toolbar')) {
+      this.injectButtons($('.accounts-toolbar'));
+    }
   }
 
   injectCSS() {


### PR DESCRIPTION
GitHub Issue (if applicable): #2937

**Explanation of Bugfix/Feature/Modification:**

Since accounts/account-toolbar has moved to a Glimmer component, we no longer have access to the render hook for that.
This PR changes to use the MutationObserver for injecting the buttons into account-header.
