### PR TITLE
fix: use new method in manage payees option (fixes #2824)

### DIFF
--- a/src/extension/features/accounts/bulk-edit-memo/index.jsx
+++ b/src/extension/features/accounts/bulk-edit-memo/index.jsx
@@ -49,7 +49,7 @@ const EditMemo = () => {
           </div>
         )}
         {!isEditMode && (
-          <button onClick={() => setIsEditMode(true)}>
+          <button className="button-list" onClick={() => setIsEditMode(true)}>
             <i className="flaticon stroke document-1 ynab-new-icon"></i>
             {containerLookup('service:accounts').areChecked.length === 1
               ? l10n('toolkit.editMemo', 'Edit Memo')

--- a/src/extension/features/accounts/bulk-manage-payees/index.js
+++ b/src/extension/features/accounts/bulk-manage-payees/index.js
@@ -32,13 +32,13 @@ export class BulkManagePayees extends Feature {
     // The second <li> functions as a separator on the menu after the feature menu item.
     $('.modal-account-edit-transaction-move').before(
       $(`<li id="tk-manage-payees">
-          <button class="toolkit-modal-select-budget-manage-payees">
+          <button class="button-list toolkit-modal-select-budget-manage-payees">
             <i class="ynab-new-icon ember-view flaticon stroke group"><!----></i>${menuText}
           </button>
         </li>
         <li><hr /><li>
       `).on('click', () => {
-        serviceLookup('accounts').send('openPayeeModal');
+        serviceLookup('accounts').openPayeeModal();
       })
     );
   }


### PR DESCRIPTION
GitHub Issue (if applicable): Fixes #2824

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Using new `openPayeeModal()` method instead of `send('openPayeeModal')`
Added `button-list` class to bulk-manage-payees
