### PR TITLE
Fixes duplicate transaction filters, fixes enable-ember-debug on Firefox

### DIFF
--- a/src/extension/features/accounts/toggle-transaction-filters/index.tsx
+++ b/src/extension/features/accounts/toggle-transaction-filters/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Feature } from 'toolkit/extension/features/feature';
 import { componentBefore } from 'toolkit/extension/utils/react';
 import { getAccountsService } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 
 const ToggleButton = ({
   stateField,
@@ -37,34 +38,38 @@ const ToggleButton = ({
 };
 
 export class ToggleTransactionFilters extends Feature {
-  observe(changedNodes: Set<string>) {
-    if (changedNodes.has('accounts-toolbar-right')) {
-      this.injectButtons($('.accounts-toolbar'));
-    }
+  containerClass = 'tk-toggle-transaction-filters';
+
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage();
   }
 
   injectCSS() {
     return require('./styles.scss');
   }
 
-  destroy() {
-    $('#transaction-filters').remove();
+  onRouteChanged() {
+    if (!this.shouldInvoke()) return;
+
+    this.invoke();
   }
 
-  injectButtons = ($element: JQuery<HTMLElement>) => {
-    const toolbarRight = $('.accounts-toolbar-right', $element);
-    if ($('#tk-toggle-transaction-filters', toolbarRight).length) {
-      return;
-    }
+  destroy() {
+    document.querySelector('.' + this.containerClass)?.remove();
+  }
 
+  invoke() {
     const showLabel = this.settings.enabled === '2';
+    const toggleTransactionFiltersContainer = document.querySelector('.' + this.containerClass);
 
-    componentBefore(
-      <span id="tk-toggle-transaction-filters" className="tk-toggle-transaction-filters">
-        <ToggleButton stateField="scheduled" showLabel={showLabel} />
-        <ToggleButton stateField="reconciled" showLabel={showLabel} />
-      </span>,
-      $('.js-transaction-search', toolbarRight)[0]
-    );
-  };
+    if (!toggleTransactionFiltersContainer) {
+      componentBefore(
+        <span className={this.containerClass}>
+          <ToggleButton stateField="scheduled" showLabel={showLabel} />
+          <ToggleButton stateField="reconciled" showLabel={showLabel} />
+        </span>,
+        document.querySelector('.js-transaction-search')
+      );
+    }
+  }
 }

--- a/src/extension/features/general/import-notification/index.js
+++ b/src/extension/features/general/import-notification/index.js
@@ -59,14 +59,18 @@ export class ImportNotification extends Feature {
   checkImportTransactions() {
     this.isActive = true;
 
-    $('.nav-account-row').each((index, row) => {
-      let account = getEmberView($(row).attr('id')).account;
-      let accountName = $('.nav-account-name', row);
+    $('.nav-account-row').each((_, element) => {
+      let account = getEmberView(element.id)?.account;
+      if (!account) {
+        return;
+      }
+
+      let accountName = $('.nav-account-name', element);
       if (accountName.length) {
         // Remove the title attribute and our underline class in case the account no longer has txns to be imported
         $(accountName).removeAttr('title').removeClass(this.importClass);
 
-        let currentTitle = $(row).find('.nav-account-name').prop('title');
+        let currentTitle = $(element).find('.nav-account-name').prop('title');
 
         // Check for both functions should be temporary until all users have been switched to new bank data
         // provider but of course we have no good way of knowing when that has occurred.

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -10,6 +10,17 @@
       "all_frames": true,
       "run_at": "document_idle",
       "js": ["content-scripts/extension-bridge.js"]
+    },
+    {
+      "matches": [
+        "http://*.youneedabudget.com/*",
+        "https://*.youneedabudget.com/*",
+        "https://*.ynab.com/*",
+        "http://*.ynab.com/*"
+      ],
+      "all_frames": true,
+      "run_at": "document_start",
+      "js": ["content-scripts/enable-ember-debug.js"]
     }
   ],
   "web_accessible_resources": ["assets/*", "web-accessibles/*"],


### PR DESCRIPTION
GitHub Issue (if applicable): #3379, #3259

Explanation of Bugfix/Feature/Modification:
- Fixes issue #3379 by only adding filter buttons onRouteChanged instead of observe
- Fixes issue #3259 by including enable-ember-debug.js in Firefox manifest
- Additional safety check for import notification feat.

Screenshots
![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/5180063/8d6c974a-6d2a-4709-bc23-42ef187e2c6d)
![image](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/5180063/8fc06e6d-0c5c-43b5-a0b1-3b23d5680a78)

