### PR TITLE
chore: fix shell script word splitting

### DIFF
--- a/checks/_lib.sh
+++ b/checks/_lib.sh
@@ -18,44 +18,44 @@ find_check_files() {
   PRECOMMIT=1
   PREPUSH=1
   # END dummy variables
-  
+
   while read -r file; do
     unset check PRECOMMIT PREPUSH
     . "$file"
     case $1 in
-      precommit)
-        if [ $PRECOMMIT = 1 ]; then
-          echo "$file"
-        fi
-        ;;
-      prepush)
-        if [ $PREPUSH = 1 ]; then
-          echo "$file"
-        fi
-        ;;
-      all)
+    precommit)
+      if [ "$PRECOMMIT" = 1 ]; then
         echo "$file"
-        ;;
-      *)
-        echo "Unrecognized argument: $1" >2
-        return 1
-        ;;
+      fi
+      ;;
+    prepush)
+      if [ "$PREPUSH" = 1 ]; then
+        echo "$file"
+      fi
+      ;;
+    all)
+      echo "$file"
+      ;;
+    *)
+      echo "Unrecognized argument: $1" 1>&2
+      return 1
+      ;;
     esac
-  done<<<$all_files
+  done <<<"$all_files"
 }
 
 # $1 - any of 'precommit', 'prepush', or 'all'
 run_checks() {
   echo "Running $1 checks"
-  for file in $(find_check_files $1); do
-    printf "\nRunning check $file\n\n"
+  for file in $(find_check_files "$1"); do
+    printf '\nRunning check %s\n\n' "$file"
 
-    . $file
+    . "$file"
     check
   done
 }
 
 is_ci() {
   # The CI variable is present when running in GitHub actions/workflows.
-  [ -n $CI ]
+  [ -n "$CI" ]
 }

--- a/checks/lint.sh
+++ b/checks/lint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-PRECOMMIT=1
-PREPUSH=1
+export PRECOMMIT=1
+export PREPUSH=1
 
 check() {
   yarn lint

--- a/checks/type-check.sh
+++ b/checks/type-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-PRECOMMIT=0
-PREPUSH=1
+export PRECOMMIT=0
+export PREPUSH=1
 
 check() {
   yarn type-check

--- a/checks/validate-checks.sh
+++ b/checks/validate-checks.sh
@@ -2,7 +2,6 @@
 
 . ./checks/_lib.sh
 
-
 export PRECOMMIT=0
 export PREPUSH=0
 
@@ -13,7 +12,7 @@ check_var() {
   value=$2
   var_name=$3
 
-  if [ -z $value ]; then
+  if [ -z "$value" ]; then
     echo "$file must have a '$var_name' variable."
     return 1
   fi
@@ -40,8 +39,8 @@ check() {
       return 1
     fi
 
-    check_var "$1" $PRECOMMIT PRECOMMIT
-    check_var "$1" $PREPUSH PREPUSH
+    check_var "$file" "$PRECOMMIT" PRECOMMIT
+    check_var "$file" "$PREPUSH" PREPUSH
 
     echo "$file OK"
   done


### PR DESCRIPTION
GitHub Issue (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
Fixes word splitting in shell scripts for BSD-like shell environments (like MacOS).

**Screenshots**
N/A
