### PR TITLE
Update tab title when switching to toolkit reports

### DIFF
--- a/src/extension/features/toolkit-reports/index.js
+++ b/src/extension/features/toolkit-reports/index.js
@@ -75,9 +75,8 @@ export class ToolkitReports extends Feature {
     $(YNAB_NAVLINK_SELECTOR).removeClass('active');
     $(YNAB_NAVACCOUNT_SELECTOR).removeClass('is-selected');
     $(TOOLKIT_REPORTS_NAVLINK_SELECTOR).addClass('active');
-    $(`${YNAB_NAVLINK_SELECTOR}, ${YNAB_NAVACCOUNT_SELECTOR}`).on(
-      'click',
-      this._removeToolkitReports
+    $(`${YNAB_NAVLINK_SELECTOR}, ${YNAB_NAVACCOUNT_SELECTOR}`).on('click', () =>
+      this._removeToolkitReports()
     );
   }
 
@@ -114,7 +113,9 @@ export class ToolkitReports extends Feature {
       const container = document.getElementById(TOOLKIT_REPORTS_CONTAINER_ID);
       if (container) {
         $(container).css('height', '100%');
-        this.reactRoot = ReactDOM.createRoot(container);
+        if (!this.reactRoot) {
+          this.reactRoot = ReactDOM.createRoot(container);
+        }
         this.reactRoot.render(React.createElement(Root));
       }
     }, 50);

--- a/src/extension/features/toolkit-reports/pages/root/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/component.tsx
@@ -7,8 +7,9 @@ import {
 import { ReportFilters } from './components/report-filters';
 import { ReportSelector } from './components/report-selector';
 import './styles.scss';
-import { YNABTransaction } from 'toolkit/types/ynab/data/transaction';
 import { withReportContextProvider } from '../../common/components/report-context/reports-provider';
+import { useDocumentTitle } from 'toolkit/hooks/useDocumentTitle';
+import { REPORT_TYPES } from '../../common/constants/report-types';
 
 function mapContextToProps(context: ReportContextType) {
   return {
@@ -18,26 +19,23 @@ function mapContextToProps(context: ReportContextType) {
 
 const Noop = () => null;
 
-export class RootComponent extends React.Component<
-  { selectedReport: ReportContextType['selectedReport'] },
-  { filteredTransactions: YNABTransaction[] }
-> {
-  state = {
-    filteredTransactions: [],
-  };
+export const RootComponent = ({
+  selectedReport,
+}: {
+  selectedReport: ReportContextType['selectedReport'];
+}) => {
+  const Report = selectedReport ? selectedReport.component : Noop;
+  const name = REPORT_TYPES.find((r) => r.key === selectedReport?.key)?.name || 'Toolkit Reports';
+  useDocumentTitle(name);
 
-  render() {
-    const Report = this.props.selectedReport ? this.props.selectedReport.component : Noop;
-
-    return (
-      <div className="tk-reports-root tk-flex tk-flex-column tk-full-height">
-        <ReportSelector />
-        <ReportFilters />
-        <Report />
-      </div>
-    );
-  }
-}
+  return (
+    <div className="tk-reports-root tk-flex tk-flex-column tk-full-height">
+      <ReportSelector />
+      <ReportFilters />
+      <Report />
+    </div>
+  );
+};
 
 export const Root = withReportContextProvider(
   withModalContextProvider(withReportContext(mapContextToProps)(RootComponent))

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import { localizedMonthAndYear } from 'toolkit/extension/utils/date';
 import {
   FiltersType,

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -5,7 +5,7 @@ export const useDocumentTitle = (title: string, overwriteCompletely = false) => 
     const originalTitle = document.title;
     const newTitle = overwriteCompletely
       ? title
-      : [title, originalTitle.split(' | ').slice(1)].join(' | ');
+      : [title, ...originalTitle.split(' | ').slice(1)].join(' | ');
     document.title = newTitle;
     return () => {
       document.title = originalTitle;

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+export const useDocumentTitle = (title: string, overwriteCompletely = false) => {
+  useEffect(() => {
+    const originalTitle = document.title;
+    const newTitle = overwriteCompletely
+      ? title
+      : [title, originalTitle.split(' | ').slice(1)].join(' | ');
+    document.title = newTitle;
+    return () => {
+      document.title = originalTitle;
+    };
+  }, [title, overwriteCompletely]);
+};


### PR DESCRIPTION
GitHub Issue (if applicable): #3429

**Explanation of Bugfix/Feature/Modification:**
Updated toolkit to change page title when user opens/switches toolkit report

**Screenshots**
If you're adding or changing a feature. Please include screenshots or a video of the feature.
