### PR TITLE
fix: use native getters/setters on "transaction" values

### DIFF
--- a/src/extension/features/accounts/check-numbers/index.js
+++ b/src/extension/features/accounts/check-numbers/index.js
@@ -72,7 +72,7 @@ export class CheckNumbers extends Feature {
       .addClass('accounts-text-field')
       .addClass('ynab-grid-cell-tk-check-number-input')
       .on('blur', function () {
-        transaction.set('checkNumber', $(this).val());
+        transaction.checkNumber = $(this).val();
       });
 
     $inputBox.val(transaction.checkNumber);

--- a/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
+++ b/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
@@ -44,7 +44,7 @@ export class ToggleSplitButton extends React.Component {
 
     [scheduledTransactionsCollection, transactionsCollection].forEach((collection) => {
       collection.reduce((reduced, transaction) => {
-        if (transaction.getIsSplit()) {
+        if (transaction.isSplit) {
           reduced[transaction?.entityId] = true;
         }
 

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/component.jsx
@@ -180,7 +180,7 @@ export class InflowOutflowComponent extends React.Component {
 
       const transactionAccountId = transaction.accountId;
 
-      if (transaction.getIsOnBudgetTransfer()) {
+      if (transaction.isOnBudgetTransfer) {
         return;
       }
 

--- a/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-category/component.jsx
@@ -82,7 +82,7 @@ export class SpendingByCategoryComponent extends React.Component {
     const spendingByMasterCategory = new Map();
 
     this.props.filteredTransactions.forEach((transaction) => {
-      if (transaction.getIsOnBudgetTransfer()) {
+      if (transaction.isOnBudgetTransfer) {
         return;
       }
 

--- a/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/spending-by-payee/component.jsx
@@ -65,7 +65,7 @@ export class SpendingByPayeeComponent extends React.Component {
     const spendingByPayeeData = new Map();
 
     this.props.filteredTransactions.forEach((transaction) => {
-      if (transaction.getIsOnBudgetTransfer()) {
+      if (transaction.isOnBudgetTransfer) {
         return;
       }
 


### PR DESCRIPTION
Fixes #3209, #3213, #3215

**Explanation of Bugfix/Feature/Modification:**
Changes calls to now-removed get wrappers in "transaction" values to direct getter/setter access; likely missed by #3194