### PR TITLE
fix: income not shown on split transactions in income-breakdown

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
+++ b/src/extension/features/toolkit-reports/pages/income-breakdown/component.jsx
@@ -148,7 +148,7 @@ export class IncomeBreakdownComponent extends React.Component {
       }
 
       if (transactionSubCategory.isImmediateIncomeCategory()) {
-        const transactionPayeeId = transaction.payeeId || transaction.parentTransactionPayeeId;
+        const transactionPayeeId = transaction.payeeId || transaction.parentTransaction?.payeeId;
         if (!transactionPayeeId) {
           return;
         }


### PR DESCRIPTION
GitHub Issue (if applicable): #3243 
(The linked issue is mentioning an outflow in the split, so not 100% sure, if their scenario is the same as mine)

Trello Link (if applicable): n/a

**Explanation of Bugfix/Feature/Modification:**
The Income-Breakdown toolkit report didn't show income assigned as "Inflow: Ready to assign", when using split transactions.
This happened because a non-existant property was used to find the parent transaction payee id.

Example Transaction:
![Screenshot 2023-12-05 at 12 16 36](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/1248214/2a613df2-d6d0-4b89-bc6b-99b2ffbf2d8d)

Before:
![Screenshot 2023-12-05 at 12 17 41](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/1248214/21fcea34-c21b-40ad-90e1-8fd035b23205)

After:
![Screenshot 2023-12-05 at 12 16 52](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/1248214/3e632a97-60ac-468b-bce9-ee3f68d7c8f4)


