### PR TITLE
fix: selected entry approval on key events in search input

### DIFF
--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -27,6 +27,10 @@ export class EasyTransactionApproval extends Feature {
 
   handleKeydown(event) {
     if (event.code === 'KeyA' || event.code === 'Enter') {
+      const isInputEvent = event.target.nodeName === 'INPUT';
+
+      if (isInputEvent) return;
+
       const { transactionsCollection } = getEntityManager();
       getEntityManager().batchChangeProperties(() => {
         containerLookup('service:accounts').areChecked.forEach((transaction) => {


### PR DESCRIPTION
GitHub Issue (if applicable): #2940

Trello Link (if applicable): None

**Explanation of Bugfix/Feature/Modification:**
Selected entries were being approved on 'a' and 'enter' key events while trying to use inputs, causing unexpected behavior from the search transactions input.

Created guard to avoid reacting to key events where target is an input element.
