### PR TITLE
Income vs Expense Report could show NaN% savings ratio

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.jsx
@@ -17,7 +17,7 @@ export const MonthlySavingsRatioRow = (props) => {
   );
 
   let allMonthsRatioTotal = 0;
-  if (allMonthsIncomeTotal >= allMonthsExpenseTotal) {
+  if (allMonthsIncomeTotal !== 0 && allMonthsIncomeTotal >= allMonthsExpenseTotal) {
     allMonthsRatioTotal = 1 - allMonthsExpenseTotal / allMonthsIncomeTotal;
   }
 
@@ -38,7 +38,7 @@ export const MonthlySavingsRatioRow = (props) => {
           const incomeTotal = incomeMonthData.get('total');
           const expenseTotal = Math.abs(expenseMonthData.get('total'));
           let ratio = 0;
-          if (incomeTotal >= expenseTotal) {
+          if (incomeTotal !== 0 && incomeTotal >= expenseTotal) {
             ratio = 1 - expenseTotal / incomeTotal;
           }
 


### PR DESCRIPTION
GitHub Issue (if applicable): #3036 

**Explanation of Bugfix/Feature/Modification:**
A clear and concise description of what changes you've made and why.

MonthlySavingsRatioRow had two places where a divide by zero error could occur when calculating the savings ratio.  