### PR TITLE
access month string from budgetHeaderValues.monthlyBudget.month momen…

### DIFF
--- a/src/extension/utils/ynab.ts
+++ b/src/extension/utils/ynab.ts
@@ -21,7 +21,7 @@ export function getEntityManager() {
 }
 
 export function getCurrentBudgetDate() {
-  const date = getBudgetService()?.monthString;
+  const date = getBudgetService()?.budgetHeaderValues?.monthlyBudget?.month?.format('YYYYMM');
   return { year: date?.slice(0, 4), month: date?.slice(4, 6) };
 }
 
@@ -65,7 +65,8 @@ export function getBudgetViewModel() {
 }
 
 export function getSelectedMonth() {
-  const monthString = getBudgetService()?.monthString;
+  const monthString =
+    getBudgetService()?.budgetHeaderValues?.monthlyBudget?.month?.format('YYYYMM');
   if (monthString) {
     return ynab.utilities.DateWithoutTime.createFromString(monthString, 'YYYYMM');
   }

--- a/src/types/ynab/services/YNABBudgetService.d.ts
+++ b/src/types/ynab/services/YNABBudgetService.d.ts
@@ -5,6 +5,5 @@ interface YNABBudgetService {
         format: (input: string) => string;
       };
     };
-    monthString: string;
   };
 }

--- a/src/types/ynab/services/YNABBudgetService.d.ts
+++ b/src/types/ynab/services/YNABBudgetService.d.ts
@@ -1,3 +1,10 @@
 interface YNABBudgetService {
-  monthString: string;
+  budgetHeaderValues: {
+    monthlyBudget: {
+      month: {
+        format: (input: string) => string;
+      };
+    };
+    monthString: string;
+  };
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #2960

**Explanation of Bugfix/Feature/Modification:**
According to the debugger, `monthString` doesn't exist on the budget service. A little hunting around led me to `budgetHeaderValues.monthlyBudget.month` moment object which seems to provide the necessary value for these methods to work as intended.

Not sure if I have enough context to say this is the most logical place to access the month, but its resolved the issue on my end.