### PR TITLE
fix(auto-enable-running-balance): use service instead of controller to toggle running balance column

### DIFF
--- a/src/extension/features/accounts/auto-enable-running-balance/index.js
+++ b/src/extension/features/accounts/auto-enable-running-balance/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
-import { controllerLookup, serviceLookup } from 'toolkit/extension/utils/ember';
+import { serviceLookup } from 'toolkit/extension/utils/ember';
 
 export class AutoEnableRunningBalance extends Feature {
   shouldInvoke() {
@@ -8,7 +8,7 @@ export class AutoEnableRunningBalance extends Feature {
   }
 
   invoke() {
-    const { selectedAccountId } = controllerLookup('accounts');
+    const { selectedAccountId } = serviceLookup('accounts');
     const registerGridService = serviceLookup('register-grid');
     if (!registerGridService) {
       return;


### PR DESCRIPTION
GitHub Issue (if applicable): -

Trello Link (if applicable): -

**Explanation of Bugfix/Feature/Modification:**
Use accounts service instead of controller to auto-enable the running balance column.
