### PR TITLE
Fix typo 2936

### DIFF
--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -239,7 +239,7 @@ Removes the highlight colour from positive (or zero) category balances and colou
 
 ## Add "Auto Distribute" Button To Split Transactions
 
-Distrubutes the remaining total of a split transaction proportionally to all other splits which contain an amount.
+Distributes the remaining total of a split transaction proportionally to all other splits which contain an amount.
 
 ## Add "Check Number" Column
 

--- a/src/extension/features/accounts/auto-distribute-splits/settings.js
+++ b/src/extension/features/accounts/auto-distribute-splits/settings.js
@@ -5,5 +5,5 @@ module.exports = {
   section: 'accounts',
   title: 'Add "Auto Distribute" Button To Split Transactions',
   description:
-    'Distrubutes the remaining total of a split transaction proportionally to all other splits which contain an amount.',
+    'Distributes the remaining total of a split transaction proportionally to all other splits which contain an amount.',
 };

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -27,6 +27,10 @@ export class EasyTransactionApproval extends Feature {
 
   handleKeydown(event) {
     if (event.code === 'KeyA' || event.code === 'Enter') {
+      const isInputEvent = event.target.nodeName === 'INPUT';
+
+      if (isInputEvent) return;
+
       const { transactionsCollection } = getEntityManager();
       getEntityManager().batchChangeProperties(() => {
         containerLookup('service:accounts').areChecked.forEach((transaction) => {


### PR DESCRIPTION
GitHub Issue (if applicable): #2936 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Typo 'distrubutes' changed to 'distributes' in AutoDistributeSplits featue
