### PR TITLE
highlight mis-budgeted CC accounts in budgets nav

### DIFF
--- a/src/extension/features/budget/check-credit-balances/index.css
+++ b/src/extension/features/budget/check-credit-balances/index.css
@@ -19,3 +19,10 @@
   background: var(--budget_balance_warning_background) !important;
   color: var(--budget_balance_warning_text) !important;
 }
+
+svg.cc-budget-mismatch {
+  fill: var(--message_warning_accent);
+  margin-left: 0.5em;
+  height: 13px;
+  width: 13px;
+}

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -94,9 +94,39 @@ export class CheckCreditBalances extends Feature {
     if (!category.isCreditCardPaymentCategory) return;
 
     const difference = this.calculateDifference(category);
-    if (difference && category.available >= 0)
+    const categoryAccountId = category.subCategoryAccount?.entityId;
+    const accountBudgetLabel = categoryAccountId
+      ? document.querySelector(`a[data-account-id='${categoryAccountId}']`)
+      : undefined;
+
+    if (difference) {
+      // Upsert the indicator on the accounts nav
+      let mismatchIndicator = accountBudgetLabel?.querySelector('.cc-budget-mismatch');
+      if (mismatchIndicator) {
+        mismatchIndicator.style.display = 'inline';
+      } else if (accountBudgetLabel) {
+        const accountNameElem = accountBudgetLabel.querySelector('.nav-account-name');
+        $(accountNameElem).append(this.alertIcon());
+      }
+      // set the background in the budget nav
       categoryElement.setAttribute('data-tk-pif-assist', 'true');
-    else categoryElement.removeAttribute('data-tk-pif-assist');
+    } else {
+      // hide the indicator in the accounts nav
+      accountBudgetLabel?.querySelectorAll('.cc-budget-mismatch').forEach((elem) => {
+        elem.style.display = 'none';
+      });
+      // unset the background in the budget nav
+      categoryElement.removeAttribute('data-tk-pif-assist');
+    }
+  }
+
+  alertIcon() {
+    return $(`
+      <svg class="ynab-new-icon view-button-icon cc-budget-mismatch">
+        <title>Account balance does not match available funds in budget.</title>
+        <use href="#icon_sprite_general_warning"></use>
+      </svg>
+    `);
   }
 
   calculateDifference(category) {


### PR DESCRIPTION
> **note**
> I wrote this "on spec", without a Trello card or GH issue. I couldn't find any existing cards or issues for this, but am happy to file one if you like! :-)

GitHub Issue (if applicable): none

Trello Link (if applicable): none

**Explanation of Bugfix/Feature/Modification:**

This augments the check-credit-balances feature to also add a warning icon to the corresponding account (in the Accounts nav) when it's out of sync with its budget.

This slightly tweaks the existing logic, in that it now always sets the budget's background to the warning color, instead of only doing so when the available amount is non-negative.

Since we always try to pay off our credit cards in full via autopay, we typically don't pay attention to the credit card rows in the budget list. However, the budget amount and the account balance will often go out of sync (I'm not sure why — I'm still trying to catch it in the act!). This feature makes the mismatch more immediately visible.
