### PR TITLE
fix: use accountsService for toggleSplits

### DIFF
--- a/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
+++ b/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 import { l10n } from 'toolkit/extension/utils/toolkit';
-import { getEmberView } from 'toolkit/extension/utils/ember';
-import { getEntityManager } from 'toolkit/extension/utils/ynab';
+import { getAccountsService, getEntityManager } from 'toolkit/extension/utils/ynab';
 
 export class ToggleSplitButton extends React.Component {
   state = {
@@ -53,16 +52,16 @@ export class ToggleSplitButton extends React.Component {
       }, collapsedSplitsMap);
     });
 
-    const emberView = getEmberView($('.ynab-grid').attr('id'));
-    if (emberView) {
-      emberView.set('collapsedSplits', collapsedSplitsMap);
+    const accountService = getAccountsService();
+    if (accountService) {
+      accountService.collapsedSplits = collapsedSplitsMap;
     }
   };
 
   showAllSplits = () => {
-    const emberView = getEmberView($('.ynab-grid').attr('id'));
-    if (emberView) {
-      emberView.set('collapsedSplits', {});
+    const accountsService = getAccountsService();
+    if (accountsService) {
+      accountsService.collapsedSplits = {};
     }
   };
 }

--- a/src/extension/features/accounts/toggle-splits/index.js
+++ b/src/extension/features/accounts/toggle-splits/index.js
@@ -16,7 +16,7 @@ export class ToggleSplits extends Feature {
 
     componentAfter(
       <ToggleSplitButton />,
-      document.querySelector('.accounts-toolbar-edit-transaction')
+      document.querySelector('.js-accounts-toolbar-file-import-transactions')
     );
   }
 

--- a/src/extension/utils/ynab.ts
+++ b/src/extension/utils/ynab.ts
@@ -73,7 +73,7 @@ export function getApplicationService() {
 }
 
 export function getAccountsService() {
-  return serviceLookup<YNABBudgetService>('accounts');
+  return serviceLookup<YNABAccountsService>('accounts');
 }
 
 export function getBudgetService() {

--- a/src/types/ynab/services/YNABAccountsService.d.ts
+++ b/src/types/ynab/services/YNABAccountsService.d.ts
@@ -1,3 +1,6 @@
 interface YNABAccountsService {
   selectedAccountId: string;
+  collapsedSplits: {
+    [transactionID: string]: boolean;
+  };
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #3147 

**Explanation of Bugfix/Feature/Modification:**
using accounts service directly since we can't get it from the ynab-grid ember view
