### PR TITLE
fix: approve selected transactions via key

### DIFF
--- a/src/extension/features/accounts/bulk-edit-memo/index.jsx
+++ b/src/extension/features/accounts/bulk-edit-memo/index.jsx
@@ -3,11 +3,7 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { containerLookup } from 'toolkit/extension/utils/ember';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 import { componentAfter } from 'toolkit/extension/utils/react';
-import {
-  getTransactionById,
-  getEntityManager,
-  getModalService,
-} from 'toolkit/extension/utils/ynab';
+import { getEntityManager, getModalService } from 'toolkit/extension/utils/ynab';
 
 const DEFAULT_DISPLAY_MODE = 'defaultDisplayMode';
 const MENU_DISPLAY_MODE = 'menuDisplayMode';
@@ -38,7 +34,7 @@ const EditMemo = () => {
     const checkedRows = containerLookup('service:accounts').areChecked;
     getEntityManager().performAsSingleChangeSet(() => {
       checkedRows.forEach((transaction) => {
-        const entity = getTransactionById(transaction.entityId);
+        const entity = getEntityManager().getTransactionById(transaction.entityId);
         const memoPrevValue = transaction.memo || '';
         if (entity) {
           entity.memo = makeNewMemo(memoPrevValue);

--- a/src/extension/features/accounts/bulk-edit-memo/index.jsx
+++ b/src/extension/features/accounts/bulk-edit-memo/index.jsx
@@ -3,7 +3,11 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { containerLookup } from 'toolkit/extension/utils/ember';
 import { l10n } from 'toolkit/extension/utils/toolkit';
 import { componentAfter } from 'toolkit/extension/utils/react';
-import { getEntityManager, getModalService } from 'toolkit/extension/utils/ynab';
+import {
+  getTransactionById,
+  getEntityManager,
+  getModalService,
+} from 'toolkit/extension/utils/ynab';
 
 const DEFAULT_DISPLAY_MODE = 'defaultDisplayMode';
 const MENU_DISPLAY_MODE = 'menuDisplayMode';
@@ -32,13 +36,12 @@ const EditMemo = () => {
 
   const handleConfirm = () => {
     const checkedRows = containerLookup('service:accounts').areChecked;
-    const { transactionsCollection } = getEntityManager();
     getEntityManager().performAsSingleChangeSet(() => {
       checkedRows.forEach((transaction) => {
-        const entity = transactionsCollection.findItemByEntityId(transaction.entityId);
+        const entity = getTransactionById(transaction.entityId);
         const memoPrevValue = transaction.memo || '';
         if (entity) {
-          entity.set('memo', makeNewMemo(memoPrevValue));
+          entity.memo = makeNewMemo(memoPrevValue);
         }
       });
     });

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { containerLookup } from 'toolkit/extension/utils/ember';
-import { getEntityManager } from 'toolkit/extension/utils/ynab';
+import { getTransactionById, getEntityManager } from 'toolkit/extension/utils/ynab';
 
 export class EasyTransactionApproval extends Feature {
   shouldInvoke() {
@@ -31,12 +31,11 @@ export class EasyTransactionApproval extends Feature {
 
       if (isInputEvent) return;
 
-      const { transactionsCollection } = getEntityManager();
       getEntityManager().batchChangeProperties(() => {
         containerLookup('service:accounts').areChecked.forEach((transaction) => {
-          const entity = transactionsCollection.findItemByEntityId(transaction?.entityId);
+          const entity = getTransactionById(transaction?.entityId);
           if (entity) {
-            entity.set('accepted', true);
+            entity.accepted = true;
           }
         });
       });
@@ -55,11 +54,10 @@ export class EasyTransactionApproval extends Feature {
 
     const rowId = event.currentTarget?.parentElement?.parentElement?.dataset?.rowId;
     if (rowId) {
-      const { transactionsCollection } = getEntityManager();
       getEntityManager().batchChangeProperties(() => {
-        const entity = transactionsCollection.findItemByEntityId(rowId);
+        const entity = getTransactionById(rowId);
         if (entity) {
-          entity.set('accepted', true);
+          entity.accepted = true;
         }
       });
     }

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { containerLookup } from 'toolkit/extension/utils/ember';
-import { getTransactionById, getEntityManager } from 'toolkit/extension/utils/ynab';
+import { getEntityManager } from 'toolkit/extension/utils/ynab';
 
 export class EasyTransactionApproval extends Feature {
   shouldInvoke() {
@@ -33,7 +33,7 @@ export class EasyTransactionApproval extends Feature {
 
       getEntityManager().batchChangeProperties(() => {
         containerLookup('service:accounts').areChecked.forEach((transaction) => {
-          const entity = getTransactionById(transaction?.entityId);
+          const entity = getEntityManager().getTransactionById(transaction?.entityId);
           if (entity) {
             entity.accepted = true;
           }
@@ -55,7 +55,7 @@ export class EasyTransactionApproval extends Feature {
     const rowId = event.currentTarget?.parentElement?.parentElement?.dataset?.rowId;
     if (rowId) {
       getEntityManager().batchChangeProperties(() => {
-        const entity = getTransactionById(rowId);
+        const entity = getEntityManager().getTransactionById(rowId);
         if (entity) {
           entity.accepted = true;
         }

--- a/src/extension/utils/ynab.ts
+++ b/src/extension/utils/ynab.ts
@@ -9,6 +9,10 @@ export function getEntityManager() {
   return ynab.YNABSharedLib.defaultInstance.entityManager;
 }
 
+export function getTransactionById(id: string) {
+  return getEntityManager().getTransactionById(id);
+}
+
 export function getCurrentBudgetDate() {
   const date = getSelectedMonth()?.format('YYYYMM');
   return { year: date?.slice(0, 4), month: date?.slice(4, 6) };

--- a/src/extension/utils/ynab.ts
+++ b/src/extension/utils/ynab.ts
@@ -9,10 +9,6 @@ export function getEntityManager() {
   return ynab.YNABSharedLib.defaultInstance.entityManager;
 }
 
-export function getTransactionById(id: string) {
-  return getEntityManager().getTransactionById(id);
-}
-
 export function getCurrentBudgetDate() {
   const date = getSelectedMonth()?.format('YYYYMM');
   return { year: date?.slice(0, 4), month: date?.slice(4, 6) };


### PR DESCRIPTION
GitHub Issue (if applicable): #3199

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
It looks like `ynab.YNABSharedLib.defaultInstance.entityManager` no longer has the method `findItemByEntityId`, but the same action can be accomplished via `entityManager.getTransactionById`. Further, the found `entity` doesn't support `set`ting properties anymore, but writing to them via `=` does (I'm guessing they converted those to tracked properties).

I'm sure this touches on lots of other little issues elsewhere, but this <kbd>a</kbd> / <kbd>Enter</kbd> feature fix seemed nicely scoped, and is (selfishly) sorely missed in my own budgeting process!
