### PR TITLE
fix: update getters for income/expenses

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/component.jsx
@@ -136,11 +136,14 @@ export class IncomeVsExpenseComponent extends React.Component {
       const prevPayees = prevState.incomes.get('sources');
       const prevMasterCategories = prevState.expenses.get('sources');
       prevPayees.forEach((payee) => {
-        collapsedSources.add(payee.get('source')?.entityId);
+        const entityId = payee.get('source')?.entityId ?? payee.get('source')?.get('entityId');
+        collapsedSources.add(entityId);
       });
 
       prevMasterCategories.forEach((category) => {
-        collapsedSources.add(category.get('source')?.entityId);
+        const entityId =
+          category.get('source')?.entityId ?? category.get('source')?.get('entityId');
+        collapsedSources.add(entityId);
       });
 
       return { collapsedSources };

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/component.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { CollapsableRow } from './components/collapsable-row';
+import { CollapsibleRow } from './components/collapsable-row';
 import { MonthlyTotalsRow } from 'toolkit-reports/pages/income-vs-expense/components/monthly-totals-row';
 import './styles.scss';
 
@@ -57,7 +57,7 @@ export class MonthlyTransactionTotalsTable extends React.Component {
       const sourceId = source?.entityId ?? source.get('entityId');
 
       return (
-        <CollapsableRow
+        <CollapsibleRow
           key={sourceId}
           source={source}
           sources={sourceData.get('sources')}

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/components/collapsable-row/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-transaction-totals-table/components/collapsable-row/component.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { MonthlyTotalsRow } from 'toolkit-reports/pages/income-vs-expense/components/monthly-totals-row';
 
-export class CollapsableRow extends React.Component {
+export class CollapsibleRow extends React.Component {
   static propTypes = {
     isCollapsed: PropTypes.bool.isRequired,
     onToggleCollapse: PropTypes.func.isRequired,
@@ -29,7 +29,7 @@ export class CollapsableRow extends React.Component {
             {this._renderChildRows()}
             <MonthlyTotalsRow
               className="tk-totals-table__child-summary-row"
-              titleCell={`Total ${source?.name}`}
+              titleCell={`Total ${source?.name ?? source.get('name')}`}
               monthlyTotals={monthlyTotals}
             />
           </div>
@@ -44,7 +44,7 @@ export class CollapsableRow extends React.Component {
     return (
       <div className="tk-flex">
         <i className={`flaticon stroke ${isCollapsed ? 'up' : 'down'}`} />
-        <div>{source?.name}</div>
+        <div>{source?.name ?? source.get('name')}</div>
       </div>
     );
   }
@@ -66,6 +66,6 @@ export class CollapsableRow extends React.Component {
   }
 
   _toggleCollapse = () => {
-    this.props.onToggleCollapse(this.props.source?.entityId);
+    this.props.onToggleCollapse(this.props.source?.entityId ?? this.props.source?.get('entityId'));
   };
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #3217 

**Explanation of Bugfix/Feature/Modification:**
We used maps because `.get` played nicely in an attempt to "lookalike" with Ember data but those days are gone, stuff was broken when we straight removed the .gets on the income expense report.
