### PR TITLE
fix: support adding prefixes and suffixes in Bulk Edit Memo

### DIFF
--- a/src/extension/features/accounts/bulk-edit-memo/index.jsx
+++ b/src/extension/features/accounts/bulk-edit-memo/index.jsx
@@ -1,13 +1,34 @@
 import React, { useState } from 'react';
 import { Feature } from 'toolkit/extension/features/feature';
-import { containerLookup, controllerLookup } from 'toolkit/extension/utils/ember';
+import { containerLookup } from 'toolkit/extension/utils/ember';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 import { componentAfter } from 'toolkit/extension/utils/react';
-import { getEntityManager } from 'toolkit/extension/utils/ynab';
+import { getEntityManager, getAccountsController } from 'toolkit/extension/utils/ynab';
+
+const DEFAULT_DISPLAY_MODE = 'defaultDisplayMode';
+const MENU_DISPLAY_MODE = 'menuDisplayMode';
+const EDIT_DISPLAY_MODE = 'editDisplayMode';
+
+const REPLACE_EDIT_MODE = 'replaceEditMode';
+const ADD_PREFIX_EDIT_MODE = 'addPrefixEditMode';
+const ADD_SUFFIX_EDIT_MODE = 'addSuffixEditMode';
 
 const EditMemo = () => {
-  const [isEditMode, setIsEditMode] = useState(false);
+  const [displayMode, setDisplayMode] = useState(DEFAULT_DISPLAY_MODE);
+  const [editMode, setEditMode] = useState(REPLACE_EDIT_MODE);
   const [memoInputValue, setMemoInputValue] = useState('');
+
+  const makeNewMemo = (prevMemo) => {
+    switch (editMode) {
+      case REPLACE_EDIT_MODE:
+        return memoInputValue;
+      case ADD_PREFIX_EDIT_MODE:
+        return memoInputValue + ' ' + prevMemo;
+      case ADD_SUFFIX_EDIT_MODE:
+        return prevMemo + ' ' + memoInputValue;
+    }
+    return memoInputValue;
+  };
 
   const handleConfirm = () => {
     const checkedRows = containerLookup('service:accounts').areChecked;
@@ -15,46 +36,113 @@ const EditMemo = () => {
     getEntityManager().performAsSingleChangeSet(() => {
       checkedRows.forEach((transaction) => {
         const entity = transactionsCollection.findItemByEntityId(transaction.get('entityId'));
+        const memoPrevValue = transaction.get('memo') || '';
         if (entity) {
-          entity.set('memo', memoInputValue);
+          entity.set('memo', makeNewMemo(memoPrevValue));
         }
       });
     });
 
-    controllerLookup('accounts').send('closeModal');
+    setDisplayMode(DEFAULT_DISPLAY_MODE);
+    getAccountsController().send('closeModal');
   };
+
+  const selectedTransactionsCount = containerLookup('service:accounts').areChecked.length;
+  const makeEditLabel = () =>
+    selectedTransactionsCount === 1
+      ? l10n('toolkit.editMemoOne', 'Edit Memo')
+      : l10n('toolkit.editMemoMany', 'Edit Memos');
+  const makeReplacelabel = () =>
+    selectedTransactionsCount === 1
+      ? l10n('toolkit.editMemoReplaceOne', 'Replace memo')
+      : l10n('toolkit.editMemoReplaceMany', 'Replace memos');
+  const makeAddPrefixLabel = () =>
+    selectedTransactionsCount === 1
+      ? l10n('toolkit.editMemoPrefixOne', 'Add prefix to memo')
+      : l10n('toolkit.editMemoPrefixMany', 'Add prefix to each memo');
+  const makeAddSuffixLabel = () =>
+    selectedTransactionsCount === 1
+      ? l10n('toolkit.editMemoSuffixOne', 'Add suffix to memo')
+      : l10n('toolkit.editMemoSuffixMany', 'Add suffix to each memo');
 
   return (
     <>
       <li className="tk-bulk-edit-memo">
-        {isEditMode && (
-          <div className="button-list">
-            <input
-              autoFocus
-              className="accounts-text-field"
-              value={memoInputValue}
-              onChange={(e) => setMemoInputValue(e.target.value)}
-            />
-            <div className="tk-grid-actions">
-              <button
-                className="button button-cancel tk-memo-cancel"
-                onClick={() => setIsEditMode(false)}
-              >
-                {l10n('toolkit.editMemoCancel', 'Cancel')}
-              </button>
-              <button className="button button-primary tk-memo-save" onClick={handleConfirm}>
-                {l10n('toolkit.editMemoSave', 'Save')}
-              </button>
-            </div>
-          </div>
-        )}
-        {!isEditMode && (
-          <button onClick={() => setIsEditMode(true)}>
+        {displayMode === DEFAULT_DISPLAY_MODE && (
+          <button className="button-list" onClick={() => setDisplayMode(MENU_DISPLAY_MODE)}>
             <i className="flaticon stroke document-1 ynab-new-icon"></i>
-            {containerLookup('service:accounts').areChecked.length === 1
-              ? l10n('toolkit.editMemo', 'Edit Memo')
-              : l10n('toolkit.editMemoOther', 'Edit Memos')}
+            {makeEditLabel()}
           </button>
+        )}
+        {displayMode === MENU_DISPLAY_MODE && (
+          <>
+            <button
+              autoFocus
+              className="button-list"
+              onClick={() => {
+                setDisplayMode(EDIT_DISPLAY_MODE);
+                setEditMode(REPLACE_EDIT_MODE);
+              }}
+            >
+              {makeReplacelabel()}
+            </button>
+            <button
+              className="button-list"
+              onClick={() => {
+                setDisplayMode(EDIT_DISPLAY_MODE);
+                setEditMode(ADD_PREFIX_EDIT_MODE);
+              }}
+            >
+              {makeAddPrefixLabel()}
+            </button>
+            <button
+              className="button-list"
+              onClick={() => {
+                setDisplayMode(EDIT_DISPLAY_MODE);
+                setEditMode(ADD_SUFFIX_EDIT_MODE);
+              }}
+            >
+              {makeAddSuffixLabel()}
+            </button>
+            <button
+              className="button-list button-cancel tk-memo-cancel"
+              onClick={() => setDisplayMode(DEFAULT_DISPLAY_MODE)}
+            >
+              {l10n('toolkit.editMemoCancel', 'Cancel')}
+            </button>
+          </>
+        )}
+        {displayMode === EDIT_DISPLAY_MODE && (
+          <>
+            {editMode === REPLACE_EDIT_MODE && (
+              <li className="button-list button-disabled">{makeReplacelabel()}</li>
+            )}
+            {editMode === ADD_PREFIX_EDIT_MODE && (
+              <li className="button-list button-disabled">{makeAddPrefixLabel()}</li>
+            )}
+            {editMode === ADD_SUFFIX_EDIT_MODE && (
+              <li className="button-list button-disabled">{makeAddSuffixLabel()}</li>
+            )}
+            <div className="button-list">
+              <input
+                autoFocus
+                className="accounts-text-field"
+                value={memoInputValue}
+                onChange={(e) => setMemoInputValue(e.target.value)}
+              />
+              <div className="tk-grid-actions">
+                <button
+                  className="button button-cancel tk-memo-cancel"
+                  onClick={() => setDisplayMode(MENU_DISPLAY_MODE)}
+                >
+                  {l10n('toolkit.editMemoBack', 'Back')}
+                </button>
+                <button className="button button-primary tk-memo-save" onClick={handleConfirm}>
+                  {l10n('toolkit.editMemoSave', 'Save')}
+                </button>
+              </div>
+            </div>
+          </>
         )}
       </li>
       <li>

--- a/src/extension/features/accounts/bulk-edit-memo/settings.js
+++ b/src/extension/features/accounts/bulk-edit-memo/settings.js
@@ -5,5 +5,5 @@ module.exports = {
   section: 'accounts',
   title: 'Bulk Edit Memos',
   description:
-    'Add an option to the "Edit Transaction(s)" menu to "Edit Memo(s)" for all selected transactions.',
+    'Add an option to the "Edit Transaction(s)" menu to "Edit Memo(s)" for all selected transactions. Allows adding a prefix or a suffix to selected memos.',
 };


### PR DESCRIPTION
GitHub Issue (if applicable): #2917

Trello Link (if applicable): https://trello.com/c/GyXyE3jo/343-edit-multiple-memo-fields-at-once

**Explanation of Bugfix/Feature/Modification:**
Added selection of what you actually want to do with the memos: replace with a new value, add prefix or add suffix.

Now `EditMemo` component has 3 steps:
1. **Step 1** (default): showing just the button "Edit Memos". When you click it, it goes to **Step 2**.
2. **Step 2**: showing 4 buttons: 
    a. "Replace memos"
    b. "Add prefix to each memo"
    c. "Add suffix to each memo"
    d. "Cancel" - goes back to **Step 1**
    When you click any of the buttons a-c, the component goes to **Step 3**.
3. **Step 3**: showing:
    - a label that reminds you what you selected on **Step 2**
    - an input
    - button "Back" - go back to **Step 2**
    - button "Save" - perform bulk memo edit in the way that you chose on **Step 2**, close the menu and go back to **Step 1**).

Below are screenshots of all the possible states.

![01 - step 1](https://user-images.githubusercontent.com/23550734/194716678-11b7663c-f51b-47cb-918d-e4cd625bb757.png)
Default state - Step 1

![02 - step 2](https://user-images.githubusercontent.com/23550734/194716677-842b2781-4b54-4d56-bbab-a53888c4a741.png)
Clicked the button

![03 - step 3 - replace](https://user-images.githubusercontent.com/23550734/194716676-6e89d00e-a318-4042-a71c-f25aeba2dd59.png)
Clicked "Replace memos"

![04 - step 3 - prefix](https://user-images.githubusercontent.com/23550734/194716674-23aa7b87-1d1f-4a81-84c0-ffea5322c179.png)
Clicked "Back" and then clicked "Add prefix to each memo"

![05 - step 3 - suffix](https://user-images.githubusercontent.com/23550734/194716672-5b661c4a-fc79-45c9-bc6a-7f253c1052ec.png)
Clicked "Back" and the clicked "Add suffix to each memo"

Previously it had only **Step 1** and **Step 3**, and the only way to bulk edit memos was to replace all the old memos with the new one you inputed. Now, depending on what you selected on **Step 2**, your input will either replace the old memos, or be prepended to each of them (without adding any whitespaces), or get appended (also without adding any whitespaces).

Below are screenshots of the component built from the branch "main".
![06 - main - step 1](https://user-images.githubusercontent.com/23550734/194716670-7c76ec19-8163-4607-a04c-cac82364159c.png)
![07 - main - step 3](https://user-images.githubusercontent.com/23550734/194716669-2225e6dd-8dc8-4d44-9dbc-5c51826f822a.png)


**Additional small fix:**
Fixed paddings of the "Edit memos" menu item.