### PR TITLE
Clean up background highlight of current month

### DIFF
--- a/src/extension/features/budget/highlight-current-month/index.css
+++ b/src/extension/features/budget/highlight-current-month/index.css
@@ -37,7 +37,10 @@ body.theme-dark {
 /* current month styles */
 .tk-highlight-current-month {
   background: var(--tk-current-month-background-color) !important;
+  background-clip: content-box !important;
+  border-radius: 1rem !important;
 }
+
 .budget-header .tk-highlight-current-month .budget-header-calendar-prev,
 .budget-header .tk-highlight-current-month .budget-header-calendar-next {
   color: var(--tk-current-month-control-color);


### PR DESCRIPTION
GitHub Issue (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
I like the feature to highlight the current month, but when it is active it becomes a bit ugly with the surrounding elements. The bottom ends up touching the filters and the boxy corners don't match with many of the other backgrounds.

**Screenshots**

Before:
<img width="593" alt="image" src="https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/6256032/4a9fde64-e6a8-4658-9ed7-8f5b29c34800">


After:
<img width="606" alt="image" src="https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/6256032/46276803-03d9-4d30-94f1-2c919bd781c2">

