### PR TITLE
"Enable Markdown in Memos" fix, refactor MutationObserver

### DIFF
--- a/src/extension/features/accounts/memo-as-markdown/index.jsx
+++ b/src/extension/features/accounts/memo-as-markdown/index.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { componentPrepend } from 'toolkit/extension/utils/react';
@@ -36,7 +37,9 @@ export class MemoAsMarkdown extends Feature {
       }
 
       const note = row?.content?.memo;
-      const originalMemo = transactionElement.querySelector('.ynab-grid-cell-memo span');
+      const originalMemo = transactionElement.querySelector(
+        '.ynab-grid-cell-memo span:not(.tk-markdown-memo)'
+      );
       if (note && originalMemo) {
         $(originalMemo).hide();
 
@@ -46,22 +49,26 @@ export class MemoAsMarkdown extends Feature {
           }
         };
 
-        componentPrepend(
-          <div className="tk-markdown-memo" onClick={handleClick}>
-            <ReactMarkdown
-              components={{
-                link: ({ href, children }) => (
-                  <a href={href} target="_blank" rel="noopener noreferrer">
-                    {children}
-                  </a>
-                ),
-              }}
-            >
-              {note}
-            </ReactMarkdown>
-          </div>,
-          transactionElement.querySelector('.ynab-grid-cell-memo')
+        const span = document.createElement('span');
+        span.className = 'tk-markdown-memo';
+        span.onclick = handleClick;
+        ReactDOM.createRoot(span).render(
+          <ReactMarkdown
+            components={{
+              link: ({ href, children }) => (
+                <a href={href} target="_blank" rel="noopener noreferrer">
+                  {children}
+                </a>
+              ),
+            }}
+          >
+            {note}
+          </ReactMarkdown>
         );
+        const memoCell = transactionElement.querySelector('.ynab-grid-cell-memo');
+        if (memoCell) {
+          memoCell.prepend(span);
+        }
       }
     });
   };

--- a/src/extension/features/accounts/memo-as-markdown/index.jsx
+++ b/src/extension/features/accounts/memo-as-markdown/index.jsx
@@ -2,10 +2,8 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
-import { componentPrepend } from 'toolkit/extension/utils/react';
 import ReactMarkdown from 'react-markdown';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class MemoAsMarkdown extends Feature {
   injectCSS() {
@@ -85,7 +83,7 @@ export class MemoAsMarkdown extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (isClassInChangedNodes('ynab-grid-body-row', changedNodes)) {
+    if (changedNodes.has('ynab-grid-body-row')) {
       this.invoke();
     }
   }

--- a/src/extension/features/budget/budget-progress-bars/index.js
+++ b/src/extension/features/budget/budget-progress-bars/index.js
@@ -2,7 +2,6 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { pacingForCategory } from 'toolkit/extension/utils/pacing';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 const PROGRESS_INDICATOR_WIDTH = 0.001; // Current month progress indicator width
 
@@ -31,7 +30,7 @@ export class BudgetProgressBars extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (isClassInChangedNodes('budget-table-row', changedNodes)) {
+    if (changedNodes.has('budget-table-row')) {
       this.invoke();
     }
   }

--- a/src/extension/features/budget/check-credit-balances/index.js
+++ b/src/extension/features/budget/check-credit-balances/index.js
@@ -6,7 +6,6 @@ import {
 } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getEmberView } from 'toolkit/extension/utils/ember';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class CheckCreditBalances extends Feature {
   injectCSS() {
@@ -24,7 +23,7 @@ export class CheckCreditBalances extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
+    if (changedNodes.has('budget-inspector-button')) {
       this.addRectifyDifferenceButton();
     }
 

--- a/src/extension/features/budget/custom-average-budgeting/index.tsx
+++ b/src/extension/features/budget/custom-average-budgeting/index.tsx
@@ -6,7 +6,6 @@ import { Feature } from '../../feature';
 import { componentAfter } from 'toolkit/extension/utils/react';
 import type { FeatureSetting } from 'toolkit/types/toolkit/features';
 import type { BudgetTableRowComponent } from 'toolkit/types/ynab/components/BudgetTableRow';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 const QuickBudgetButton = ({
   setting,
@@ -34,7 +33,7 @@ const QuickBudgetButton = ({
 
 export class CustomAverageBudgeting extends Feature {
   observe(changedNodes: Set<string>) {
-    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
+    if (changedNodes.has('budget-inspector-button')) {
       this._renderButton();
     }
   }

--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -6,7 +6,6 @@ import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/
 
 import { FormattedCurrency } from './FormattedCurrency';
 import { InspectorCard } from './InspectorCard';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 const BreakdownItem = ({ label, children, className = '' }) => {
   return (
@@ -205,7 +204,7 @@ export class DisplayTotalMonthlyGoals extends Feature {
       return;
     }
 
-    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
+    if (changedNodes.has('budget-inspector-button')) {
       this.addMonthlyGoalsOverview();
     }
   }

--- a/src/extension/features/budget/display-total-overspent/index.js
+++ b/src/extension/features/budget/display-total-overspent/index.js
@@ -1,11 +1,10 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class DisplayTotalOverspent extends Feature {
   observe(changedNodes) {
-    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
+    if (changedNodes.has('budget-inspector-button')) {
       this.addTotalOverspent();
     }
   }

--- a/src/extension/features/budget/fund-half/index.ts
+++ b/src/extension/features/budget/fund-half/index.ts
@@ -2,7 +2,6 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { getBudgetService, isCurrentMonthSelected } from 'toolkit/extension/utils/ynab';
 import type { YNABBudgetMonthDisplayItem } from 'toolkit/types/ynab/services/YNABBudgetService';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 // The concept here is that for odd monthly Target amounts there is a low half and a high half.
 // Example:  For $65.05 the low half is $32.52 (x2 = $65.04).  The high half is $32.53 (x2 - $65.06).
@@ -44,7 +43,7 @@ export class FundHalf extends Feature {
   observe(changedNodes: Set<string>) {
     if (!this.shouldInvoke()) return;
 
-    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
+    if (changedNodes.has('budget-inspector-button')) {
       this.updateDOM();
     }
   }

--- a/src/extension/features/budget/goal-indicator/index.js
+++ b/src/extension/features/budget/goal-indicator/index.js
@@ -5,7 +5,6 @@ import {
   GOAL_TABLE_CELL_CLASSNAME,
 } from 'toolkit/extension/features/budget/utils';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class GoalIndicator extends Feature {
   injectCSS() {
@@ -23,7 +22,7 @@ export class GoalIndicator extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (isClassInChangedNodes('budget-table-row', changedNodes)) {
+    if (changedNodes.has('budget-table-row')) {
       this.invoke();
     }
   }

--- a/src/extension/features/budget/live-on-last-months-income/index.js
+++ b/src/extension/features/budget/live-on-last-months-income/index.js
@@ -2,11 +2,10 @@ import { Feature } from 'toolkit/extension/features/feature';
 import { getCurrentBudgetDate, getEntityManager } from 'toolkit/extension/utils/ynab';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { l10n, l10nMonth, MonthStyle } from 'toolkit/extension/utils/toolkit';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class LiveOnLastMonthsIncome extends Feature {
   observe(changedNodes) {
-    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
+    if (changedNodes.has('budget-inspector-button')) {
       this.injectLastMonthsIncome();
     }
   }

--- a/src/extension/features/budget/quick-budget-warning/index.js
+++ b/src/extension/features/budget/quick-budget-warning/index.js
@@ -1,6 +1,5 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class QuickBudgetWarning extends Feature {
   shouldInvoke() {
@@ -54,7 +53,7 @@ export class QuickBudgetWarning extends Feature {
       changedNodes.has('navlink-budget active') ||
       changedNodes.has('budget-inspector') ||
       changedNodes.has('inspector-quick-budget') ||
-      isClassInChangedNodes('budget-inspector-button', changedNodes)
+      changedNodes.has('budget-inspector-button')
     ) {
       this.invoke();
     }

--- a/src/extension/features/budget/show-available-after-savings/index.js
+++ b/src/extension/features/budget/show-available-after-savings/index.js
@@ -3,11 +3,10 @@ import { l10n } from 'toolkit/extension/utils/toolkit';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
 import { getBudgetBreakdownEntries } from '../subtract-upcoming-from-available/budget-breakdown-monthly-totals';
 import { isSavingsCategory } from '../subtract-upcoming-from-available/categories';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class ShowAvailableAfterSavings extends Feature {
   observe(changedNodes) {
-    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
+    if (changedNodes.has('budget-inspector-button')) {
       this.handleBudgetBreakdown();
     }
   }

--- a/src/extension/features/budget/subtract-upcoming-from-available/index.js
+++ b/src/extension/features/budget/subtract-upcoming-from-available/index.js
@@ -5,7 +5,6 @@ import { handleBudgetBreakdownMonthlyTotals } from './budget-breakdown-monthly-t
 import { handleBudgetTableRows } from './budget-table-row';
 import { setCategoriesObject } from './categories';
 import * as destroyHelpers from './destroy-helpers';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 import { isCurrentRouteBudgetPage } from 'toolkit/extension/utils/ynab';
 
 export class SubtractUpcomingFromAvailable extends Feature {
@@ -16,11 +15,11 @@ export class SubtractUpcomingFromAvailable extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
+    if (changedNodes.has('budget-inspector-button')) {
       handleBudgetBreakdownAvailableBalance();
       handleBudgetBreakdownMonthlyTotals();
     }
-    if (isClassInChangedNodes('budget-table-row', changedNodes)) {
+    if (changedNodes.has('budget-table-row')) {
       setCategoriesObject();
       handleBudgetTableRows();
     }

--- a/src/extension/features/budget/target-balance-warning/index.js
+++ b/src/extension/features/budget/target-balance-warning/index.js
@@ -1,7 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { getEmberView } from 'toolkit/extension/utils/ember';
 import { getBudgetService } from 'toolkit/extension/utils/ynab';
-import { isClassInChangedNodes } from 'toolkit/extension/utils/helpers';
 
 export class TargetBalanceWarning extends Feature {
   shouldInvoke() {
@@ -15,7 +14,7 @@ export class TargetBalanceWarning extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (isClassInChangedNodes('budget-inspector-button', changedNodes)) {
+    if (changedNodes.has('budget-inspector-button')) {
       this.modifyInspector();
     }
   }

--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -6,10 +6,17 @@ const { later } = ynabRequire('@ember/runloop');
 const IGNORE_UPDATES = new Set([
   // every time you hover a budget row, one of these nodes change which is _just a lot_.
   'ynab-new-icon category-moves-moves-icon',
+  'ynab-new-icon',
+  'category-moves-moves-icon',
   'budget-table-cell-category-moves js-budget-toolbar-open-category-moves',
+  'budget-table-cell-category-moves',
+  'js-budget-toolbar-open-category-moves',
   'budget-table-cell-category-moves js-budget-toolbar-open-category-moves category-moves-hidden',
+  'category-moves-hidden',
   // when you scroll on an accounts page :D
-  'ynab-grid-container  scrolling',
+  'ynab-grid-container scrolling',
+  'ynab-grid-container',
+  'scrolling',
 ]);
 
 export class ObserveListener {
@@ -26,9 +33,19 @@ export class ObserveListener {
 
       const addChangedNodes = (nodes) => {
         nodes.each((index, element) => {
-          var nodeClass = $(element).attr('class');
-          if (nodeClass) {
-            this.changedNodes.add(nodeClass.replace(/ember-view/g, '').trim());
+          let nodeClass = $(element).attr('class') || '';
+          nodeClass = nodeClass.replace(/ember-view/g, '').trim();
+          if (nodeClass && !this.changedNodes.has(nodeClass)) {
+            this.changedNodes.add(nodeClass);
+
+            let splitClasses = nodeClass.split(' ');
+            if (splitClasses && splitClasses.length) {
+              splitClasses.forEach((splitClass) => {
+                if (splitClass && !this.changedNodes.has(splitClass)) {
+                  this.changedNodes.add(splitClass);
+                }
+              });
+            }
           }
         });
       };

--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -38,14 +38,12 @@ export class ObserveListener {
           if (nodeClass) {
             this.changedNodes.add(nodeClass);
 
-            let splitClasses = nodeClass.split(' ');
-            if (splitClasses && splitClasses.length) {
-              splitClasses.forEach((splitClass) => {
-                if (splitClass) {
-                  this.changedNodes.add(splitClass);
-                }
-              });
-            }
+            const nodeClasses = nodeClass.split(' ');
+            nodeClasses.forEach((className) => {
+              if (className) {
+                this.changedNodes.add(className);
+              }
+            });
           }
         });
       };

--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -35,13 +35,13 @@ export class ObserveListener {
         nodes.each((index, element) => {
           let nodeClass = $(element).attr('class') || '';
           nodeClass = nodeClass.replace(/ember-view/g, '').trim();
-          if (nodeClass && !this.changedNodes.has(nodeClass)) {
+          if (nodeClass) {
             this.changedNodes.add(nodeClass);
 
             let splitClasses = nodeClass.split(' ');
             if (splitClasses && splitClasses.length) {
               splitClasses.forEach((splitClass) => {
-                if (splitClass && !this.changedNodes.has(splitClass)) {
+                if (splitClass) {
                   this.changedNodes.add(splitClass);
                 }
               });

--- a/src/extension/utils/helpers.ts
+++ b/src/extension/utils/helpers.ts
@@ -30,13 +30,3 @@ export function compareSemanticVersion(left: string, right: string) {
 
   return 0;
 }
-
-export function isClassInChangedNodes(className: string, changedNodes: Set<string>) {
-  for (const node of changedNodes) {
-    if (!!node?.split(' ')?.some((c) => c === className)) {
-      return true;
-    }
-  }
-
-  return false;
-}


### PR DESCRIPTION
GitHub Issue (if applicable): #3139 

**Explanation of Bugfix/Feature/Modification:**
- Refactors MutationObserver logic to include all individual classes in changedNodes (split by space)
- Update Memo Markdown feature to use observe pattern

**Screenshots**
If you're adding or changing a feature. Please include screenshots or a video of the feature.
