### PR TITLE
Implemented Link-In-Memo

### DIFF
--- a/src/extension/features/budget/link-in-memo/index.js
+++ b/src/extension/features/budget/link-in-memo/index.js
@@ -1,0 +1,44 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+
+export class LinkInMemo extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage();
+  }
+
+  invoke() {
+    // Select the memo cells
+    let memos = document.querySelectorAll('.ynab-grid-cell-memo:not(.ynab-grid-header-cell)');
+
+    // Loop through each cell to turn it into a link if the memo starts with "https://"
+    memos.forEach((memo) => {
+      if (!memo.dataset.isLink) {
+        let title = memo.getAttribute('title');
+        if (typeof title === 'string' && title.toLowerCase().startsWith('https://')) {
+          // Get the span containing the full link (title may be truncacted)
+          let span = memo.querySelector('span');
+
+          // Create a link element
+          let link = document.createElement('a');
+          link.setAttribute('href', span.innerText);
+          link.setAttribute('target', '_blank');
+          link.innerText = span.innerText;
+
+          // Swap the original text for the link
+          span.innerText = '';
+          span.appendChild(link);
+
+          // Mark this memo as having a link to prevent duplicate modification
+          memo.dataset.isLink = true;
+        }
+      }
+    });
+  }
+
+  observe(changedNodes) {
+    if (!changedNodes.has('ynab-grid-body')) return;
+    if (this.shouldInvoke()) {
+      this.invoke();
+    }
+  }
+}

--- a/src/extension/features/budget/link-in-memo/settings.js
+++ b/src/extension/features/budget/link-in-memo/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'LinkInMemo',
+  type: 'checkbox',
+  default: false,
+  section: 'budget',
+  title: 'Hyperlinks in the memo field',
+  description:
+    'Any memo on the budget screen that starts with "https://", will be displayed as a hyperlink. Use this to link to files in your favourite cloud storage (iCloud, OneDrive, Dropbox, etc.) Note - "http", rather than "https", links are ignored for security reasons.',
+};


### PR DESCRIPTION
**Explanation of Feature:**
* Display any memo on the accounts page that starts with **https://** as a hyperlink.
* This is a simple workaround for the often requested feature of uploading/managing receipts and proof of purchase in ynab, by linking to cloud service providers
* Alternatively, you could link to online order confirmation/history (e.g. amazon) or any other useful website for each transaction