### PR TITLE
chore(deps): pin yarn version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -137,3 +137,6 @@ TODO         text
 browserslist   text
 Makefile       text
 makefile       text
+
+## YARN RELEASES
+.yarn/releases/*.js linguist-vendored

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.19.cjs

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
   },
   "engines": {
     "node": ">=18.12.1",
-    "yarn": ">=1.10.0"
-  }
+    "yarn": "1.22.19"
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
This change pins the `yarn` version in the repo, and uses `yarn set version` to package the `yarn` release with the repo. This means that usage of a release that is not the default set by the repo will throw an error with common `yarn` subcommands, like `add`.

Usage of `yarn/yarn install` will automatically detect the correct yarn release from the source, so this shouldn't happen often, if at all.

Using this packaged release and pinned version will make it easier for new developers to onboard to the repo without having to deal with a differently-configured global `yarn` version.

**Screenshots**
![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/31600776/9be2201d-9346-4a79-b483-3601ab3e6edd)

