### PR TITLE
fix: get budgetViewModel from budget service instead of budget controller

### DIFF
--- a/src/extension/utils/ynab.ts
+++ b/src/extension/utils/ynab.ts
@@ -73,11 +73,11 @@ export function getCurrentRouteName() {
 }
 
 export function getAllBudgetMonthsViewModel() {
-  return getBudgetController()?.budgetViewModel?.allBudgetMonthsViewModel;
+  return getBudgetService()?.budgetViewModel?.allBudgetMonthsViewModel;
 }
 
 export function getBudgetViewModel() {
-  return getBudgetController()?.budgetViewModel;
+  return getBudgetService()?.budgetViewModel;
 }
 
 export function getSelectedMonth() {

--- a/src/types/ynab/controllers/YNABBudgetController.d.ts
+++ b/src/types/ynab/controllers/YNABBudgetController.d.ts
@@ -1,8 +1,4 @@
 interface YNABBudgetController {
   applicationService: YNABApplicationService;
   budgetService: YNABBudgetService;
-  budgetViewModel?: {
-    allBudgetMonthsViewModel: {};
-    month: DateWithoutTime;
-  };
 }

--- a/src/types/ynab/services/YNABBudgetService.d.ts
+++ b/src/types/ynab/services/YNABBudgetService.d.ts
@@ -5,6 +5,10 @@ interface YNABBudgetMonthDisplayItem {
 
 interface YNABBudgetService {
   activeCategory: {};
+  budgetViewModel?: {
+    allBudgetMonthsViewModel: {};
+    month: DateWithoutTime;
+  };
   checkedRowsCount: number;
   checkedRows: YNABBudgetMonthDisplayItem[];
   inspectorCategories: [];


### PR DESCRIPTION
GitHub Issue (if applicable): #3157 

**Explanation of Bugfix:**
It looks like `budgetViewModel` moved from BudgetController to BudgetService. Updating it fixes SubtractUpcomingFromAvailable and any other features that depend on `getSelectedMonth`