### PR TITLE
Fix categories search missing in new design

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "classnames": "^2.3.2",
     "core-js": "2",
+    "debounce": "^1.2.1",
     "fuzzysort": "^2.0.3",
     "highcharts": "^9.1.1",
     "jquery": "^3.6.1",

--- a/src/extension/features/budget/filter-categories/index.css
+++ b/src/extension/features/budget/filter-categories/index.css
@@ -1,12 +1,12 @@
 .tk-categories-filter-input {
   float: right;
-  border-radius: 0.4em;
-  border: 1px solid #009cc2;
-  color: #009cc2;
-  font-style: italic;
+  border-radius: 0.35rem;
+  border: 1px solid var(--action_primary);
+  color: var(--label_primary);
   outline: none;
-  padding: 0.3rem 0.3rem 0.3rem 1.6rem;
+  padding: 0.3rem 1.2rem 0.3rem 1.6rem;
   z-index: 10;
+  font-size: 0.875rem;
 }
 
 .tk-categories-filter-input:focus {
@@ -18,19 +18,24 @@
 }
 
 .tk-categories-filter-icon {
-  color: #009cc2;
-  left: 0.6em;
+  color: var(--action_primary);
+  left: 0.5rem;
   position: absolute;
-  top: 0.55em;
+  top: 0.55rem;
   z-index: 11;
+  font-size: 0.8rem;
 }
 
 .tk-categories-filter-cancel-icon {
-  color: #009cc2;
+  /* Reset inherited styles from YNAB stylesheets */
+  padding: 0 !important;
+  display: block !important;
+
+  color: var(--action_primary);
   cursor: pointer;
   position: absolute;
-  right: 0;
-  top: 0.45rem;
+  right: 0.25rem;
+  top: 0.05rem;
   z-index: 11;
 }
 

--- a/src/extension/features/budget/filter-categories/index.jsx
+++ b/src/extension/features/budget/filter-categories/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import fuzzysort from 'fuzzysort';
+import debounce from 'debounce';
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { l10n } from 'toolkit/extension/utils/toolkit';
@@ -51,7 +52,19 @@ export class FilterCategories extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('budget-table', 'didRender', this.handleTableRender);
+    const table = document.querySelector('.budget-table');
+    if (!table) return;
+    this.handleTableRender();
+  }
+
+  debouncedInvoke = debounce(this.invoke, 200);
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (changedNodes.has('budget-table')) {
+      this.debouncedInvoke();
+    }
   }
 
   destroy() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,6 +3543,11 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
+
 debug@2.6.9, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"


### PR DESCRIPTION
GitHub Issue (if applicable): 

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Categories search/filter was't injected because YNAB seem to migrate budget-table so it doesn't emit hook anymore. I updated feature to use observe instead and also updated styles to match new YNAB design
