### PR TITLE
Trigger blur to save inflow before adding new sub transactions

### DIFF
--- a/src/extension/features/accounts/split-transaction-auto-adjust/index.js
+++ b/src/extension/features/accounts/split-transaction-auto-adjust/index.js
@@ -2,139 +2,41 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 export class SplitTransactionAutoAdjust extends Feature {
-  addAnotherSplit;
-
-  splitTransactionRow;
-
-  isInitialized;
-
-  addingAnotherSplit;
-
-  deletingSplit;
-
   shouldInvoke() {
-    return isCurrentRouteAccountsPage();
+    return isCurrentRouteAccountsPage() && $('.ynab-grid-split-add-sub-transaction').length !== 0;
   }
 
   invoke() {
-    this.addAnotherSplit = null;
-    this.splitTransactionRow = null;
-    this.isInitialized = false;
-    this.addingAnotherSplit = false;
-    this.deletingSplit = false;
-  }
+    let outflows = $('.is-editing .ynab-grid-cell-outflow .ember-text-field').toArray();
+    let inflows = $('.is-editing .ynab-grid-cell-inflow .ember-text-field').toArray();
 
-  initialize() {
-    this.splitTransactionRow = $('.ynab-grid-add-rows');
-    this.addAnotherSplit = $('.ynab-grid-split-add-sub-transaction');
+    let remaining = ynab.unformat(inflows[0].value) - ynab.unformat(outflows[0].value);
 
-    this.splitTransactionRow.on(
-      'keyup',
-      '.currency-input .ember-text-field',
-      this,
-      this.onKeyPress
-    );
-    this.splitTransactionRow.on('click', '.ynab-grid-sub-remove', this.onDeleteSplit);
-    this.addAnotherSplit.on('click', this.onAddAnotherSplit);
-  }
-
-  onKeyPress(event) {
-    let _this = event.data;
-    let element = $(this);
-    let currentInputClass = _this.getCurrentInputClass();
-
-    if ($(element).parents(currentInputClass).length) {
-      _this.autoFillNextRow(element);
+    for (let i = 1; i < outflows.length; i++) {
+      remaining -= ynab.unformat(inflows[i].value);
+      remaining += ynab.unformat(outflows[i].value);
     }
-  }
 
-  getCurrentInputClass() {
-    let firstRow = $('.ynab-grid-body-row', this.splitTransactionRow).first();
-    let outflowValue = ynab.unformat(
-      $('.ynab-grid-cell-outflow .ember-text-field', firstRow).val()
-    );
-    let inflowValue = ynab.unformat($('.ynab-grid-cell-inflow .ember-text-field', firstRow).val());
-    return outflowValue > 0
-      ? '.ynab-grid-cell-outflow'
-      : inflowValue > 0
-      ? '.ynab-grid-cell-inflow'
-      : false;
-  }
-
-  onAddAnotherSplit() {
-    this.addingAnotherSplit = true;
-  }
-
-  onDeleteSplit() {
-    this.deletingSplit = true;
-  }
-
-  autoFillNextRow(currentInputElement) {
-    let inputClass = this.getCurrentInputClass();
-    let total =
-      ynab.unformat(
-        $(inputClass + ' .ember-text-field', this.splitTransactionRow.children().eq(0)).val()
-      ) * 1000;
-    // local version of the class variable to get around the 'this' issue in the .each() function below.
-    let splitTransactionRow = this.splitTransactionRow;
-
-    if (inputClass && total) {
-      let currentRow = $(currentInputElement).parents('.ynab-grid-body-row');
-      let currentRowIndex = splitTransactionRow.children().index(currentRow);
-      let currentValue = ynab.unformat($(currentInputElement).val()) * 1000;
-
-      splitTransactionRow.children().each(function (index, splitRow) {
-        if (index === currentRowIndex) {
-          let nextRow = splitTransactionRow.children().eq(currentRowIndex + 1);
-          if (index === 0) {
-            $(inputClass + ' .ember-text-field', nextRow).val(ynab.formatCurrency(total));
-            $(inputClass + ' .ember-text-field', nextRow).trigger('change');
-          } else {
-            total -= currentValue;
-            $(inputClass + ' .ember-text-field', nextRow).val(ynab.formatCurrency(total));
-            $(inputClass + ' .ember-text-field', nextRow).trigger('change');
+    if (remaining) {
+      for (let i = 1; i < outflows.length; i++) {
+        if (outflows[i].value === '' && inflows[i].value === '') {
+          if (remaining < 0) {
+            $(outflows[i]).val(ynab.formatCurrency(-remaining * 1000));
+            $(outflows[i]).trigger('change');
+            $(outflows[i]).trigger('blur');
+          } else if (remaining > 0) {
+            $(inflows[i]).val(ynab.formatCurrency(remaining * 1000));
+            $(inflows[i]).trigger('change');
+            $(inflows[i]).trigger('blur');
           }
-        } else if (index < currentRowIndex) {
-          if (index !== 0) {
-            // don't decrement total if we're the total row, that's silly
-            total -= ynab.unformat($(inputClass + ' .ember-text-field', splitRow).val()) * 1000;
-          }
+          break;
         }
-      });
-    }
-  }
-
-  observe(changedNodes) {
-    if (!this.shouldInvoke()) return;
-
-    let addTransactionSplit = changedNodes.has(
-      'button button-primary modal-account-categories-split-transaction'
-    );
-    let editSplitTransaction = changedNodes.has(
-      'ynab-grid-body-row ynab-grid-body-split is-editing'
-    );
-    let splitTransactionNodeChanged = addTransactionSplit && !editSplitTransaction;
-    let splitTransactionButton = $('.ynab-grid-split-add-sub-transaction').length !== 0;
-
-    if (this.addingAnotherSplit) {
-      this.addingAnotherSplit = false;
-
-      let inputClass = this.getCurrentInputClass();
-      let currentLastSplitRow = $('.ynab-grid-body-sub', this.splitTransactionRow).eq(-2);
-      let lastSplitInput = $(inputClass + ' .ember-text-field', currentLastSplitRow)[0];
-
-      this.autoFillNextRow(lastSplitInput);
-    } else if (this.deletingSplit) {
-      this.deletingSplit = false;
-    } else if (splitTransactionNodeChanged) {
-      if (splitTransactionButton) {
-        if (!this.isInitialized) {
-          this.isInitialized = true;
-          this.initialize();
-        }
-      } else {
-        this.isInitialized = false;
       }
     }
+  }
+
+  observe() {
+    if (!this.shouldInvoke()) return;
+    this.invoke();
   }
 }

--- a/src/extension/features/accounts/split-transaction-tab-expand/index.js
+++ b/src/extension/features/accounts/split-transaction-tab-expand/index.js
@@ -22,6 +22,8 @@ export class SplitTransactionTabExpand extends Feature {
   applyNewTabBehavior(event) {
     // If tab was pressed, simulate a mouse click on the "Add another split" button
     if (event.keyCode === 9 && !event.shiftKey) {
+      $(event.target).trigger('blur');
+
       let addSplitButton = $('.ynab-grid-split-add-sub-transaction');
       if (addSplitButton.length !== 0) {
         // The YNAB app checks the detail property isn't 0, so .click() won't work


### PR DESCRIPTION
GitHub Issue (if applicable): #2844 

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.

applyNewTabBehavior function is called on keydown, which meant that the blur event that ynab expects wasn't being triggered, and so the value of the input box wasn't being saved.  Added one line to trigger the blur event manually. 
