### PR TITLE
Fixed total monthly goals, following YNAB switch to glimmer

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -196,6 +196,16 @@ export class DisplayTotalMonthlyGoals extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('budget/budget-inspector', 'didRender', this.addMonthlyGoalsOverview);
+    return null;
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) {
+      return;
+    }
+
+    if (changedNodes.has('budget-inspector-button')) {
+      this.addMonthlyGoalsOverview();
+    }
   }
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2948, #2946

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Apparently, YNAB is in the process of changing Ember components over to Glimmer. That broke a couple features, as explained by @williammck [in a similar bugfix PR](https://github.com/toolkit-for-ynab/toolkit-for-ynab/pull/2942).

I had to do some playing around to find a node that would change when you go between having specific categories checked and having no categories checked. I think this `budget-inspector-button` should do the trick...