### PR TITLE
fix: remove-zero-categories observe (fixes #2919)

### DIFF
--- a/src/extension/features/budget/remove-zero-categories/index.js
+++ b/src/extension/features/budget/remove-zero-categories/index.js
@@ -1,19 +1,14 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class RemoveZeroCategories extends Feature {
-  shouldInvoke() {
-    return isCurrentRouteBudgetPage();
-  }
-
   destroy() {
     $('.modal-budget-overspending .dropdown-list > li').removeClass('tk-hidden');
   }
 
-  invoke() {
-    this.addToolkitEmberHook('modal', 'didRender', this.hideEmpties, {
-      guard: () => document.querySelector('.modal-budget-overspending') !== null,
-    });
+  observe(changedNodes) {
+    if (changedNodes.has('dropdown-container categories-dropdown-container')) {
+      this.hideEmpties();
+    }
   }
 
   hideEmpties() {


### PR DESCRIPTION
GitHub Issue (if applicable): #2919

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
For some reason, this specific modal isn't getting hooked into. Doing some observation instead.
