### PR TITLE
Revert "Remove approve and clear keyboard shortcut in favor of native shortcuts"

### DIFF
--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -349,6 +349,14 @@ Makes the uncleared, cleared and reconciled icons slightly larger and easier to 
 
 Add support for links in memos on the accounts page.
 
+## Keyboard Shortcut: Approve Transaction [A] or [Enter]
+
+Approve scheduled or linked transactions by pressing 'A' or 'Enter' on your keyboard selecting any number of transactions. Alternately, approve single scheduled or linked transactions by right clicking on the blue 'i' or link icon.
+
+## Keyboard Shortcut: Clear Transaction [CTRL + Enter]
+
+Clear a new or edited transaction by pressing CTRL+Enter (CMD on Mac) while it's selected.
+
 ## Modify First Day of the Week
 
 Adjust the first day of the week in the calendar to whichever day you chose when editing or adding a transaction.

--- a/src/extension/features/accounts/ctrl-enter-cleared/index.js
+++ b/src/extension/features/accounts/ctrl-enter-cleared/index.js
@@ -1,0 +1,47 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+
+export class CtrlEnterCleared extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage() && !!$('.ynab-grid-body-row.is-editing').length;
+  }
+
+  invoke() {
+    const $editRows = $('.ynab-grid-body-row.is-editing');
+    const $editInputs = $(
+      '.ynab-grid-cell-memo input, .ynab-grid-cell-outflow input, .ynab-grid-cell-inflow input',
+      $editRows
+    );
+    $editInputs.each((_, input) => {
+      if (!input.getAttribute('data-toolkit-ctrl-behavior')) {
+        input.setAttribute('data-toolkit-ctrl-behavior', true);
+        input.addEventListener('keydown', this.applyCtrlEnter);
+      }
+    });
+  }
+
+  destroy() {
+    const $editInputs = $('input[data-toolkit-ctrl-behavior]');
+    $editInputs.each((_, input) => {
+      input.removeAttribute('data-toolkit-ctrl-behavior');
+      input.removeEventListener('keydown', this.applyCtrlEnter);
+    });
+  }
+
+  applyCtrlEnter(event) {
+    // This check is added so that there is no conflict with ChangeMemoEnterBehavior
+    if ($(this)[0].getAttribute('data-toolkit-memo-behavior')) return;
+    if (event.keyCode === 13 && (event.metaKey || event.ctrlKey)) {
+      let $markClearedButton = $('.is-editing .ynab-cleared:not(.is-cleared)');
+      $markClearedButton.trigger('click');
+    }
+  }
+
+  observe(changedNodes) {
+    if (!changedNodes.has('ynab-grid-body')) return;
+
+    if (this.shouldInvoke()) {
+      this.invoke();
+    }
+  }
+}

--- a/src/extension/features/accounts/ctrl-enter-cleared/settings.js
+++ b/src/extension/features/accounts/ctrl-enter-cleared/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'CtrlEnterCleared',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Keyboard Shortcut: Clear Transaction [CTRL + Enter]',
+  description:
+    "Clear a new or edited transaction by pressing CTRL+Enter (CMD on Mac) while it's selected.",
+};

--- a/src/extension/features/accounts/easy-transaction-approval/index.js
+++ b/src/extension/features/accounts/easy-transaction-approval/index.js
@@ -1,0 +1,65 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { containerLookup } from 'toolkit/extension/utils/ember';
+import { getEntityManager } from 'toolkit/extension/utils/ynab';
+
+export class EasyTransactionApproval extends Feature {
+  shouldInvoke() {
+    return true;
+  }
+
+  invoke() {
+    document.body.addEventListener('keydown', this.handleKeydown);
+
+    for (const element of document.querySelectorAll('.ynab-grid-cell-notification button')) {
+      element.addEventListener('contextmenu', this.approveTransaction);
+    }
+
+    this.addToolkitEmberHook('register/grid-row', 'didUpdate', this.attachEasyApproval);
+  }
+
+  destroy() {
+    document.body.removeEventListener('keydown', this.handleKeydown);
+
+    for (const element of document.querySelectorAll('.ynab-grid-cell-notification button')) {
+      element.removeEventListener('contextmenu', this.approveTransaction);
+    }
+  }
+
+  handleKeydown(event) {
+    if (event.code === 'KeyA' || event.code === 'Enter') {
+      const isInputEvent = event.target.nodeName === 'INPUT';
+
+      if (isInputEvent) return;
+
+      getEntityManager().batchChangeProperties(() => {
+        containerLookup('service:accounts').areChecked.forEach((transaction) => {
+          const entity = getEntityManager().getTransactionById(transaction?.entityId);
+          if (entity) {
+            entity.accepted = true;
+          }
+        });
+      });
+    }
+  }
+
+  attachEasyApproval(element) {
+    element
+      .querySelector('.ynab-grid-cell-notification button')
+      ?.addEventListener('contextmenu', this.approveTransaction);
+  }
+
+  approveTransaction = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const rowId = event.currentTarget?.parentElement?.parentElement?.dataset?.rowId;
+    if (rowId) {
+      getEntityManager().batchChangeProperties(() => {
+        const entity = getEntityManager().getTransactionById(rowId);
+        if (entity) {
+          entity.accepted = true;
+        }
+      });
+    }
+  };
+}

--- a/src/extension/features/accounts/easy-transaction-approval/settings.js
+++ b/src/extension/features/accounts/easy-transaction-approval/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'EasyTransactionApproval',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Keyboard Shortcut: Approve Transaction [A] or [Enter]',
+  description:
+    "Approve scheduled or linked transactions by pressing 'A' or 'Enter' on your keyboard selecting any number of transactions. Alternately, approve single scheduled or linked transactions by right clicking on the blue 'i' or link icon.",
+};


### PR DESCRIPTION
Reverts toolkit-for-ynab/toolkit-for-ynab#3384

Fixes #3398

Turns out that the new keyboard shortcuts are in beta, that's a shame. Reverting for now.