### PR TITLE
Progress bar emphasis color fix (fixes 2935)

### DIFF
--- a/src/extension/features/budget/goal-warning-color/index.css
+++ b/src/extension/features/budget/goal-warning-color/index.css
@@ -32,6 +32,10 @@ body.theme-classic {
   background-color: var(--tk-color-goal-warning-underfunded-hover);
 }
 
+.ynab-new-budget-bar-v2-segment.is-partially-funded {
+  background-color: var(--tk-color-goal-warning-underfunded);
+}
+
 /* inspector */
 .budget-inspector
   .budget-inspector-category-overview


### PR DESCRIPTION
GitHub Issue (if applicable): #2935

Trello Link (if applicable): n/a

**Explanation of Bugfix/Feature/Modification:**
Fix to budget feature 'goal-warning-color'. Added CSS to correctly color progress bars with blue emphasis color.
