### PR TITLE
use classic while syntax to allow checks/_lib.sh to be run with SH

### DIFF
--- a/checks/_lib.sh
+++ b/checks/_lib.sh
@@ -3,11 +3,6 @@
 # Finds the check scripts in the check/ directory
 # Must be run from the repo root
 find_check_files() {
-  all_files="$(find ./checks \
-    -type f \
-    -name '*.sh' \
-    -not -name '_lib.sh' \
-    -not -name '_template.sh' | sort)"
 
   # Dummy variables/functions are set so that
   # the call to unset below doesn't fail if
@@ -19,7 +14,11 @@ find_check_files() {
   PREPUSH=1
   # END dummy variables
 
-  while read -r file; do
+  find ./checks -type f \
+    -name '*.sh' \
+    -not -name '_lib.sh' \
+    -not -name '_template.sh' | sort | while read -r file 
+  do
     unset check PRECOMMIT PREPUSH
     . "$file"
     case $1 in
@@ -41,7 +40,7 @@ find_check_files() {
       return 1
       ;;
     esac
-  done <<<"$all_files"
+  done
 }
 
 # $1 - any of 'precommit', 'prepush', or 'all'


### PR DESCRIPTION
GitHub Issue (if applicable): #3411

**Explanation of Bugfix/Feature/Modification:**
I removed the here-string using `<<<"$all_files"` from the `checks/_lib.sh` script, and replaced it with a typical loop in which the results of `find` are piped into `while`. This variant works for `sh` and `bash`.

**Result**
Without the change:
```bash
$ git commit
.husky/pre-commit: 44: ./checks/_lib.sh: Syntax error: redirection unexpected
husky - pre-commit hook exited with code 2 (error)
```

With the change:
```bash
$ git commit
Running precommit checks

Running check ./checks/format.sh

yarn run v1.22.19
🔍  Finding changed files since git revision 06c271a9.
🎯  Found 0 changed files.
✅  Everything is awesome!
...
```
