### PR TITLE
feat(accounts): Compact account headers

### DIFF
--- a/src/extension/features/accounts/compact-account-header/index.css
+++ b/src/extension/features/accounts/compact-account-header/index.css
@@ -1,0 +1,22 @@
+.new-account-header .account-info-small-text {
+  display: none !important;
+}
+
+.new-account-header .accounts-header-actions .reconcile-button-and-label {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.new-account-header .accounts-header-balances .accounts-header-balances-amount-negative,
+.new-account-header .accounts-header-balances .accounts-header-balances-cleared .currency.negative,
+.new-account-header
+  .accounts-header-balances
+  .accounts-header-balances-uncleared
+  .currency.negative,
+.new-account-header .accounts-header-balances .accounts-header-balances-working .currency.negative,
+.new-account-header .accounts-header-balances .accounts-header-overspending .currency.negative,
+.new-account-header .accounts-header-balances .accounts-header-payment .currency.negative,
+.new-account-header .accounts-header-balances .accounts-header-selected-total .currency.negative {
+  color: #ca481d !important;
+}

--- a/src/extension/features/accounts/compact-account-header/index.ts
+++ b/src/extension/features/accounts/compact-account-header/index.ts
@@ -1,0 +1,34 @@
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+import { Feature } from '../../feature';
+
+export class CompactAccountHeader extends Feature {
+  injectCSS() {
+    return require('./index.css');
+  }
+
+  observe(changedNodes: Set<string>) {
+    if (!changedNodes.has('ynab-grid-body')) {
+      return;
+    }
+
+    if (this.shouldInvoke()) {
+      this.invoke();
+    }
+  }
+
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage();
+  }
+
+  invoke() {
+    let $reconcileTimeframe = $('.account-info-small-text > small[title]');
+    let $accountBalances = $('.accounts-header-balances');
+    let $accountHeaderFirstChild = $('.accounts-header-top > div:nth-child(1)');
+    let $largeEditButton = $('.accounts-header-edit-account');
+
+    $largeEditButton.remove();
+    $accountHeaderFirstChild.after($accountBalances);
+    $reconcileTimeframe.addClass('accounts-header-label');
+    $('.reconcile-button-and-label').append($reconcileTimeframe);
+  }
+}

--- a/src/extension/features/accounts/compact-account-header/settings.js
+++ b/src/extension/features/accounts/compact-account-header/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'CompactAccountHeader',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Compact Account Header',
+  description:
+    'Compact the account header. Something reminescent of the old-style account headers.',
+};


### PR DESCRIPTION
GitHub Issue (if applicable): #3008

This implements compacted account headers in the style of the old account headers. Screenshot below:


![reverted-account-header](https://user-images.githubusercontent.com/21992321/202872521-c402092e-de8b-43e2-adad-3bb84cc998e9.PNG)

Closes #3008.
