### PR TITLE
fix: observe calendar for day change (fixes #2953)

### DIFF
--- a/src/extension/features/accounts/calendar-first-day/index.js
+++ b/src/extension/features/accounts/calendar-first-day/index.js
@@ -6,7 +6,13 @@ export class CalendarFirstDay extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('calendar', 'didInsertElement', this.adjustDays);
+    //
+  }
+
+  observe(changedNodes) {
+    if (!changedNodes.has('accounts-calendar')) return;
+
+    this.adjustDays(document.querySelector('.accounts-calendar'));
   }
 
   adjustDays(element) {


### PR DESCRIPTION
GitHub Issue (if applicable): #2953

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
calendar component got moved to glimmer, this looks for the new node.
