### PR TITLE
fix: update help button CSS selector in hide-help (fixes #2987)

### DIFF
--- a/src/extension/features/general/hide-help/index.css
+++ b/src/extension/features/general/hide-help/index.css
@@ -1,4 +1,4 @@
-body.toolkit-hide-help #hs-beacon {
+body.toolkit-hide-help .self-service {
   display: none !important;
 }
 


### PR DESCRIPTION
GitHub Issue (if applicable): #2987 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Updated CSS selector for help button.
