### PR TITLE
Hide collapsed auto assign window space in page print

### DIFF
--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -27,6 +27,10 @@ export class EasyTransactionApproval extends Feature {
 
   handleKeydown(event) {
     if (event.code === 'KeyA' || event.code === 'Enter') {
+      const isInputEvent = event.target.nodeName === 'INPUT';
+
+      if (isInputEvent) return;
+
       const { transactionsCollection } = getEntityManager();
       getEntityManager().batchChangeProperties(() => {
         containerLookup('service:accounts').areChecked.forEach((transaction) => {

--- a/src/extension/features/budget/collapse-inspector/index.css
+++ b/src/extension/features/budget/collapse-inspector/index.css
@@ -33,3 +33,9 @@
 .budget-inspector[tk-collapse-inspector] .budget-inspector-content > *:not(.tk-collapse-inspector) {
   display: none;
 }
+
+@media print {
+  .budget-inspector[tk-collapse-inspector] {
+    display: none;
+  }
+}


### PR DESCRIPTION
GitHub Issue (if applicable): #2827 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Auto assign sicebar and space is now hidden from print view when collapsed
