### PR TITLE
fix: observe budget table for displaying upcoming (fixes #2733)

### DIFF
--- a/src/extension/features/budget/display-upcoming-amount/index.js
+++ b/src/extension/features/budget/display-upcoming-amount/index.js
@@ -53,6 +53,15 @@ export class DisplayUpcomingAmount extends Feature {
     });
   }
 
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    // This changes when overspending filter gets toggled
+    if (changedNodes.has('budget-table-container')) {
+      this.invoke();
+    }
+  }
+
   onRouteChanged() {
     if (!this.shouldInvoke()) return;
     this.invoke();


### PR DESCRIPTION
GitHub Issue (if applicable): #2733

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
It appears the whole budget table gets re-rendered when clicking "Clear Filter" - let's watch for that.
