### PR TITLE
fix: allow site access to app.ynab.com

### DIFF
--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -4,7 +4,8 @@
       "matches": [
         "http://*.youneedabudget.com/*",
         "https://*.youneedabudget.com/*",
-        "https://app.ynab.com/*"
+        "https://*.ynab.com/*",
+        "http://*.ynab.com/*"
       ],
       "all_frames": true,
       "run_at": "document_idle",
@@ -29,7 +30,8 @@
   "permissions": [
     "http://*.youneedabudget.com/*",
     "https://*.youneedabudget.com/*",
-    "https://app.ynab.com/*",
+    "https://*.ynab.com/*",
+    "http://*.ynab.com/*",
     "storage"
   ]
 }

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,7 +1,11 @@
 {
   "content_scripts": [
     {
-      "matches": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*"],
+      "matches": [
+        "http://*.youneedabudget.com/*",
+        "https://*.youneedabudget.com/*",
+        "https://app.ynab.com/*"
+      ],
       "all_frames": true,
       "run_at": "document_idle",
       "js": ["content-scripts/extension-bridge.js"]
@@ -22,5 +26,10 @@
     "default_title": "Toolkit for YNAB",
     "default_popup": "popup/index.html"
   },
-  "permissions": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*", "storage"]
+  "permissions": [
+    "http://*.youneedabudget.com/*",
+    "https://*.youneedabudget.com/*",
+    "https://app.ynab.com/*",
+    "storage"
+  ]
 }

--- a/src/manifest.ios.json
+++ b/src/manifest.ios.json
@@ -4,7 +4,8 @@
       "matches": [
         "http://*.youneedabudget.com/*",
         "https://*.youneedabudget.com/*",
-        "https://app.ynab.com/*"
+        "https://*.ynab.com/*",
+        "http://*.ynab.com/*"
       ],
       "all_frames": true,
       "run_at": "document_idle",
@@ -30,7 +31,8 @@
   "permissions": [
     "http://*.youneedabudget.com/*",
     "https://*.youneedabudget.com/*",
-    "https://app.ynab.com/*",
+    "https://*.ynab.com/*",
+    "http://*.ynab.com/*",
     "storage"
   ]
 }

--- a/src/manifest.ios.json
+++ b/src/manifest.ios.json
@@ -1,7 +1,11 @@
 {
   "content_scripts": [
     {
-      "matches": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*"],
+      "matches": [
+        "http://*.youneedabudget.com/*",
+        "https://*.youneedabudget.com/*",
+        "https://app.ynab.com/*"
+      ],
       "all_frames": true,
       "run_at": "document_idle",
       "js": ["content-scripts/extension-bridge.js"]
@@ -23,5 +27,10 @@
     "default_title": "Toolkit for YNAB",
     "default_popup": "popup/index.html"
   },
-  "permissions": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*", "storage"]
+  "permissions": [
+    "http://*.youneedabudget.com/*",
+    "https://*.youneedabudget.com/*",
+    "https://app.ynab.com/*",
+    "storage"
+  ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,11 @@
   "version": "3.5.0",
   "content_scripts": [
     {
-      "matches": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*"],
+      "matches": [
+        "http://*.youneedabudget.com/*",
+        "https://*.youneedabudget.com/*",
+        "https://app.ynab.com/*"
+      ],
       "all_frames": true,
       "run_at": "document_idle",
       "js": ["content-scripts/extension-bridge.js"]
@@ -25,7 +29,11 @@
   "web_accessible_resources": [
     {
       "resources": ["assets/*", "web-accessibles/*"],
-      "matches": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*"]
+      "matches": [
+        "http://*.youneedabudget.com/*",
+        "https://*.youneedabudget.com/*",
+        "https://app.ynab.com/*"
+      ]
     }
   ],
   "background": {
@@ -43,5 +51,9 @@
     "default_popup": "popup/index.html"
   },
   "permissions": ["storage"],
-  "host_permissions": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*"]
+  "host_permissions": [
+    "http://*.youneedabudget.com/*",
+    "https://*.youneedabudget.com/*",
+    "https://app.ynab.com/*"
+  ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,8 @@
       "matches": [
         "http://*.youneedabudget.com/*",
         "https://*.youneedabudget.com/*",
-        "https://app.ynab.com/*"
+        "https://*.ynab.com/*",
+        "http://*.ynab.com/*"
       ],
       "all_frames": true,
       "run_at": "document_idle",
@@ -32,7 +33,8 @@
       "matches": [
         "http://*.youneedabudget.com/*",
         "https://*.youneedabudget.com/*",
-        "https://app.ynab.com/*"
+        "https://*.ynab.com/*",
+        "http://*.ynab.com/*"
       ]
     }
   ],
@@ -54,6 +56,7 @@
   "host_permissions": [
     "http://*.youneedabudget.com/*",
     "https://*.youneedabudget.com/*",
-    "https://app.ynab.com/*"
+    "https://*.ynab.com/*",
+    "http://*.ynab.com/*"
   ]
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #3067 

**Explanation of Bugfix/Feature/Modification:**

It looks like YNAB have moved to app.ynab.com for the web version of the app at the moment. I can't see why this would be a temporary change, but I've kept the old hostnames in there just incase.

Fixes #3067 and #3066.