### PR TITLE
Broken feature fixes

### DIFF
--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -1,6 +1,8 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { pacingForCategory } from 'toolkit/extension/utils/pacing';
 import { getEmberView } from 'toolkit/extension/utils/ember';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 const PROGRESS_INDICATOR_WIDTH = 0.001; // Current month progress indicator width
 
@@ -10,7 +12,7 @@ export class BudgetProgressBars extends Feature {
   }
 
   shouldInvoke() {
-    return true;
+    return isCurrentRouteBudgetPage();
   }
 
   destroy() {
@@ -26,9 +28,17 @@ export class BudgetProgressBars extends Feature {
     });
   }
 
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (isClassInChangedNodes('budget-table-row', changedNodes)) {
+      this.invoke();
+    }
+  }
+
   invoke() {
-    this.addToolkitEmberHook('budget-table-row', 'didRender', this.addProgressBars, {
-      debounce: 50,
+    $('.budget-table-row').each((_, element) => {
+      this.addProgressBars(element);
     });
   }
 

--- a/src/extension/features/budget/budget-progress-bars/settings.js
+++ b/src/extension/features/budget/budget-progress-bars/settings.js
@@ -7,10 +7,10 @@ module.exports = {
   description:
     'Add progress bars and a vertical bar that shows how far you are through the month to category rows.',
   options: [
-    { name: 'Goals progress', value: 'goals' },
+    { name: 'Target progress', value: 'goals' },
     { name: 'Pacing progress', value: 'pacing' },
     {
-      name: 'Pacing on name column and goals on budgeted column',
+      name: 'Pacing on name column and targets on budgeted column',
       value: 'both',
     },
   ],

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -6,7 +6,7 @@ import {
 } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getEmberView } from 'toolkit/extension/utils/ember';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class CheckCreditBalances extends Feature {
   injectCSS() {
@@ -24,7 +24,7 @@ export class CheckCreditBalances extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
       this.addRectifyDifferenceButton();
     }
 

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -79,7 +79,8 @@ export class CheckCreditBalances extends Feature {
     const rectifyDifference = (event) => {
       currencyInput.click();
       input.value = ynab.formatCurrency(category.budgeted + difference);
-      input.blur();
+      input.dispatchEvent(new Event('change'));
+      input.dispatchEvent(new Event('blur'));
       event.currentTarget.setAttribute('disabled', true); // Disable button once it's clicked.
     };
     const buttonDiv = this.createButton(formattedDifference, rectifyDifference);

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -97,7 +97,6 @@ export class CheckCreditBalances extends Feature {
   }
 
   checkCategoryForDifference(categoryElement) {
-    console.log('checkCategoryForDifference');
     if (!isCurrentMonthSelected()) return;
 
     const category = getEmberView(categoryElement.id).category;

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -6,6 +6,7 @@ import {
 } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getEmberView } from 'toolkit/extension/utils/ember';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class CheckCreditBalances extends Feature {
   injectCSS() {
@@ -23,7 +24,7 @@ export class CheckCreditBalances extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (changedNodes.has('budget-inspector-button')) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.addRectifyDifferenceButton();
     }
 

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -6,7 +6,7 @@ import {
 } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getEmberView } from 'toolkit/extension/utils/ember';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 export class CheckCreditBalances extends Feature {
   injectCSS() {
@@ -24,7 +24,7 @@ export class CheckCreditBalances extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangesSet(changedNodes)) {
+    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
       this.addRectifyDifferenceButton();
     }
 

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -6,7 +6,7 @@ import {
 } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getEmberView } from 'toolkit/extension/utils/ember';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class CheckCreditBalances extends Feature {
   injectCSS() {
@@ -24,7 +24,7 @@ export class CheckCreditBalances extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.addRectifyDifferenceButton();
     }
 

--- a/src/extension/features/budget/collapse-inspector/index.js
+++ b/src/extension/features/budget/collapse-inspector/index.js
@@ -30,7 +30,7 @@ export class CollapseInspector extends Feature {
   collapseButton() {
     return $(`
       <button class="sidebar-collapse" type="button">
-        <svg height="24" width="24" class="ynab-new-icon ember-view">
+        <svg height="12" width="12" class="ynab-new-icon ember-view">
           <use href="#icon_sprite_sidebar_open"></use>
           <title>Collapse Inspector</title>    
         </svg>
@@ -41,7 +41,7 @@ export class CollapseInspector extends Feature {
   expandButton() {
     return $(`
       <button class="sidebar-expand" type="button">
-        <svg height="24" width="24" class="ynab-new-icon ember-view">
+        <svg height="12" width="12" class="ynab-new-icon ember-view">
           <use href="#icon_sprite_sidebar_close"></use>
           <title>Expand Inspector</title>    
         </svg>

--- a/src/extension/features/budget/custom-average-budgeting/index.tsx
+++ b/src/extension/features/budget/custom-average-budgeting/index.tsx
@@ -6,7 +6,7 @@ import { Feature } from '../../feature';
 import { componentAfter } from 'toolkit/extension/utils/react';
 import type { FeatureSetting } from 'toolkit/types/toolkit/features';
 import type { BudgetTableRowComponent } from 'toolkit/types/ynab/components/BudgetTableRow';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 const QuickBudgetButton = ({
   setting,
@@ -34,7 +34,7 @@ const QuickBudgetButton = ({
 
 export class CustomAverageBudgeting extends Feature {
   observe(changedNodes: Set<string>) {
-    if (budgetInspectorButtonInChangesSet(changedNodes)) {
+    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
       this._renderButton();
     }
   }

--- a/src/extension/features/budget/custom-average-budgeting/index.tsx
+++ b/src/extension/features/budget/custom-average-budgeting/index.tsx
@@ -6,6 +6,7 @@ import { Feature } from '../../feature';
 import { componentAfter } from 'toolkit/extension/utils/react';
 import type { FeatureSetting } from 'toolkit/types/toolkit/features';
 import type { BudgetTableRowComponent } from 'toolkit/types/ynab/components/BudgetTableRow';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 const QuickBudgetButton = ({
   setting,
@@ -33,7 +34,7 @@ const QuickBudgetButton = ({
 
 export class CustomAverageBudgeting extends Feature {
   observe(changedNodes: Set<string>) {
-    if (changedNodes.has('budget-inspector-button')) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this._renderButton();
     }
   }

--- a/src/extension/features/budget/custom-average-budgeting/index.tsx
+++ b/src/extension/features/budget/custom-average-budgeting/index.tsx
@@ -6,7 +6,7 @@ import { Feature } from '../../feature';
 import { componentAfter } from 'toolkit/extension/utils/react';
 import type { FeatureSetting } from 'toolkit/types/toolkit/features';
 import type { BudgetTableRowComponent } from 'toolkit/types/ynab/components/BudgetTableRow';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 const QuickBudgetButton = ({
   setting,
@@ -34,7 +34,7 @@ const QuickBudgetButton = ({
 
 export class CustomAverageBudgeting extends Feature {
   observe(changedNodes: Set<string>) {
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
       this._renderButton();
     }
   }

--- a/src/extension/features/budget/custom-average-budgeting/index.tsx
+++ b/src/extension/features/budget/custom-average-budgeting/index.tsx
@@ -6,7 +6,7 @@ import { Feature } from '../../feature';
 import { componentAfter } from 'toolkit/extension/utils/react';
 import type { FeatureSetting } from 'toolkit/types/toolkit/features';
 import type { BudgetTableRowComponent } from 'toolkit/types/ynab/components/BudgetTableRow';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 const QuickBudgetButton = ({
   setting,
@@ -34,7 +34,7 @@ const QuickBudgetButton = ({
 
 export class CustomAverageBudgeting extends Feature {
   observe(changedNodes: Set<string>) {
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this._renderButton();
     }
   }

--- a/src/extension/features/budget/display-target-goal-amount/settings.js
+++ b/src/extension/features/budget/display-target-goal-amount/settings.js
@@ -3,11 +3,11 @@ module.exports = {
   type: 'select',
   default: false,
   section: 'budget',
-  title: 'Display Target Goal and Emphasize Overbudget',
-  description: `Adds a "Goal" column which displays the target goal amount for every category with a goal. Optionally emphasize the amount as red if you've budgeted beyond your goal or green if you've met/exceeded your goal.`,
+  title: 'Display Target and Emphasize Overbudget',
+  description: `Adds a "Target" column which displays the target amount for every category with a target. Optionally emphasize the amount as red if you've budgeted beyond your target or green if you've met/exceeded your target.`,
   options: [
-    { name: 'Display goal amount with no emphasis', value: '3' },
-    { name: 'Display goal amount and emphasize overbudget with red', value: '1' },
-    { name: 'Display goal amount and emphasize funded goals as green', value: '2' },
+    { name: 'Display target amount with no emphasis', value: '3' },
+    { name: 'Display target amount and emphasize overbudget with red', value: '1' },
+    { name: 'Display target amount and emphasize funded targets as green', value: '2' },
   ],
 };

--- a/src/extension/features/budget/display-total-monthly-goals/InspectorCard.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/InspectorCard.jsx
@@ -4,13 +4,13 @@ import { useLocalStorage } from 'toolkit/extension/hooks/useLocalStorage';
 import { FormattedCurrency } from './FormattedCurrency';
 
 const RightArrow = () => (
-  <svg height="24" width="24" id="ember1340" className="ynab-new-icon card-chevron">
+  <svg height="12" width="12" id="ember1340" className="ynab-new-icon card-chevron">
     <use href="#icon_sprite_chevron_right"></use>
   </svg>
 );
 
 const DownArrow = () => (
-  <svg height="24" width="24" id="ember1340" className="ynab-new-icon card-chevron">
+  <svg height="12" width="12" id="ember1340" className="ynab-new-icon card-chevron">
     <use href="#icon_sprite_chevron_down"></use>
   </svg>
 );

--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -6,7 +6,7 @@ import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/
 
 import { FormattedCurrency } from './FormattedCurrency';
 import { InspectorCard } from './InspectorCard';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 const BreakdownItem = ({ label, children, className = '' }) => {
   return (
@@ -205,7 +205,7 @@ export class DisplayTotalMonthlyGoals extends Feature {
       return;
     }
 
-    if (budgetInspectorButtonInChangesSet(changedNodes)) {
+    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
       this.addMonthlyGoalsOverview();
     }
   }

--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -6,7 +6,7 @@ import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/
 
 import { FormattedCurrency } from './FormattedCurrency';
 import { InspectorCard } from './InspectorCard';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 const BreakdownItem = ({ label, children, className = '' }) => {
   return (
@@ -205,7 +205,7 @@ export class DisplayTotalMonthlyGoals extends Feature {
       return;
     }
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.addMonthlyGoalsOverview();
     }
   }

--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -6,6 +6,7 @@ import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/
 
 import { FormattedCurrency } from './FormattedCurrency';
 import { InspectorCard } from './InspectorCard';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 const BreakdownItem = ({ label, children, className = '' }) => {
   return (
@@ -204,7 +205,7 @@ export class DisplayTotalMonthlyGoals extends Feature {
       return;
     }
 
-    if (changedNodes.has('budget-inspector-button')) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.addMonthlyGoalsOverview();
     }
   }

--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -6,7 +6,7 @@ import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/
 
 import { FormattedCurrency } from './FormattedCurrency';
 import { InspectorCard } from './InspectorCard';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 const BreakdownItem = ({ label, children, className = '' }) => {
   return (
@@ -205,7 +205,7 @@ export class DisplayTotalMonthlyGoals extends Feature {
       return;
     }
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
       this.addMonthlyGoalsOverview();
     }
   }

--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -149,23 +149,23 @@ export class DisplayTotalMonthlyGoals extends Feature {
     return (
       <div className={this.containerClass}>
         <InspectorCard
-          title="Total Monthly Goals"
+          title="Total Monthly Targets"
           mainAmount={totalGoals}
           className="total-monthly-goals-card"
         >
           {shouldShowGoalBreakdown && (
             <div className="ynab-breakdown">
-              <BreakdownItem label="Savings Goals">
+              <BreakdownItem label="Savings Targets">
                 <FormattedCurrency amount={savingsGoals} />
               </BreakdownItem>
-              <BreakdownItem label="Spending Goals" className="extra-bottom-space">
+              <BreakdownItem label="Spending Targets" className="extra-bottom-space">
                 <FormattedCurrency amount={spendingGoals} />
               </BreakdownItem>
-              <BreakdownItem label="Budgeted for Goals" className="colorize-currency">
+              <BreakdownItem label="Budgeted for Targets" className="colorize-currency">
                 <FormattedCurrency amount={budgeted} />
               </BreakdownItem>
               <BreakdownItem
-                label={`${needed > 0 ? 'Needed for' : 'Exceeded from'} Goals`}
+                label={`${needed > 0 ? 'Needed for' : 'Exceeded from'} Targets`}
                 className={`goal-remaining-balance ${needed > 0 ? 'negative' : 'positive'}`}
               >
                 <FormattedCurrency amount={Math.abs(needed)} />

--- a/src/extension/features/budget/display-total-monthly-goals/settings.js
+++ b/src/extension/features/budget/display-total-monthly-goals/settings.js
@@ -3,14 +3,14 @@ module.exports = {
   type: 'select',
   default: false,
   section: 'budget',
-  title: 'Add Total Monthly Goals',
+  title: 'Add Total Monthly Targets',
   description:
-    "Add a 'Total Monthly Goals' section to the budget inspector, which displays the total amount of monthly funding goals. It's also possible to have a more detailed overview of the goals, and information of 'Income vs Spending' for the month.",
+    "Add a 'Total Monthly Targets' section to the budget inspector, which displays the total amount of monthly funding targets. It's also possible to have a more detailed overview of the targets, and information of 'Income vs Spending' for the month.",
   options: [
-    { name: 'Show monthly goal amount', value: 'show-total-only' },
-    { name: 'Show monthly goal amount with goals breakdown', value: 'show-goal-breakdown' },
+    { name: 'Show monthly target amount', value: 'show-total-only' },
+    { name: 'Show monthly target amount with targets breakdown', value: 'show-goal-breakdown' },
     {
-      name: 'Show monthly goal amount, goals breakdown and income vs spending overview',
+      name: 'Show monthly target amount, targets breakdown and income vs spending overview',
       value: 'show-goal-breakdown-and-income-vs-spending',
     },
   ],

--- a/src/extension/features/budget/display-total-overspent/index.js
+++ b/src/extension/features/budget/display-total-overspent/index.js
@@ -1,10 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class DisplayTotalOverspent extends Feature {
   observe(changedNodes) {
-    if (changedNodes.has('budget-inspector-button')) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.addTotalOverspent();
     }
   }

--- a/src/extension/features/budget/display-total-overspent/index.js
+++ b/src/extension/features/budget/display-total-overspent/index.js
@@ -1,11 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class DisplayTotalOverspent extends Feature {
   observe(changedNodes) {
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.addTotalOverspent();
     }
   }

--- a/src/extension/features/budget/display-total-overspent/index.js
+++ b/src/extension/features/budget/display-total-overspent/index.js
@@ -1,11 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class DisplayTotalOverspent extends Feature {
   observe(changedNodes) {
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
       this.addTotalOverspent();
     }
   }

--- a/src/extension/features/budget/display-total-overspent/index.js
+++ b/src/extension/features/budget/display-total-overspent/index.js
@@ -1,11 +1,11 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 export class DisplayTotalOverspent extends Feature {
   observe(changedNodes) {
-    if (budgetInspectorButtonInChangesSet(changedNodes)) {
+    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
       this.addTotalOverspent();
     }
   }

--- a/src/extension/features/budget/fund-half/index.ts
+++ b/src/extension/features/budget/fund-half/index.ts
@@ -2,7 +2,7 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getBudgetService, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
 import type { YNABBudgetMonthDisplayItem } from 'toolkit/types/ynab/services/YNABBudgetService';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 // The concept here is that for odd monthly Target amounts there is a low half and a high half.
 // Example:  For $65.05 the low half is $32.52 (x2 = $65.04).  The high half is $32.53 (x2 - $65.06).
@@ -44,7 +44,7 @@ export class FundHalf extends Feature {
   observe(changedNodes: Set<string>) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.updateDOM();
     }
   }

--- a/src/extension/features/budget/fund-half/index.ts
+++ b/src/extension/features/budget/fund-half/index.ts
@@ -2,7 +2,7 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getBudgetService, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
 import type { YNABBudgetMonthDisplayItem } from 'toolkit/types/ynab/services/YNABBudgetService';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 // The concept here is that for odd monthly Target amounts there is a low half and a high half.
 // Example:  For $65.05 the low half is $32.52 (x2 = $65.04).  The high half is $32.53 (x2 - $65.06).
@@ -44,7 +44,7 @@ export class FundHalf extends Feature {
   observe(changedNodes: Set<string>) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
       this.updateDOM();
     }
   }

--- a/src/extension/features/budget/fund-half/index.ts
+++ b/src/extension/features/budget/fund-half/index.ts
@@ -2,7 +2,7 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getBudgetService, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
 import type { YNABBudgetMonthDisplayItem } from 'toolkit/types/ynab/services/YNABBudgetService';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 // The concept here is that for odd monthly Target amounts there is a low half and a high half.
 // Example:  For $65.05 the low half is $32.52 (x2 = $65.04).  The high half is $32.53 (x2 - $65.06).
@@ -44,7 +44,7 @@ export class FundHalf extends Feature {
   observe(changedNodes: Set<string>) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangesSet(changedNodes)) {
+    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
       this.updateDOM();
     }
   }

--- a/src/extension/features/budget/fund-half/index.ts
+++ b/src/extension/features/budget/fund-half/index.ts
@@ -2,6 +2,7 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getBudgetService, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
 import type { YNABBudgetMonthDisplayItem } from 'toolkit/types/ynab/services/YNABBudgetService';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 // The concept here is that for odd monthly Target amounts there is a low half and a high half.
 // Example:  For $65.05 the low half is $32.52 (x2 = $65.04).  The high half is $32.53 (x2 - $65.06).
@@ -43,10 +44,7 @@ export class FundHalf extends Feature {
   observe(changedNodes: Set<string>) {
     if (!this.shouldInvoke()) return;
 
-    if (
-      changedNodes.has('budget-inspector-button js-focus-on-start underfunded') ||
-      changedNodes.has('budget-inspector-button underfunded')
-    ) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.updateDOM();
     }
   }

--- a/src/extension/features/budget/goal-indicator/index.js
+++ b/src/extension/features/budget/goal-indicator/index.js
@@ -39,7 +39,7 @@ export class GoalIndicator extends Feature {
       return;
     }
 
-    const category = getEmberView(element.id).category;
+    const category = getEmberView(element.id)?.category;
     if (!category) {
       return;
     }

--- a/src/extension/features/budget/goal-indicator/index.js
+++ b/src/extension/features/budget/goal-indicator/index.js
@@ -46,11 +46,11 @@ export class GoalIndicator extends Feature {
 
     // these need to be defined inside `invoke` because ynab must be on the window
     const GoalTypeLabels = {
-      MF: ['M', 'Monthly budgeting goal'],
-      NEED: ['S', 'Spending goal'],
-      TB: ['T', 'Target balance goal'],
-      TBD: ['D', 'Target by date goal'],
-      DEBT: ['MD', 'Debt goal'],
+      MF: ['M', 'Monthly Savings Builder'],
+      NEED: ['S', 'Needed For Spending'],
+      TB: ['B', 'Savings Balance'],
+      TBD: ['D', 'Savings Balance By Date'],
+      DEBT: ['MD', 'Monthly Debt Payment'],
     };
 
     const goalContainer = element.querySelector(`.${GOAL_TABLE_CELL_CLASSNAME}`);
@@ -66,21 +66,23 @@ export class GoalIndicator extends Feature {
       return;
     }
 
-    if (goalTypeElement) {
-      if (!goalType) {
-        goalTypeElement.remove();
-      }
+    if (category.goalCreatedOn) {
+      if (goalTypeElement) {
+        if (!goalType) {
+          goalTypeElement.remove();
+        }
 
-      $(goalTypeElement).attr('title', GoalTypeLabels[goalType][1]);
-      $(goalTypeElement).text(GoalTypeLabels[goalType][0]);
-    } else if (goalType) {
-      $(goalContainer).append(
-        $('<div>', {
-          class: 'tk-goal-indicator',
-          title: GoalTypeLabels[goalType][1],
-          text: GoalTypeLabels[goalType][0],
-        })
-      );
+        $(goalTypeElement).attr('title', GoalTypeLabels[goalType][1]);
+        $(goalTypeElement).text(GoalTypeLabels[goalType][0]);
+      } else if (goalType) {
+        $(goalContainer).append(
+          $('<div>', {
+            class: 'tk-goal-indicator',
+            title: GoalTypeLabels[goalType][1],
+            text: GoalTypeLabels[goalType][0],
+          })
+        );
+      }
     }
 
     if (upcomingElement) {

--- a/src/extension/features/budget/goal-indicator/index.js
+++ b/src/extension/features/budget/goal-indicator/index.js
@@ -4,6 +4,8 @@ import {
   ensureGoalColumn,
   GOAL_TABLE_CELL_CLASSNAME,
 } from 'toolkit/extension/features/budget/utils';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class GoalIndicator extends Feature {
   injectCSS() {
@@ -11,15 +13,25 @@ export class GoalIndicator extends Feature {
   }
 
   shouldInvoke() {
-    return true;
+    return isCurrentRouteBudgetPage();
   }
 
   destroy() {
     $('.tk-goal-indicator').remove();
   }
 
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (isClassInChangedNodes('budget-table-row', changedNodes)) {
+      this.invoke();
+    }
+  }
+
   invoke() {
-    this.addToolkitEmberHook('budget-table-row', 'didRender', this.addGoalIndicator);
+    $('.budget-table-row').each((_, element) => {
+      this.addGoalIndicator(element);
+    });
   }
 
   addGoalIndicator(element) {

--- a/src/extension/features/budget/goal-indicator/settings.js
+++ b/src/extension/features/budget/goal-indicator/settings.js
@@ -3,7 +3,7 @@ module.exports = {
   type: 'checkbox',
   default: false,
   section: 'budget',
-  title: 'Add Goal Indicator',
+  title: 'Add Target Indicator',
   description:
-    'Add an indicator to subcategories with goals. Types: (M)onthly goal, target by (D)ate goal, (T)arget without date, (S)pending goals, and (U)pcoming transactions.',
+    'Add an indicator to subcategories with targets. Types: (M)onthly Savings Builder, Savings Balance By (D)ate, Savings (B)alance, Needed For (S)pending, (M)onthly (D)ebt Payment, and (U)pcoming transactions.',
 };

--- a/src/extension/features/budget/goal-warning-color/settings.js
+++ b/src/extension/features/budget/goal-warning-color/settings.js
@@ -3,7 +3,7 @@ module.exports = {
   type: 'checkbox',
   default: false,
   section: 'budget',
-  title: 'Emphasize Underfunded Goals',
+  title: 'Emphasize Underfunded Targets',
   description:
-    'Change the default orange goal underfunded warning to blue to better differentiate it from credit card overspending.',
+    'Change the default orange target underfunded warning to blue to better differentiate it from credit card overspending.',
 };

--- a/src/extension/features/budget/live-on-last-months-income/index.js
+++ b/src/extension/features/budget/live-on-last-months-income/index.js
@@ -2,11 +2,11 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { l10n, l10nMonth, MonthStyle } from 'toolkit/extension/utils/toolkit';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 export class LiveOnLastMonthsIncome extends Feature {
   observe(changedNodes) {
-    if (budgetInspectorButtonInChangesSet(changedNodes)) {
+    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
       this.injectLastMonthsIncome();
     }
   }

--- a/src/extension/features/budget/live-on-last-months-income/index.js
+++ b/src/extension/features/budget/live-on-last-months-income/index.js
@@ -2,11 +2,11 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { l10n, l10nMonth, MonthStyle } from 'toolkit/extension/utils/toolkit';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class LiveOnLastMonthsIncome extends Feature {
   observe(changedNodes) {
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.injectLastMonthsIncome();
     }
   }

--- a/src/extension/features/budget/live-on-last-months-income/index.js
+++ b/src/extension/features/budget/live-on-last-months-income/index.js
@@ -2,11 +2,11 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { l10n, l10nMonth, MonthStyle } from 'toolkit/extension/utils/toolkit';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class LiveOnLastMonthsIncome extends Feature {
   observe(changedNodes) {
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
       this.injectLastMonthsIncome();
     }
   }

--- a/src/extension/features/budget/live-on-last-months-income/index.js
+++ b/src/extension/features/budget/live-on-last-months-income/index.js
@@ -2,10 +2,11 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { l10n, l10nMonth, MonthStyle } from 'toolkit/extension/utils/toolkit';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class LiveOnLastMonthsIncome extends Feature {
   observe(changedNodes) {
-    if (changedNodes.has('budget-inspector-button')) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.injectLastMonthsIncome();
     }
   }

--- a/src/extension/features/budget/quick-budget-warning/index.js
+++ b/src/extension/features/budget/quick-budget-warning/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class QuickBudgetWarning extends Feature {
   shouldInvoke() {
@@ -54,7 +54,7 @@ export class QuickBudgetWarning extends Feature {
       changedNodes.has('navlink-budget active') ||
       changedNodes.has('budget-inspector') ||
       changedNodes.has('inspector-quick-budget') ||
-      budgetInspectorButtonInChangedNodes(changedNodes)
+      isClassInChangedNodes('budget-inspector-button', changedNodes)
     ) {
       this.invoke();
     }

--- a/src/extension/features/budget/quick-budget-warning/index.js
+++ b/src/extension/features/budget/quick-budget-warning/index.js
@@ -1,5 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class QuickBudgetWarning extends Feature {
   shouldInvoke() {
@@ -53,7 +54,7 @@ export class QuickBudgetWarning extends Feature {
       changedNodes.has('navlink-budget active') ||
       changedNodes.has('budget-inspector') ||
       changedNodes.has('inspector-quick-budget') ||
-      changedNodes.has('budget-inspector-button')
+      budgetInspectorButtonInChangesSet(changedNodes)
     ) {
       this.invoke();
     }

--- a/src/extension/features/budget/quick-budget-warning/index.js
+++ b/src/extension/features/budget/quick-budget-warning/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class QuickBudgetWarning extends Feature {
   shouldInvoke() {
@@ -54,7 +54,7 @@ export class QuickBudgetWarning extends Feature {
       changedNodes.has('navlink-budget active') ||
       changedNodes.has('budget-inspector') ||
       changedNodes.has('inspector-quick-budget') ||
-      budgetInspectorButtonInChangedNodes(changedNodes)
+      budgetInspectorButtonInChangesSet(changedNodes)
     ) {
       this.invoke();
     }

--- a/src/extension/features/budget/quick-budget-warning/index.js
+++ b/src/extension/features/budget/quick-budget-warning/index.js
@@ -1,6 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 export class QuickBudgetWarning extends Feature {
   shouldInvoke() {
@@ -54,7 +54,7 @@ export class QuickBudgetWarning extends Feature {
       changedNodes.has('navlink-budget active') ||
       changedNodes.has('budget-inspector') ||
       changedNodes.has('inspector-quick-budget') ||
-      budgetInspectorButtonInChangesSet(changedNodes)
+      budgetInspectorButtonInChangedNodes(changedNodes)
     ) {
       this.invoke();
     }

--- a/src/extension/features/budget/show-available-after-savings/index.js
+++ b/src/extension/features/budget/show-available-after-savings/index.js
@@ -3,11 +3,11 @@ import { l10n } from 'toolkit/extension/utils/toolkit';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
 import { getBudgetBreakdownEntries } from '../subtract-upcoming-from-available/budget-breakdown-monthly-totals';
 import { isSavingsCategory } from '../subtract-upcoming-from-available/categories';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class ShowAvailableAfterSavings extends Feature {
   observe(changedNodes) {
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
       this.handleBudgetBreakdown();
     }
   }

--- a/src/extension/features/budget/show-available-after-savings/index.js
+++ b/src/extension/features/budget/show-available-after-savings/index.js
@@ -3,11 +3,11 @@ import { l10n } from 'toolkit/extension/utils/toolkit';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
 import { getBudgetBreakdownEntries } from '../subtract-upcoming-from-available/budget-breakdown-monthly-totals';
 import { isSavingsCategory } from '../subtract-upcoming-from-available/categories';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class ShowAvailableAfterSavings extends Feature {
   observe(changedNodes) {
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.handleBudgetBreakdown();
     }
   }

--- a/src/extension/features/budget/show-available-after-savings/index.js
+++ b/src/extension/features/budget/show-available-after-savings/index.js
@@ -3,10 +3,11 @@ import { l10n } from 'toolkit/extension/utils/toolkit';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
 import { getBudgetBreakdownEntries } from '../subtract-upcoming-from-available/budget-breakdown-monthly-totals';
 import { isSavingsCategory } from '../subtract-upcoming-from-available/categories';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class ShowAvailableAfterSavings extends Feature {
   observe(changedNodes) {
-    if (changedNodes.has('budget-inspector-button')) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.handleBudgetBreakdown();
     }
   }

--- a/src/extension/features/budget/show-available-after-savings/index.js
+++ b/src/extension/features/budget/show-available-after-savings/index.js
@@ -3,11 +3,11 @@ import { l10n } from 'toolkit/extension/utils/toolkit';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
 import { getBudgetBreakdownEntries } from '../subtract-upcoming-from-available/budget-breakdown-monthly-totals';
 import { isSavingsCategory } from '../subtract-upcoming-from-available/categories';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 export class ShowAvailableAfterSavings extends Feature {
   observe(changedNodes) {
-    if (budgetInspectorButtonInChangesSet(changedNodes)) {
+    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
       this.handleBudgetBreakdown();
     }
   }

--- a/src/extension/features/budget/subtract-upcoming-from-available/budget-table-row.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/budget-table-row.js
@@ -4,19 +4,20 @@ import * as categories from './categories';
 import { setCategoryOriginalValues } from './destroy-helpers';
 import { shouldRun } from './index';
 
-export function handleBudgetTableRow(element) {
+export function handleBudgetTableRows() {
   if (!shouldRun()) return;
+  $('.budget-table-row').each((_, element) => {
+    const $categoryObjects = getCategoryObjects(element);
+    if (!$categoryObjects) return;
 
-  const $categoryObjects = getCategoryObjects(element);
-  if (!$categoryObjects) return;
+    const category = getEmberView(element.id).category;
+    if (!category) return;
 
-  const category = getEmberView(element.id).category;
-  if (!category) return;
+    const categoryData = categories.setAndGetCategoryData(category);
+    if (!categoryData) return;
 
-  const categoryData = categories.setAndGetCategoryData(category);
-  if (!categoryData) return;
-
-  categoryValues(categoryData, category, $categoryObjects);
+    categoryValues(categoryData, category, $categoryObjects);
+  });
 }
 
 function categoryValues(categoryData, category, $categoryObjects) {

--- a/src/extension/features/budget/subtract-upcoming-from-available/categories.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/categories.js
@@ -102,7 +102,8 @@ export function setCategoriesObject() {
     allBudgetMonthsViewModel.monthlySubCategoryBudgetCalculationsCollection;
   if (!categoryCalculationsCollection) return;
 
-  const categoriesArray = categoryCalculationsCollection._internalDataArray;
+  const categoriesArray = categoryCalculationsCollection.collectionItems;
+  if (!categoriesArray) return;
 
   relevantCategorySet.clear();
   for (const category of categoriesArray) {

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -5,7 +5,7 @@ import { handleBudgetBreakdownMonthlyTotals } from './budget-breakdown-monthly-t
 import { handleBudgetTableRow } from './budget-table-row';
 import { setCategoriesObject } from './categories';
 import * as destroyHelpers from './destroy-helpers';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class SubtractUpcomingFromAvailable extends Feature {
   shouldInvoke() {
@@ -20,7 +20,7 @@ export class SubtractUpcomingFromAvailable extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       handleBudgetBreakdownAvailableBalance();
       handleBudgetBreakdownMonthlyTotals();
     }

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -5,7 +5,7 @@ import { handleBudgetBreakdownMonthlyTotals } from './budget-breakdown-monthly-t
 import { handleBudgetTableRow } from './budget-table-row';
 import { setCategoriesObject } from './categories';
 import * as destroyHelpers from './destroy-helpers';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 export class SubtractUpcomingFromAvailable extends Feature {
   shouldInvoke() {
@@ -20,7 +20,7 @@ export class SubtractUpcomingFromAvailable extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangesSet(changedNodes)) {
+    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
       handleBudgetBreakdownAvailableBalance();
       handleBudgetBreakdownMonthlyTotals();
     }

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -2,19 +2,15 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { getSelectedMonth } from 'toolkit/extension/utils/ynab';
 import { handleBudgetBreakdownAvailableBalance } from './budget-breakdown-available-balance';
 import { handleBudgetBreakdownMonthlyTotals } from './budget-breakdown-monthly-totals';
-import { handleBudgetTableRow } from './budget-table-row';
+import { handleBudgetTableRows } from './budget-table-row';
 import { setCategoriesObject } from './categories';
 import * as destroyHelpers from './destroy-helpers';
 import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
+import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class SubtractUpcomingFromAvailable extends Feature {
   shouldInvoke() {
-    return true;
-  }
-
-  invoke() {
-    setCategoriesObject();
-    this.addToolkitEmberHook('budget-table-row', 'didRender', handleBudgetTableRow);
+    return isCurrentRouteBudgetPage();
   }
 
   observe(changedNodes) {
@@ -24,11 +20,13 @@ export class SubtractUpcomingFromAvailable extends Feature {
       handleBudgetBreakdownAvailableBalance();
       handleBudgetBreakdownMonthlyTotals();
     }
+    if (isClassInChangedNodes('budget-table-row', changedNodes)) {
+      setCategoriesObject();
+      handleBudgetTableRows();
+    }
   }
 
-  onRouteChanged() {
-    setCategoriesObject();
-  }
+  invoke() {}
 
   destroy() {
     destroyHelpers.resetInspectorMessage();

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -5,6 +5,7 @@ import { handleBudgetBreakdownMonthlyTotals } from './budget-breakdown-monthly-t
 import { handleBudgetTableRow } from './budget-table-row';
 import { setCategoriesObject } from './categories';
 import * as destroyHelpers from './destroy-helpers';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class SubtractUpcomingFromAvailable extends Feature {
   shouldInvoke() {
@@ -19,7 +20,7 @@ export class SubtractUpcomingFromAvailable extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (changedNodes.has('budget-inspector-button')) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       handleBudgetBreakdownAvailableBalance();
       handleBudgetBreakdownMonthlyTotals();
     }

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -5,7 +5,7 @@ import { handleBudgetBreakdownMonthlyTotals } from './budget-breakdown-monthly-t
 import { handleBudgetTableRow } from './budget-table-row';
 import { setCategoriesObject } from './categories';
 import * as destroyHelpers from './destroy-helpers';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class SubtractUpcomingFromAvailable extends Feature {
   shouldInvoke() {
@@ -20,7 +20,7 @@ export class SubtractUpcomingFromAvailable extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
       handleBudgetBreakdownAvailableBalance();
       handleBudgetBreakdownMonthlyTotals();
     }

--- a/src/extension/features/budget/target-balance-warning/index.js
+++ b/src/extension/features/budget/target-balance-warning/index.js
@@ -1,7 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
-import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
 
 export class TargetBalanceWarning extends Feature {
   shouldInvoke() {
@@ -15,7 +15,7 @@ export class TargetBalanceWarning extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangesSet(changedNodes)) {
+    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
       this.modifyInspector();
     }
   }

--- a/src/extension/features/budget/target-balance-warning/index.js
+++ b/src/extension/features/budget/target-balance-warning/index.js
@@ -1,7 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class TargetBalanceWarning extends Feature {
   shouldInvoke() {
@@ -15,7 +15,7 @@ export class TargetBalanceWarning extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
       this.modifyInspector();
     }
   }

--- a/src/extension/features/budget/target-balance-warning/index.js
+++ b/src/extension/features/budget/target-balance-warning/index.js
@@ -1,7 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
-import { budgetInspectorButtonInChangedNodes } from 'toolkit/extension/features/budget/utils';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class TargetBalanceWarning extends Feature {
   shouldInvoke() {
@@ -15,7 +15,7 @@ export class TargetBalanceWarning extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetInspectorButtonInChangedNodes(changedNodes)) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.modifyInspector();
     }
   }

--- a/src/extension/features/budget/target-balance-warning/index.js
+++ b/src/extension/features/budget/target-balance-warning/index.js
@@ -1,6 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
+import { budgetInspectorButtonInChangesSet } from 'toolkit/extension/features/budget/utils';
 
 export class TargetBalanceWarning extends Feature {
   shouldInvoke() {
@@ -14,7 +15,7 @@ export class TargetBalanceWarning extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (changedNodes.has('budget-inspector-button')) {
+    if (budgetInspectorButtonInChangesSet(changedNodes)) {
       this.modifyInspector();
     }
   }

--- a/src/extension/features/budget/utils.ts
+++ b/src/extension/features/budget/utils.ts
@@ -29,7 +29,7 @@ export function ensureGoalColumn(element: HTMLElement | null): boolean {
 
   const $goalContainer = $('<div>', {
     class: `${GOAL_TABLE_CELL_CLASSNAME} budget-table-row-li`,
-  }).text(isBudgetHeaderLabels ? 'GOAL' : '');
+  }).text(isBudgetHeaderLabels ? 'TARGET' : '');
 
   $('.budget-table-cell-name', element).after($goalContainer);
   if (!isBudgetHeaderLabels) {

--- a/src/extension/features/budget/utils.ts
+++ b/src/extension/features/budget/utils.ts
@@ -42,3 +42,16 @@ export function ensureGoalColumn(element: HTMLElement | null): boolean {
 export function budgetRowInChangesSet(changes: Set<string>) {
   return changes.has('budget-table-row js-budget-table-row budget-table-row-ul is-sub-category');
 }
+
+export function budgetInspectorButtonInChangesSet(changes: Set<string>) {
+  return (
+    changes.has('budget-inspector-button js-focus-on-start underfunded') ||
+    changes.has('budget-inspector-button underfunded') ||
+    changes.has('budget-inspector-button  assigned-last month') ||
+    changes.has('budget-inspector-button  paid-last month') ||
+    changes.has('budget-inspector-button  average-assigned') ||
+    changes.has('budget-inspector-button  average-paid') ||
+    changes.has('budget-inspector-button  set-available amount to zero') ||
+    changes.has('budget-inspector-button  reset-assigned amount')
+  );
+}

--- a/src/extension/features/budget/utils.ts
+++ b/src/extension/features/budget/utils.ts
@@ -43,15 +43,13 @@ export function budgetRowInChangesSet(changes: Set<string>) {
   return changes.has('budget-table-row js-budget-table-row budget-table-row-ul is-sub-category');
 }
 
-export function budgetInspectorButtonInChangesSet(changes: Set<string>) {
-  return (
-    changes.has('budget-inspector-button js-focus-on-start underfunded') ||
-    changes.has('budget-inspector-button underfunded') ||
-    changes.has('budget-inspector-button  assigned-last month') ||
-    changes.has('budget-inspector-button  paid-last month') ||
-    changes.has('budget-inspector-button  average-assigned') ||
-    changes.has('budget-inspector-button  average-paid') ||
-    changes.has('budget-inspector-button  set-available amount to zero') ||
-    changes.has('budget-inspector-button  reset-assigned amount')
-  );
+export function budgetInspectorButtonInChangedNodes(changedNodes: Set<string>) {
+  let isInSet = false;
+  for (const node of changedNodes) {
+    if (node?.includes('budget-inspector-button')) {
+      isInSet = true;
+    }
+  }
+
+  return isInSet;
 }

--- a/src/extension/features/budget/utils.ts
+++ b/src/extension/features/budget/utils.ts
@@ -43,15 +43,16 @@ export function budgetRowInChangesSet(changes: Set<string>) {
   return changes.has('budget-table-row js-budget-table-row budget-table-row-ul is-sub-category');
 }
 
-export function budgetInspectorButtonInChangesSet(changes: Set<string>) {
-  return (
-    changes.has('budget-inspector-button js-focus-on-start underfunded') ||
-    changes.has('budget-inspector-button underfunded') ||
-    changes.has('budget-inspector-button  assigned-last month') ||
-    changes.has('budget-inspector-button  paid-last month') ||
-    changes.has('budget-inspector-button  average-assigned') ||
-    changes.has('budget-inspector-button  average-paid') ||
-    changes.has('budget-inspector-button  set-available amount to zero') ||
-    changes.has('budget-inspector-button  reset-assigned amount')
-  );
+export function budgetInspectorButtonInChangedNodes(changes: Set<string>) {
+  return isClassInChangedNodes('budget-inspector-button', changes);
+}
+
+export function isClassInChangedNodes(className: string, changes: Set<string>) {
+  for (const node of changes) {
+    if (!!node?.split(' ')?.some((x) => x === className)) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/extension/features/budget/utils.ts
+++ b/src/extension/features/budget/utils.ts
@@ -43,13 +43,15 @@ export function budgetRowInChangesSet(changes: Set<string>) {
   return changes.has('budget-table-row js-budget-table-row budget-table-row-ul is-sub-category');
 }
 
-export function budgetInspectorButtonInChangedNodes(changedNodes: Set<string>) {
-  let isInSet = false;
-  for (const node of changedNodes) {
-    if (node?.includes('budget-inspector-button')) {
-      isInSet = true;
-    }
-  }
-
-  return isInSet;
+export function budgetInspectorButtonInChangesSet(changes: Set<string>) {
+  return (
+    changes.has('budget-inspector-button js-focus-on-start underfunded') ||
+    changes.has('budget-inspector-button underfunded') ||
+    changes.has('budget-inspector-button  assigned-last month') ||
+    changes.has('budget-inspector-button  paid-last month') ||
+    changes.has('budget-inspector-button  average-assigned') ||
+    changes.has('budget-inspector-button  average-paid') ||
+    changes.has('budget-inspector-button  set-available amount to zero') ||
+    changes.has('budget-inspector-button  reset-assigned amount')
+  );
 }

--- a/src/extension/features/budget/utils.ts
+++ b/src/extension/features/budget/utils.ts
@@ -42,17 +42,3 @@ export function ensureGoalColumn(element: HTMLElement | null): boolean {
 export function budgetRowInChangesSet(changes: Set<string>) {
   return changes.has('budget-table-row js-budget-table-row budget-table-row-ul is-sub-category');
 }
-
-export function budgetInspectorButtonInChangedNodes(changes: Set<string>) {
-  return isClassInChangedNodes('budget-inspector-button', changes);
-}
-
-export function isClassInChangedNodes(className: string, changes: Set<string>) {
-  for (const node of changes) {
-    if (!!node?.split(' ')?.some((x) => x === className)) {
-      return true;
-    }
-  }
-
-  return false;
-}

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/component.tsx
@@ -320,7 +320,6 @@ export class IncomeVsExpenseComponent extends React.Component<
   _createEmptyMonthMapFromFilters() {
     const { fromDate, toDate } = this.props.filters!.dateFilter;
     const date = fromDate.clone();
-    console.log('Date', date);
     const dates = {
       // TODO: is this DateWithoutTime or Moment? Or is it the same shit?
       [date.toISOString()]: createMonthlyTotalsMap(date),

--- a/src/extension/utils/helpers.ts
+++ b/src/extension/utils/helpers.ts
@@ -30,3 +30,13 @@ export function compareSemanticVersion(left: string, right: string) {
 
   return 0;
 }
+
+export function isClassInChangedNodes(className: string, changedNodes: Set<string>) {
+  for (const node of changedNodes) {
+    if (!!node?.split(' ')?.some((c) => c === className)) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
GitHub Issue (if applicable): #3378, #3374, #3380, #2990, #3162, #3050, #3253, #3186, #3371, #3389

**Explanation of Bugfix/Feature/Modification:**

- Fix budget-inspector-button classes by using centralized method to check for it, updates classes
  - This should resolve issues with: Last Month Income, Total Monthly Goals, Total Overspent, Live on Last Months Income, and probably more
- Fix Rectify Difference button
- Fix Subtract Upcoming (removed addToolkitEmberHook call, fixes error)
- Fix Goal Indicator (removed addToolkitEmberHook call)
- Renames Goals -> Target
- Fix Budget Progress Bars (removed addToolkitEmberHook call)
- Updates Goal Indicator labels