### PR TITLE
Add explainer for forecast report

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/modal/context/component.tsx
+++ b/src/extension/features/toolkit-reports/common/components/modal/context/component.tsx
@@ -1,14 +1,18 @@
 import { ModalContainer } from '../components/modal-container';
-import React, { ComponentType, createContext } from 'react';
+import React, { ComponentType, createContext, useContext } from 'react';
 
 export type ModalContextType = {
   showModal: <T extends object>(modal: ComponentType<T>, props: T) => void;
   closeModal: () => void;
 };
 
-const { Provider, Consumer } = createContext<ModalContextType>({
-  showModal: () => {},
-  closeModal: () => {},
+const ModalContext = createContext<ModalContextType>({
+  showModal: () => {
+    throw new Error('Using ModalContext outside of ModalContext.Provider');
+  },
+  closeModal: () => {
+    throw new Error('Using ModalContext outside of ModalContext.Provider');
+  },
 });
 
 export function withModalContextProvider<T extends object>(InnerComponent: ComponentType<T>) {
@@ -26,21 +30,21 @@ export function withModalContextProvider<T extends object>(InnerComponent: Compo
 
       return (
         <React.Fragment>
-          <Provider
+          <ModalContext.Provider
             value={{
               closeModal: this._closeModal,
               showModal: this._showModal,
             }}
           >
             <InnerComponent {...this.props} />
-          </Provider>
-          {Modal && (
-            <ModalContainer
-              closeModal={this._closeModal}
-              modal={Modal}
-              modalProps={this.state.modalProps}
-            />
-          )}
+            {Modal && (
+              <ModalContainer
+                closeModal={this._closeModal}
+                modal={Modal}
+                modalProps={this.state.modalProps}
+              />
+            )}
+          </ModalContext.Provider>
         </React.Fragment>
       );
     }
@@ -62,12 +66,16 @@ export function withModalContext<T extends object>(
     return class WithModalContextProvider extends React.Component {
       render() {
         return (
-          <Consumer>
+          <ModalContext.Consumer>
             {/* @ts-ignore */}
             {(value) => <InnerComponent {...this.props} {...mapContextToProps(value)} />}
-          </Consumer>
+          </ModalContext.Consumer>
         );
       }
     };
   };
+}
+
+export function useModal() {
+  return useContext(ModalContext);
 }

--- a/src/extension/features/toolkit-reports/common/components/report-context/component.tsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.tsx
@@ -11,6 +11,7 @@ export type SelectedReportContextPropType = {
     disableTrackingAccounts?: boolean;
     includeTrackingAccounts?: boolean;
   };
+  filtersExtraComponent?: React.ComponentType<{}>;
 };
 
 export type FiltersType = {

--- a/src/extension/features/toolkit-reports/common/components/report-context/reports-provider.tsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/reports-provider.tsx
@@ -18,6 +18,7 @@ import {
   storeDateFilters,
 } from '../../../utils/storage';
 import { YNABTransaction } from 'toolkit/types/ynab/data/transaction';
+import { ForecastHelp } from '../../../pages/forecast/help';
 
 const ACTIVE_REPORT_KEY = 'active-report';
 
@@ -93,6 +94,7 @@ const REPORT_COMPONENTS: SelectedReportContextPropType[] = [
       disableTrackingAccounts: false,
       includeTrackingAccounts: true,
     },
+    filtersExtraComponent: ForecastHelp,
   },
 ];
 

--- a/src/extension/features/toolkit-reports/pages/forecast/help.tsx
+++ b/src/extension/features/toolkit-reports/pages/forecast/help.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import './styles.scss';
+import { useModal } from 'toolkit/extension/features/toolkit-reports/common/components/modal';
+
+export const ForecastHelp = () => {
+  const { showModal } = useModal();
+  return (
+    <div className="tk-forecast-help-container">
+      <button
+        onClick={() => showModal(HelpModal, {})}
+        className="tk-button tk-button--hollow tk-button--medium tk-button--text"
+      >
+        How does this work?
+      </button>
+    </div>
+  );
+};
+
+const HelpModal = () => {
+  const { closeModal } = useModal();
+  return (
+    <div className="tk-forecast-help-modal">
+      <div>
+        <p>
+          This report uses{' '}
+          <a href="https://www.investopedia.com/terms/m/montecarlosimulation.asp" target="_blank">
+            Monte Carlo Simulation
+          </a>{' '}
+          to calculate the probability of having a different net worth in 10 years.
+        </p>
+
+        <p>
+          Based on your prior net worth change history, it projects 100 possible scenarios in which
+          your net worth could change in the next 10 years. It then calculates the minimal net worth
+          for the top 90%, 75%, 50%, 25%, and 10% projections (i.e., in the top 10% of projections,
+          your final net worth was $xx,xxx or more).
+        </p>
+
+        <p>For each bucket, an example projection is then selected and displayed on chart.</p>
+      </div>
+      <button onClick={closeModal} className="tk-button">
+        Close
+      </button>
+    </div>
+  );
+};

--- a/src/extension/features/toolkit-reports/pages/forecast/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/forecast/styles.scss
@@ -1,0 +1,23 @@
+.tk-forecast-help-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-grow: 1;
+}
+
+.tk-forecast-help-modal {
+  padding: 1rem;
+  max-width: 40rem;
+
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  p {
+    line-height: 1.5;
+  }
+
+  button {
+    align-self: center;
+  }
+}

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.tsx
@@ -24,6 +24,7 @@ export type ReportFiltersProps = {
 export class ReportFiltersComponent extends React.Component<ReportFiltersProps> {
   render() {
     const { disableCategoryFilter } = this.props.selectedReport.filterSettings;
+    const ExtraComponent = this.props.selectedReport.filtersExtraComponent;
     const { accountFilterIds, categoryFilterIds, dateFilter } = this.props.filters;
     const categoryButtonClasses = classnames(
       'tk-button',
@@ -62,6 +63,7 @@ export class ReportFiltersComponent extends React.Component<ReportFiltersProps> 
             </button>
           </div>
         </div>
+        {!!ExtraComponent && <ExtraComponent />}
       </div>
     );
   }


### PR DESCRIPTION
I'm not native english speaker, so if there any mistakes in the explainer feel free to correct me

Text in the modal:


> This report uses [Monte Carlo Simulation](https://www.investopedia.com/terms/m/montecarlosimulation.asp) to calculate the probability of having a different net worth in 10 years.
>
> Based on your prior net worth change history, it projects 100 possible scenarios in which your net worth could change in the next 10 years. It then calculates the minimal net worth for the top 90%, 75%, 50%, 25%, and 10% projections (i.e., in the top 10% of projections, your final net worth was $xx,xxx or more).
>
> For each bucket, an example projection is then selected and displayed on chart.


GitHub Issue (if applicable): #3323

**Explanation of Bugfix/Feature/Modification:**
Added button which shows info how forecast report works

**Screenshots**

![CleanShot 2024-02-25 at 16 28 11](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/7430438/ef526280-494d-4168-aaeb-5f8754d62957)

