### PR TITLE
fix: #3079 Add date filtering util to outflow-over-time

### DIFF
--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.jsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.jsx
@@ -7,6 +7,7 @@ import {
   filterTransactions,
   groupTransactions,
   toHighchartsSeries,
+  filterTransactionsByDate,
 } from './utils';
 import { OutflowGraph } from './OutflowGraph';
 import { useLocalStorage } from 'toolkit/extension/hooks/useLocalStorage';
@@ -14,6 +15,8 @@ import { LabeledCheckbox } from 'toolkit/extension/features/toolkit-reports/comm
 
 export const OutflowOverTimeComponent = ({ allReportableTransactions, filters }) => {
   const [outflowSeries, setOutflowSeries] = useState([]);
+
+  // Using CumulativeSum will show a growing trendline over the dates.
   const [cumulativeSum, setCumulativeSum] = useLocalStorage(
     'outflow-over-time-useCumulativeSum',
     true
@@ -21,6 +24,9 @@ export const OutflowOverTimeComponent = ({ allReportableTransactions, filters })
 
   useEffect(() => {
     const filterOutAccounts = filters.accountFilterIds;
+
+    // These dates are used to appropriately filter based on the report context.
+    const { fromDate, toDate } = filters.dateFilter;
     const calculateOutflow = cumulativeSum
       ? calculateCumulativeOutflowPerDate
       : calculateOutflowPerDate;
@@ -28,7 +34,12 @@ export const OutflowOverTimeComponent = ({ allReportableTransactions, filters })
     setOutflowSeries(
       toHighchartsSeries(
         calculateOutflow(
-          groupTransactions(filterTransactions(allReportableTransactions, filterOutAccounts))
+          groupTransactions(
+            filterTransactions(
+              filterTransactionsByDate(allReportableTransactions, fromDate, toDate),
+              filterOutAccounts
+            )
+          )
         )
       )
     );

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.js
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.js
@@ -14,6 +14,19 @@ export const filterTransactions = (transactions, filterOutAccounts) => {
     });
 };
 
+/**
+ * Filter the passed transactions to only include those within the specified date range.
+ * @param {Array} transactions - The array of transactions to be filtered.
+ * @param {Date} startDate - The start date of the desired date range.
+ * @param {Date} endDate - The end date of the desired date range.
+ * @returns {Array} - A new array containing only the transactions that fall within the specified date range.
+ */
+export const filterTransactionsByDate = (transactions, startDate, endDate) => {
+  return transactions.filter((transaction) => {
+    return transaction.date >= startDate && transaction.date <= endDate;
+  });
+};
+
 export const groupTransactions = (transactions) => {
   const groupedByMonth = lodash.groupBy(transactions, 'month');
   const groupedByMonthAndDate = {};


### PR DESCRIPTION
GitHub Issue (if applicable): #3079

In the current state, the `Outflow Over Time` report does not appropriately filter transactions by the date ranges. 
![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/17659270/ed0747e0-6f10-420d-9be1-d2b6d9fd1db4)
In the above screenshot, notice the date range is only for `June 2023 - June 2023` so only transactions from June 2023 or (`2023-06` in the legend) should appear in the graph. However, all month/year combinations from the accounts' history show up. 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
I added a new function `filterTransactionsByDate` that filters the passed transactions with the from and to dates available in the filters context: `filters.dateFilter`. I also added a few small comments to contextualize variables.

This now properly shows only the transactions that exist within the date range for the selected accounts. Here is the current month:
![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/17659270/97f0501c-b058-4c40-a957-8add85e84db2)

Sample of the latest three months:
![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/17659270/bab42bbe-4a16-4406-a9ea-c82a9933e91a)

Sample of this year:
![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/17659270/bda89a08-e29e-470f-b6f0-a1a31d21d23d)

As a random note, thank you to @simonjohansson for building this out in the first place! And for all the maintainers of this project. 
