### PR TITLE
Fix: Available Savings Zeroed out in budget inspector #2995

### DIFF
--- a/src/extension/features/budget/show-available-after-savings/index.js
+++ b/src/extension/features/budget/show-available-after-savings/index.js
@@ -31,7 +31,7 @@ export class ShowAvailableAfterSavings extends Feature {
   showAvailableAfterSavings(context) {
     const inspectorCategories = getBudgetService().inspectorCategories;
 
-    const totalAvailable = inspectorCategories.reduce((p, c) => p + c.available);
+    const totalAvailable = inspectorCategories.reduce((p, c) => p + c.available, 0);
     const totalSavings = getTotalSavings(inspectorCategories);
     const totalAvailableAfterSavings = totalAvailable - totalSavings;
 


### PR DESCRIPTION
GitHub Issue (if applicable): Closes issue #2995

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
The available after savings calculation on the "total monthly goals" feature was broken because the initial value was undefined. Setting the initial value in the reduce function corrected the issue. 


@saxtonjoshua1 This seems to be an issue where the reducer function is trying to increment the available amount for category 'c' onto 'p' which is undefined. Providing an initial value for the reducer seems to fix the issue.

const totalAvailable = inspectorCategories.reduce((p, c) => p + c.available, 0);

