### PR TITLE
fix: more places missed by the great getter migration

### DIFF
--- a/src/extension/features/accounts/reconcile-assistant/components/ReconcileAssistantContainer.tsx
+++ b/src/extension/features/accounts/reconcile-assistant/components/ReconcileAssistantContainer.tsx
@@ -39,10 +39,10 @@ export function ReconcileAssistantContainer({
       return;
     }
 
-    const { clearedBalance } = account.getAccountCalculation();
+    const { clearedBalance } = account.accountCalculation;
 
     // Note: For credit cards, we'll automatically invert to follow ynab's behavior
-    if (convertedInputValue > 0 && account.getAccountType() === 'CreditCard') {
+    if (convertedInputValue > 0 && account.accountType === 'CreditCard') {
       convertedInputValue *= -1;
     }
 

--- a/src/extension/features/general/import-notification/index.js
+++ b/src/extension/features/general/import-notification/index.js
@@ -73,8 +73,10 @@ export class ImportNotification extends Feature {
         if (
           (typeof account.getDirectConnectEnabled === 'function' &&
             account.getDirectConnectEnabled()) ||
+          account.directConnectEnabled ||
           (typeof account.getIsDirectImportActive === 'function' &&
-            account.getIsDirectImportActive())
+            account.getIsDirectImportActive()) ||
+          account.isDirectImportActive
         ) {
           let t = new ynab.managers.DirectImportManager(
             ynab.YNABSharedLib.defaultInstance.entityManager,

--- a/src/test/utils/data.ts
+++ b/src/test/utils/data.ts
@@ -1,12 +1,12 @@
-import moment from 'moment';
 import { YNABAccount } from 'toolkit/types/ynab/data/account';
 import { YNABTransaction } from 'toolkit/types/ynab/data/transaction';
+import { YNABAccountType } from 'toolkit/types/ynab/window/ynab-enums';
 
 export function mockAccount(overrides?: Partial<YNABAccount>): YNABAccount {
   return {
     accountName: 'accountName',
-    getAccountType: jest.fn(),
-    getAccountCalculation: jest.fn(),
+    accountType: YNABAccountType.Cash,
+    accountCalculation: { clearedBalance: 0 },
     getTransactions: jest.fn(),
     ...overrides,
   };

--- a/src/types/ynab/data/account.d.ts
+++ b/src/types/ynab/data/account.d.ts
@@ -3,7 +3,7 @@ import { YNABTransaction } from './transaction';
 
 export interface YNABAccount {
   accountName: string;
-  getAccountType(): YNABAccountType;
-  getAccountCalculation(): YNABAccountCalculation;
+  accountType: YNABAccountType;
+  accountCalculation: YNABAccountCalculation;
   getTransactions(): YNABTransaction[];
 }


### PR DESCRIPTION
Fixes the Reconcile Assistant crashing when the button was clicked, and presumably also fixes the "Emphasize Accounts Needing Import" feature; I can't test this one myself as YNAB doesn't support direct import in my country, but I can see that the `isDirectImportActive` getter exists in the account prototype (and appropriately returns `false` on my accounts).

GitHub Issue (if applicable): #3179

Though since YNAB seems to be moving towards automatic importing (without needing to confirm direct imports) who knows for how much longer this module will need to exist 😅