### PR TITLE
Add option to display data in 'Spending by Payee/Category' as bar chart

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/additional-settings/component.jsx
+++ b/src/extension/features/toolkit-reports/common/components/additional-settings/component.jsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import './styles.scss';
+
+export const AdditionalReportSettings = ({ children }) => {
+  return <div className="tk-additional-report-settings">{children}</div>;
+};

--- a/src/extension/features/toolkit-reports/common/components/additional-settings/index.js
+++ b/src/extension/features/toolkit-reports/common/components/additional-settings/index.js
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/extension/features/toolkit-reports/common/components/additional-settings/styles.scss
+++ b/src/extension/features/toolkit-reports/common/components/additional-settings/styles.scss
@@ -1,0 +1,6 @@
+.tk-additional-report-settings {
+  border-bottom: solid var(--separator_standard) 1px;
+  padding: 0.5rem;
+  display: flex;
+  gap: 1rem;
+}

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.jsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.jsx
@@ -7,6 +7,7 @@ import { WarningMessage } from './WarningMessage';
 import { useLocalStorage } from 'toolkit/extension/hooks/useLocalStorage';
 import { l10nAccountType } from 'toolkit/extension/utils/toolkit';
 import { getEntityManager } from 'toolkit/extension/utils/ynab';
+import { AdditionalReportSettings } from 'toolkit-reports/common/components/additional-settings';
 import {
   dataPointsToHighChartSeries,
   generateRunningBalanceMap,
@@ -136,7 +137,7 @@ export const BalanceOverTimeComponent = ({ allReportableTransactions, filters })
   }
   return (
     <div className="tk-flex tk-flex-column tk-flex-grow">
-      <div className="tk-flex tk-pd-05 tk-border-b tk-gap-1">
+      <AdditionalReportSettings>
         <LabeledCheckbox
           id="tk-balance-over-time-groupaccounts-option"
           checked={shouldGroupAccounts}
@@ -163,7 +164,7 @@ export const BalanceOverTimeComponent = ({ allReportableTransactions, filters })
           label="Use Step Graph"
           onChange={() => setUseStepGraph(!useStepGraph)}
         />
-      </div>
+      </AdditionalReportSettings>
       <RunningBalanceGraph series={series} numDatapointsLimit={NUM_DATAPOINTS_LIMIT} />
     </div>
   );

--- a/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
@@ -6,6 +6,7 @@ import { Collections } from 'toolkit/extension/utils/collections';
 import { FiltersPropType } from 'toolkit-reports/common/components/report-context/component';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { LabeledCheckbox } from 'toolkit-reports/common/components/labeled-checkbox';
+import { AdditionalReportSettings } from 'toolkit-reports/common/components/additional-settings';
 import './styles.scss';
 
 export class IncomeBreakdownComponent extends React.Component {
@@ -47,7 +48,7 @@ export class IncomeBreakdownComponent extends React.Component {
       this.state;
     return (
       <div className="tk-flex-grow tk-flex tk-flex-column">
-        <div className="tk-flex tk-pd-05 tk-border-b tk-gap-1">
+        <AdditionalReportSettings>
           <div className="tk-income-breakdown__filter">
             <LabeledCheckbox
               id="tk-income-breakdown-hide-income-selector"
@@ -89,7 +90,7 @@ export class IncomeBreakdownComponent extends React.Component {
               onChange={this.togglePositiveCategories}
             />
           </div>
-        </div>
+        </AdditionalReportSettings>
         <div className="tk-flex tk-flex-grow">
           <div className="tk-highcharts-report-container" id="tk-income-breakdown" />
         </div>

--- a/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/net-worth/component.jsx
@@ -8,6 +8,7 @@ import { FiltersPropType } from 'toolkit-reports/common/components/report-contex
 import { Legend } from './components/legend';
 import { LabeledCheckbox } from 'toolkit-reports/common/components/labeled-checkbox';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+import { AdditionalReportSettings } from 'toolkit-reports/common/components/additional-settings';
 
 const STORAGE_KEYS = {
   inverseDebt: 'net-worth-inverse-debt',
@@ -39,16 +40,14 @@ export class NetWorthComponent extends React.Component {
   render() {
     return (
       <div className="tk-flex-grow tk-flex tk-flex-column">
-        <div className="tk-flex tk-pd-05 tk-border-b">
-          <div>
-            <LabeledCheckbox
-              id="tk-net-worth-inverse-debt-selector"
-              checked={this.state.inverseDebt}
-              label="Flip Debt"
-              onChange={this.toggleDebtDirection}
-            />
-          </div>
-        </div>
+        <AdditionalReportSettings>
+          <LabeledCheckbox
+            id="tk-net-worth-inverse-debt-selector"
+            checked={this.state.inverseDebt}
+            label="Flip Debt"
+            onChange={this.toggleDebtDirection}
+          />
+        </AdditionalReportSettings>
         <div className="tk-flex tk-flex-column tk-flex-grow">
           <div className="tk-flex tk-justify-content-end">
             {this.state.hoveredData && (

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.jsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.jsx
@@ -12,6 +12,7 @@ import {
 import { OutflowGraph } from './OutflowGraph';
 import { useLocalStorage } from 'toolkit/extension/hooks/useLocalStorage';
 import { LabeledCheckbox } from 'toolkit/extension/features/toolkit-reports/common/components/labeled-checkbox';
+import { AdditionalReportSettings } from 'toolkit-reports/common/components/additional-settings';
 
 export const OutflowOverTimeComponent = ({ allReportableTransactions, filters }) => {
   const [outflowSeries, setOutflowSeries] = useState([]);
@@ -47,14 +48,14 @@ export const OutflowOverTimeComponent = ({ allReportableTransactions, filters })
 
   return (
     <div className="tk-flex tk-flex-column tk-flex-grow">
-      <div className="tk-flex tk-pd-05 tk-border-b">
+      <AdditionalReportSettings>
         <LabeledCheckbox
           id="tk-balance-over-time-stepgraph-option"
           checked={cumulativeSum}
           label="Cumulative sum"
           onChange={() => setCumulativeSum(!cumulativeSum)}
         />
-      </div>
+      </AdditionalReportSettings>
       <OutflowGraph series={outflowSeries} />
     </div>
   );


### PR DESCRIPTION
GitHub Issue (if applicable): #2619

**Explanation of Bugfix/Feature/Modification:**
Not sure why original issue was closed, but feature seem useful, so here it is
