### PR TITLE
fix: Days of buffering missing

### DIFF
--- a/src/extension/features/budget/days-of-buffering/index.js
+++ b/src/extension/features/budget/days-of-buffering/index.js
@@ -37,7 +37,7 @@ export class DaysOfBuffering extends Feature {
       }
 
       onBudgetBalance = onBudgetAccounts.reduce((reduced, current) => {
-        const calculation = current.getAccountCalculation();
+        const calculation = current.accountCalculation;
         if (calculation && !calculation.getAccountIsTombstone()) {
           reduced += calculation.getBalance();
         }


### PR DESCRIPTION
GitHub Issue: fixes #3176, fixes #3181

**Explanation of Bugfix:**
Using the budget account's `accountCalculation` property since the `getAccountCalculation` method is no longer available


<img width="1178" alt="YNAB toolkit age of money fix" src="https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/1435784/559ece2e-5fc1-46d1-b2b5-40bd22b216cc">
