### PR TITLE
fix(splits) - Fix toggle splits feature

### DIFF
--- a/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
+++ b/src/extension/features/accounts/toggle-splits/components/toggle-split-button.jsx
@@ -39,10 +39,14 @@ export class ToggleSplitButton extends React.Component {
   };
 
   hideAllSplits = () => {
-    const { scheduledTransactionsCollection, transactionsCollection } = getEntityManager();
+    let { selectedAccountId } = getAccountsService();
     const collapsedSplitsMap = {};
 
-    [scheduledTransactionsCollection, transactionsCollection].forEach((collection) => {
+    const account = getEntityManager().getAccountById(selectedAccountId);
+    const transactions = account.getTransactions();
+    const scheduledTransactions = account.scheduledTransactions;
+
+    [transactions, scheduledTransactions].forEach((collection) => {
       collection.reduce((reduced, transaction) => {
         if (transaction.isSplit) {
           reduced[transaction?.entityId] = true;


### PR DESCRIPTION
GitHub Issue (if applicable): #3229

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
`getEntityManager()` was returning undefined for both `scheduledTransactionsCollection` and `transactionsCollection`.

To resolve the issue, I retrieved the transactions from the account class.
