### PR TITLE
feat: improve documentation for firefox local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This extension uses three main things in its build process:
 
       - Build and run in Firefox
 
-            $ web-ext run --source-dir dist/extension/
+            $ yarn run manifest:firefox && web-ext run --source-dir dist/extension/
 
       - You can also disable reloading like this:
 


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX

**Explanation of Bugfix/Feature/Modification:**
Improves the documentation. Without the added step (`yarn run manifest:firefox`), the following step `web-ext run --source-dir dist/extension/` fails in firefox with the following error;

```
[/Users/thomas/.config/yarn/global/node_modules/web-ext/lib/program.js][error] 
WebExtError: installTemporaryAddon: Error: Error: Could not install add-on at '/Users/thomas/Documents/workspace/perso/toolkit-for-ynab/dist/extension': Error: background.service_worker is currently disabled
    at RemoteFirefox.installTemporaryAddon (file:///Users/thomas/.config/yarn/global/node_modules/web-ext/lib/firefox/remote.js:92:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async FirefoxDesktopExtensionRunner.startFirefoxInstance (file:///Users/thomas/.config/yarn/global/node_modules/web-ext/lib/extension-runners/firefox-desktop.js:216:27)
    at async FirefoxDesktopExtensionRunner.run (file:///Users/thomas/.config/yarn/global/node_modules/web-ext/lib/extension-runners/firefox-desktop.js:49:5)
    at async Promise.all (index 0)
    at async MultiExtensionRunner.run (file:///Users/thomas/.config/yarn/global/node_modules/web-ext/lib/extension-runners/index.js:66:5)
    at async run (file:///Users/thomas/.config/yarn/global/node_modules/web-ext/lib/cmd/run.js:177:3)
    at async Program.execute (file:///Users/thomas/.config/yarn/global/node_modules/web-ext/lib/program.js:268:7)
    at async file:///Users/thomas/.config/yarn/global/node_modules/web-ext/bin/web-ext.js:13:1


```

**Screenshots**
If you're adding or changing a feature. Please include screenshots or a video of the feature.
