### PR TITLE
fix: use acct svc in cc cleared (fixes #2968)

### DIFF
--- a/src/extension/features/accounts/default-cc-to-cleared/index.js
+++ b/src/extension/features/accounts/default-cc-to-cleared/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
-import { controllerLookup } from 'toolkit/extension/utils/ember';
+import { serviceLookup } from 'toolkit/extension/utils/ember';
 import { formatCurrency, stripCurrency } from 'toolkit/extension/utils/currency';
 
 export class DefaultCCToCleared extends Feature {
@@ -8,7 +8,7 @@ export class DefaultCCToCleared extends Feature {
 
   shouldInvoke() {
     // grab the current account
-    let { selectedAccount } = controllerLookup('accounts');
+    let { selectedAccount } = serviceLookup('accounts');
     return (
       // only activate if we're on an accounts page and it's a credit card account
       isCurrentRouteAccountsPage() &&
@@ -58,7 +58,7 @@ export class DefaultCCToCleared extends Feature {
     // transaction entry model to appear
     if (didChangeInput && this.didClickRecord) {
       // grab amounts from account
-      let { selectedAccount } = controllerLookup('accounts');
+      let { selectedAccount } = serviceLookup('accounts');
       const clearedBal = selectedAccount.accountCalculation.clearedBalance;
 
       // we want to fill in the absolute value of cleared bal, since it's positive infow,


### PR DESCRIPTION
GitHub Issue (if applicable): #2968

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Using accountsService instead of accountsController due to the move of selectedAccount
