### PR TITLE
change the CC-budget-mismatch icon

### DIFF
--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -209,7 +209,7 @@ Add a section to the budget inspector showing your variance between last month's
 
 ## Paid in Full Credit Card Assist
 
-Highlights credit card category balances with a yellow warning and adds an alert icon next to the account if the balance of the category does not match the account balance. Adds a button to the Inspector to rectify the difference.
+Highlights credit card category balances with a yellow warning and adds an icon next to the account if the balance of the category does not match the account balance. Adds a button to the Inspector to rectify the difference.
 
 ## Show Available After Savings
 

--- a/src/extension/features/budget/check-credit-balances/index.css
+++ b/src/extension/features/budget/check-credit-balances/index.css
@@ -20,9 +20,14 @@
   color: var(--budget_balance_warning_text) !important;
 }
 
-svg.cc-budget-mismatch {
-  fill: var(--message_warning_accent);
-  margin-left: 0.5em;
-  height: 13px;
-  width: 13px;
+span.cc-budget-mismatch {
+  border: 1px solid var(--message_warning_accent);
+  color: var(--message_warning_accent);
+  border-radius: 0.5em;
+  margin-left: 0.25em;
+  padding: 0 0.25em;
+  height: 1.25em;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
 }

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -103,7 +103,7 @@ export class CheckCreditBalances extends Feature {
       // Upsert the indicator on the accounts nav
       let mismatchIndicator = accountBudgetLabel?.querySelector('.cc-budget-mismatch');
       if (mismatchIndicator) {
-        mismatchIndicator.style.display = 'inline';
+        mismatchIndicator.style.display = 'inline-flex';
       } else if (accountBudgetLabel) {
         const accountNameElem = accountBudgetLabel.querySelector('.nav-account-name');
         $(accountNameElem).append(this.alertIcon());
@@ -122,10 +122,7 @@ export class CheckCreditBalances extends Feature {
 
   alertIcon() {
     return $(`
-      <svg class="ynab-new-icon view-button-icon cc-budget-mismatch">
-        <title>Account balance does not match available funds in budget.</title>
-        <use href="#icon_sprite_general_warning"></use>
-      </svg>
+      <span class="cc-budget-mismatch" title="Account balance does not match available funds in budget.">≠</span>
     `);
   }
 


### PR DESCRIPTION
GitHub Issue (if applicable): See discussion at PR #3219.

Trello Link (if applicable): n/a

**Explanation of Bugfix/Feature/Modification:**

> **warning**
> See note at bottom, after images.

Instead of a warning, use a more explicit `≠` symbol. This helps differentiate it from a warning about the account having a connection problem.

Before:
> ![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/245940/ac70680e-b1b9-40b8-ab53-8a085e13111b)


After:
> ![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/245940/428d00bd-7b0a-4fa2-a963-975294e5f9e9)
> tooltip:
> ![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/245940/d3d222e2-879e-441c-889b-ae61b8d3cb68)


Note: In thinking about this, I think I really should move this out of the accounts left-pane and to the top of the budgets pane. Ideally, it would be a custom view that gets added, that filters down to the appropriate budgets. However, that would take a bit longer to investigate how to do, so I figured this is a quick fix to remove the confusion the current approach introduced. Apologies in advance for the churn!