### PR TITLE
Fix budget row cc payment header styling

### DIFF
--- a/src/extension/features/budget/rows-height/compact.css
+++ b/src/extension/features/budget/rows-height/compact.css
@@ -11,7 +11,7 @@
 }
 
 .budget-table-cell-available-payment {
-  font-size: 0px;
+  font-size: 0px !important;
   position: absolute;
   right: -15px;
   top: 4px;

--- a/src/extension/features/budget/rows-height/large.css
+++ b/src/extension/features/budget/rows-height/large.css
@@ -11,7 +11,7 @@
 }
 
 .budget-table-cell-available-payment {
-  font-size: 0px;
+  font-size: 0px !important;
   position: absolute;
   right: -15px;
   top: 9px;

--- a/src/extension/features/budget/rows-height/medium.css
+++ b/src/extension/features/budget/rows-height/medium.css
@@ -11,7 +11,7 @@
 }
 
 .budget-table-cell-available-payment {
-  font-size: 0px;
+  font-size: 0px !important;
   position: absolute;
   right: -15px;
   top: 7px;

--- a/src/extension/features/budget/rows-height/slim-fonts.css
+++ b/src/extension/features/budget/rows-height/slim-fonts.css
@@ -11,7 +11,7 @@
 }
 
 .budget-table-cell-available-payment {
-  font-size: 0px;
+  font-size: 0px !important;
   position: absolute;
   right: -15px;
   top: 5px;

--- a/src/extension/features/budget/rows-height/slim.css
+++ b/src/extension/features/budget/rows-height/slim.css
@@ -11,7 +11,7 @@
 }
 
 .budget-table-cell-available-payment {
-  font-size: 0px;
+  font-size: 0px !important;
   position: absolute;
   right: -15px;
   top: 6px;


### PR DESCRIPTION
GitHub Issue (if applicable): #3302 #3264 

**Explanation of Bugfix/Feature/Modification:**
Overriding YNAB default styling for payment header

