### PR TITLE
Update permission to read from new domain

### DIFF
--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "content_scripts": [
     {
-      "matches": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*"],
+      "matches": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*","http://*.ynab.com/*","https://*.ynab.com/*"],
       "all_frames": true,
       "run_at": "document_idle",
       "js": ["content-scripts/extension-bridge.js"]
@@ -22,5 +22,5 @@
     "default_title": "Toolkit for YNAB",
     "default_popup": "popup/index.html"
   },
-  "permissions": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*", "storage"]
+  "permissions": ["http://*.youneedabudget.com/*", "https://*.youneedabudget.com/*","http://*.ynab.com/*","https://*.ynab.com/*","storage"]
 }


### PR DESCRIPTION
Add domains and permissions for the ynab domain

GitHub Issue (if applicable): https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/3067

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
This is to allow firefox permission to read site data from the new domain ynab.com
