### PR TITLE
Make 'Outflow over time' report legend more readable

### DIFF
--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
@@ -1,4 +1,4 @@
-import type { Moment } from 'moment';
+import moment, { Moment } from 'moment';
 
 declare module 'moment' {
   interface Moment {
@@ -104,7 +104,7 @@ export function calculateCumulativeOutflowPerDate(transactions: GroupedTransacti
 
 export function toHighchartsSeries(transactions: Record<string, Record<string, OutflowData>>) {
   return Object.entries(transactions).map(([month, data]) => ({
-    name: month,
+    name: moment(month, 'YYYY-MM').format('MMM YYYY'),
     data: Object.entries(data).map(([date, { value, transactions }]) => ({
       x: parseInt(date),
       y: value,


### PR DESCRIPTION
GitHub Issue (if applicable): #3278

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Changed format of legend from YYYY-MM to MMM YYYY
