### PR TITLE
Fix income sources not being sorted alphabetically in income vs expense report

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/component.jsx
@@ -334,18 +334,12 @@ export class IncomeVsExpenseComponent extends React.Component {
     const monthlyTotalsArray = mapToArray(incomes.get('monthlyTotals'));
     monthlyTotalsArray.sort(sortByGettableDate);
 
+    const collator = new Intl.Collator();
     const payeesArray = mapToArray(incomes.get('payees'))
       .sort((a, b) => {
-        const nameA = a?.payee?.name;
-        const nameB = b?.payee?.name;
-        if (nameA < nameB) {
-          return -1;
-        }
-        if (nameA > nameB) {
-          return 1;
-        }
-
-        return 0;
+        const nameA = a.get('payee')?.name;
+        const nameB = b.get('payee')?.name;
+        return collator.compare(nameA, nameB);
       })
       .map((payeeData) => {
         const payeeMonthlyTotalsArray = mapToArray(payeeData.get('monthlyTotals'));


### PR DESCRIPTION
GitHub Issue (if applicable): #3257

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
It seems as part of larger migration here https://github.com/toolkit-for-ynab/toolkit-for-ynab/commit/69b6bf12ff92a437dcb6e861fcfc203286c44225 `a.get('payee')` was mistakenly replaced with just property access. `a` and `b` in this context is `Map`, not EmberObject, so we need to use `get`. Also updated string comparisson to use `Intl.Collator` for better sort ordering.
