### PR TITLE
Fix markdown in notes not being updated when switching category

### DIFF
--- a/src/extension/features/budget/notes-as-markdown/index.jsx
+++ b/src/extension/features/budget/notes-as-markdown/index.jsx
@@ -12,7 +12,13 @@ export class NotesAsMarkdown extends Feature {
   }
 
   observe(changedNodes) {
-    if (changedNodes.has('inspector-notes') || changedNodes.has('inspector-notes is-editing')) {
+    const startedEditing = changedNodes.has('inspector-notes is-editing');
+    const finishedEditing = changedNodes.has('inspector-notes');
+    const notesNodeChanged =
+      changedNodes.has('inspector-category-note user-data') ||
+      changedNodes.has('inspector-category-note user-data tk-hidden');
+    const isUpdateCausedByToolkit = !changedNodes.has('ynab-new-inspector-goals-view-goal');
+    if (startedEditing || finishedEditing || (notesNodeChanged && !isUpdateCausedByToolkit)) {
       this.applyMarkdown();
     }
   }


### PR DESCRIPTION
GitHub Issue (if applicable): #3303

Trello Link (if applicable):

**Explanation of Bugfix/Feature/Modification:**
Updated 'selectors' in `changedNodes` to work with latest version of ynab
