### PR TITLE
fix: refactor markdown notes (fixes #2958)

### DIFF
--- a/src/extension/features/budget/notes-as-markdown/styles.css
+++ b/src/extension/features/budget/notes-as-markdown/styles.css
@@ -1,13 +1,6 @@
-.tk-markdown-note {
+#tk-note-container {
   position: relative;
   min-height: 8rem;
-}
-
-.tk-markdown-guide {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  font-size: 0.7rem;
 }
 
 .inspector-notes.is-editing .inspector-category-note {

--- a/src/types/ynab/data/sub-category.d.ts
+++ b/src/types/ynab/data/sub-category.d.ts
@@ -1,5 +1,6 @@
 interface YNABSubCategory {
   entityId?: string;
   masterCategoryId?: string;
+  note: string;
   sortableIndex: number;
 }


### PR DESCRIPTION
GitHub Issue (if applicable): Fixes #2958

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Refactored the markdown notes feature due to YNAB moving the notes component to Glimmer.
