### PR TITLE
fix: observe buttons in check-credit-balances

### DIFF
--- a/src/extension/utils/ynab.ts
+++ b/src/extension/utils/ynab.ts
@@ -65,12 +65,7 @@ export function getBudgetViewModel() {
 }
 
 export function getSelectedMonth() {
-  const monthString = getBudgetService()?.monthString;
-  if (monthString) {
-    return ynab.utilities.DateWithoutTime.createFromString(monthString, 'YYYYMM');
-  }
-
-  return null;
+  return getBudgetViewModel()?.month;
 }
 
 export function getApplicationService() {

--- a/src/types/ynab/controllers/YNABBudgetController.d.ts
+++ b/src/types/ynab/controllers/YNABBudgetController.d.ts
@@ -8,6 +8,7 @@ interface YNABBudgetController {
   budgetService: YNABBudgetService;
   budgetViewModel?: {
     allBudgetMonthsViewModel: {};
+    month: DateWithoutTime;
   };
   checkedRowsCount: number;
   checkedRows: YNABBudgetMonthDisplayItem[];

--- a/src/types/ynab/services/YNABBudgetService.d.ts
+++ b/src/types/ynab/services/YNABBudgetService.d.ts
@@ -1,3 +1,4 @@
 interface YNABBudgetService {
+  activeCategory: {};
   monthString: string;
 }


### PR DESCRIPTION
GitHub Issue (if applicable):

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**

`Paid in Full Credit Card Assist` didn't seem to be working properly after the Glimmer changes. 
This seems to get it back into shape from my testing.

Also, fixed `getSelectedMonth` similar to https://github.com/toolkit-for-ynab/toolkit-for-ynab/pull/2961 but pulled from the view model instead.
