### PR TITLE
Add New Feature - Emphasize Negative Loan Amounts

### DIFF
--- a/src/extension/features/general/emphasize-negative-loans/index.css
+++ b/src/extension/features/general/emphasize-negative-loans/index.css
@@ -1,0 +1,17 @@
+/* Sidebar Numbers */
+.nav-account.loan .negative {
+  background-color: #fff !important;
+  background-color: var(--sidebar_account_negative_balance_background) !important;
+  color: #ca481d !important;
+  color: var(--label_negative) !important;
+  border-radius: 1em;
+  display: block;
+  font-weight: 700 !important;
+  margin: 0 -0.265rem 0.2rem 0.5rem !important;
+  margin-bottom: 0.2em;
+  margin-right: -0.265rem;
+  padding: 0 0.4em !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/extension/features/general/emphasize-negative-loans/index.js
+++ b/src/extension/features/general/emphasize-negative-loans/index.js
@@ -1,0 +1,7 @@
+import { Feature } from 'toolkit/extension/features/feature';
+
+export class EmphasizeNegativeLoans extends Feature {
+  injectCSS() {
+    return require('./index.css');
+  }
+}

--- a/src/extension/features/general/emphasize-negative-loans/settings.js
+++ b/src/extension/features/general/emphasize-negative-loans/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'EmphasizeNegativeLoans',
+  type: 'checkbox',
+  default: false,
+  section: 'general',
+  title: 'Emphasize Negative Loans',
+  description:
+    'Emphasize loans with negative balances similar to how other negative accounts are emphasized.',
+};


### PR DESCRIPTION
GitHub Issue (if applicable): https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/3041

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.

This one was pretty simple - I added a feature that copies the styles that are applied to other negative balances, and manually applies them to negative loan balances as well. I had to use a couple `!important`s but it looked like that was done before so felt it was okay.
