### PR TITLE
Fix: Income vs Expenses report going blank for some users

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,24 +58,24 @@ This extension uses three main things in its build process:
 - Webpack: Bundles entry points for all Web Extension pages (background, popup, options,
   content scripts) into single files and manages most of the build process.
 
-1. Clone the repository.
-2. Install Node.js (>=18.12.1) and Yarn (>= v1.10.0).
+1.  Clone the repository.
+2.  Install Node.js (>=18.12.1) and Yarn (>= v1.10.0).
 
-   - On **macOS** both prerequisites can be setup using `brew`. Ensure command line developer tools (`xcode-select --install`) are also installed.
-   - On **Windows** `node` and `yarn` can be installed via Chocolatey (`choco`) package manager.
+    - On **macOS** both prerequisites can be setup using `brew`. Ensure command line developer tools (`xcode-select --install`) are also installed.
+    - On **Windows** `node` and `yarn` can be installed via Chocolatey (`choco`) package manager.
 
-3. If on VS Code you can Run Task Setup to skip steps 4 & 5. Other Tasks to run are available in the Command Pallet.
-4. Run `yarn install` within the folder you cloned. This will install all the dependencies needed for the project.
-5. Run `yarn build:development` from within the folder you cloned which will build the Toolkit.
+3.  If on VS Code you can Run Task Setup to skip steps 4 & 5. Other Tasks to run are available in the Command Pallet.
+4.  Run `yarn install` within the folder you cloned. This will install all the dependencies needed for the project.
+5.  Run `yarn build:development` from within the folder you cloned which will build the Toolkit.
 
-- Whilst developing, you may prefer to run `yarn watch` which will monitor the project
-  directory for changes and run `yarn build:development` automatically for you. If you're
-  not going to add new features and plan to work only on existing ones (i.e. your changes
-  don't require regenerating indexes) you can use `yarn watch:webpack`, this will compile
-  changes only your changes to code, without regenerating indexes which might noticeably
-  speed up the development.
+    - Whilst developing, you may prefer to run `yarn watch` which will monitor the project
+      directory for changes and run `yarn build:development` automatically for you. If you're
+      not going to add new features and plan to work only on existing ones (i.e. your changes
+      don't require regenerating indexes) you can use `yarn watch:webpack`, this will compile
+      changes only your changes to code, without regenerating indexes which might noticeably
+      speed up the development.
 
-5.  Deploying the extension:
+6.  Deploying the extension:
 
     - Chrome:
       - The built extension will be available in the `dist/extension` folder. Navigate to `chrome://extensions`

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/component.tsx
@@ -23,6 +23,7 @@ import {
   NormalizedNetIncomes,
   Incomes,
   Expenses,
+  NormalizedNetIncome,
 } from './types';
 import { YNABPayee } from 'toolkit/types/ynab/data/payee';
 import { YNABMasterCategory } from 'toolkit/types/ynab/data/master-category';
@@ -409,7 +410,10 @@ export class IncomeVsExpenseComponent extends React.Component<
     };
   }
 
-  _normalizeNetIncomes(expenses: NormalizedExpenses, incomes: NormalizedIncomes) {
+  _normalizeNetIncomes(
+    expenses: NormalizedExpenses,
+    incomes: NormalizedIncomes
+  ): NormalizedNetIncome[] {
     const expensesMonthlyTotals = expenses.monthlyTotals;
     const incomesMonthlyTotals = incomes.monthlyTotals;
 

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/component.tsx
@@ -29,6 +29,7 @@ import { YNABPayee } from 'toolkit/types/ynab/data/payee';
 import { YNABMasterCategory } from 'toolkit/types/ynab/data/master-category';
 import { YNABSubCategory } from 'toolkit/types/ynab/data/sub-category';
 import { DateWithoutTime } from 'toolkit/types/ynab/window/ynab-utilities';
+import { normalizeNetIncomes } from './normalizer';
 
 export const MONTHLY_TOTALS_KEY = '__totals';
 
@@ -414,17 +415,6 @@ export class IncomeVsExpenseComponent extends React.Component<
     expenses: NormalizedExpenses,
     incomes: NormalizedIncomes
   ): NormalizedNetIncome[] {
-    const expensesMonthlyTotals = expenses.monthlyTotals;
-    const incomesMonthlyTotals = incomes.monthlyTotals;
-
-    return incomesMonthlyTotals.map((incomeMonthData, index) => {
-      const expenseMonthData = expensesMonthlyTotals[index];
-
-      return {
-        date: incomeMonthData.date.clone(),
-        total: incomeMonthData.total + expenseMonthData.total,
-        transactions: [...incomeMonthData.transactions, ...expenseMonthData.transactions],
-      };
-    });
+    return normalizeNetIncomes(expenses, incomes);
   }
 }

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.tsx
@@ -42,8 +42,8 @@ export const MonthlySavingsRatioRow = ({
       <React.Fragment>
         {monthlyIncomes.map((incomeMonthData, index) => {
           const expenseMonthData = monthlyExpenses[index];
-          const incomeTotal = incomeMonthData.total;
-          const expenseTotal = Math.abs(expenseMonthData.total);
+          const incomeTotal = incomeMonthData?.total ?? 0;
+          const expenseTotal = Math.abs(expenseMonthData?.total ?? 0);
           let ratio = 0;
           if (incomeTotal !== 0 && incomeTotal >= expenseTotal) {
             ratio = 1 - expenseTotal / incomeTotal;

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/normalizer.test.ts
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/normalizer.test.ts
@@ -1,0 +1,156 @@
+import { DateWithoutTime } from 'toolkit/types/ynab/window/ynab-utilities';
+import { MonthlyTotals, NormalizedExpenses, NormalizedIncomes } from './types';
+import moment, { Moment } from 'moment';
+import { YNABTransaction } from 'toolkit/types/ynab/data/transaction';
+import { normalizeNetIncomes } from './normalizer';
+
+class MockDateWithoutTime implements Partial<DateWithoutTime> {
+  _date: Moment;
+
+  constructor(date: Moment) {
+    this._date = date;
+  }
+
+  clone() {
+    return new MockDateWithoutTime(moment(this._date)) as unknown as DateWithoutTime;
+  }
+
+  toUTCMoment(): Moment {
+    return this._date;
+  }
+
+  toISOString(): string {
+    return this._date.toISOString();
+  }
+
+  isBefore(date: DateWithoutTime) {
+    return this._date.isBefore(date.toUTCMoment());
+  }
+
+  isAfter(date: DateWithoutTime) {
+    return this._date.isAfter(date.toUTCMoment());
+  }
+
+  equalsByMonth(date: DateWithoutTime) {
+    return this._date.isSame(date.toUTCMoment(), 'month');
+  }
+}
+
+function generateMockMonthlyTotals(
+  startDate: Moment,
+  numMonths: number,
+  numTransactions: number,
+  negativeAmounts: boolean
+): MonthlyTotals[] {
+  const monthlyTotals: MonthlyTotals[] = [];
+  let nextDate = startDate;
+
+  for (let i = 0; i < numMonths; i++) {
+    const date = moment(nextDate);
+
+    if (i > 0) {
+      date.add(1, 'month');
+    }
+
+    const transactions: YNABTransaction[] = [];
+    let total = 0;
+
+    for (let j = 0; j < numTransactions; j++) {
+      const amount = Math.floor(Math.random() * 100) * (negativeAmounts ? -1 : 1);
+      total += amount;
+
+      const transaction = {
+        amount,
+        payeeId: `${i}-${j}`,
+      } as YNABTransaction;
+
+      transactions.push(transaction);
+    }
+
+    const ynabDate = new MockDateWithoutTime(date);
+
+    const monthlyTotal = {
+      date: ynabDate as unknown as DateWithoutTime,
+      total,
+      transactions: transactions,
+    } as MonthlyTotals;
+
+    monthlyTotals.push(monthlyTotal);
+    nextDate = date;
+  }
+
+  return monthlyTotals;
+}
+
+describe('normalizer', () => {
+  describe('normalizeNetIncomes', () => {
+    it.todo('combines incomes and expenses transactions per month');
+    it.todo('sums the totals of incomes and expenses per month');
+
+    it('handles initial months with only incomes and no expenses', () => {
+      const earlierStartDate = moment.utc('2016-06-01');
+      const laterStartDate = moment.utc('2016-08-01');
+      const totalMonths = 5;
+      const monthsFromLaterStartDate = totalMonths - 2;
+      const transactionsPerMonth = 3;
+
+      let mockExpenses: Partial<NormalizedExpenses> = {
+        monthlyTotals: generateMockMonthlyTotals(
+          laterStartDate,
+          monthsFromLaterStartDate,
+          transactionsPerMonth,
+          true
+        ),
+      };
+      let mockIncome: Partial<NormalizedIncomes> = {
+        monthlyTotals: generateMockMonthlyTotals(
+          earlierStartDate,
+          totalMonths,
+          transactionsPerMonth,
+          false
+        ),
+      };
+
+      const normalizedNetIncomes = normalizeNetIncomes(
+        mockExpenses as NormalizedExpenses,
+        mockIncome as NormalizedIncomes
+      );
+
+      expect(normalizedNetIncomes.length).toBe(totalMonths);
+      expect(normalizedNetIncomes[0].date.toUTCMoment()).toEqual(earlierStartDate);
+    });
+
+    it('handles initial months with only expenses and no incomes', () => {
+      const earlierStartDate = moment.utc('2016-06-01');
+      const laterStartDate = moment.utc('2016-08-01');
+      const totalMonths = 5;
+      const monthsFromLaterStartDate = totalMonths - 2;
+      const transactionsPerMonth = 3;
+
+      let mockExpenses: Partial<NormalizedExpenses> = {
+        monthlyTotals: generateMockMonthlyTotals(
+          earlierStartDate,
+          totalMonths,
+          transactionsPerMonth,
+          true
+        ),
+      };
+      let mockIncome: Partial<NormalizedIncomes> = {
+        monthlyTotals: generateMockMonthlyTotals(
+          laterStartDate,
+          monthsFromLaterStartDate,
+          transactionsPerMonth,
+          false
+        ),
+      };
+
+      const normalizedNetIncomes = normalizeNetIncomes(
+        mockExpenses as NormalizedExpenses,
+        mockIncome as NormalizedIncomes
+      );
+
+      expect(normalizedNetIncomes.length).toBe(totalMonths);
+      expect(normalizedNetIncomes[0].date.toUTCMoment()).toEqual(earlierStartDate);
+    });
+  });
+});

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/normalizer.ts
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/normalizer.ts
@@ -1,0 +1,19 @@
+import type { NormalizedExpenses, NormalizedIncomes, NormalizedNetIncome } from './types';
+
+export function normalizeNetIncomes(
+  expenses: NormalizedExpenses,
+  incomes: NormalizedIncomes
+): NormalizedNetIncome[] {
+  const expensesMonthlyTotals = expenses.monthlyTotals;
+  const incomesMonthlyTotals = incomes.monthlyTotals;
+
+  return incomesMonthlyTotals.map((incomeMonthData, index) => {
+    const expenseMonthData = expensesMonthlyTotals[index];
+
+    return {
+      date: incomeMonthData.date.clone(),
+      total: incomeMonthData.total + expenseMonthData.total,
+      transactions: [...incomeMonthData.transactions, ...expenseMonthData.transactions],
+    };
+  });
+}

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/normalizer.ts
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/normalizer.ts
@@ -7,13 +7,60 @@ export function normalizeNetIncomes(
   const expensesMonthlyTotals = expenses.monthlyTotals;
   const incomesMonthlyTotals = incomes.monthlyTotals;
 
-  return incomesMonthlyTotals.map((incomeMonthData, index) => {
-    const expenseMonthData = expensesMonthlyTotals[index];
+  let netIncomes: NormalizedNetIncome[] = [];
 
-    return {
-      date: incomeMonthData.date.clone(),
-      total: incomeMonthData.total + expenseMonthData.total,
-      transactions: [...incomeMonthData.transactions, ...expenseMonthData.transactions],
-    };
-  });
+  let expensesIdx = 0;
+  let incomeIdx = 0;
+
+  while (expensesIdx < expensesMonthlyTotals.length || incomeIdx < incomesMonthlyTotals.length) {
+    const expenses = expensesMonthlyTotals[expensesIdx];
+    const income = incomesMonthlyTotals[incomeIdx];
+
+    let netIncome: NormalizedNetIncome;
+
+    // There is no case for if expense and income are both null, because that should never happen.
+    // If it did, then we would not have anything to determine date from and thus we'd generate an
+    // invalid NormalizedNetIncome object
+    if (expenses == null) {
+      netIncome = {
+        date: income.date.clone(),
+        total: income.total,
+        transactions: [...income.transactions],
+      };
+      incomeIdx++;
+    } else if (income == null) {
+      netIncome = {
+        date: expenses.date.clone(),
+        total: expenses.total,
+        transactions: [...expenses.transactions],
+      };
+      expensesIdx++;
+    } else if (expenses.date.equalsByMonth(income.date)) {
+      netIncome = {
+        date: income.date.clone(),
+        total: income.total + expenses.total,
+        transactions: [...income.transactions, ...expenses.transactions],
+      };
+      expensesIdx++;
+      incomeIdx++;
+    } else if (expenses.date.isBefore(income.date)) {
+      netIncome = {
+        date: expenses.date.clone(),
+        total: expenses.total,
+        transactions: [...expenses.transactions],
+      };
+      expensesIdx++;
+    } else {
+      netIncome = {
+        date: income.date.clone(),
+        total: income.total,
+        transactions: [...income.transactions],
+      };
+      incomeIdx++;
+    }
+
+    netIncomes.push(netIncome);
+  }
+
+  return netIncomes;
 }

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/types.ts
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/types.ts
@@ -38,6 +38,12 @@ export type Expenses = {
   monthlyTotals: MonthlyTotalsMap;
 };
 
+export type NormalizedNetIncome = {
+  date: DateWithoutTime;
+  total: number;
+  transactions: YNABTransaction[];
+};
+
 export type NormalizedIncomes = ReturnType<IncomeVsExpenseComponent['_sortAndNormalizeIncomes']>;
 export type NormalizedExpenses = ReturnType<IncomeVsExpenseComponent['_sortAndNormalizeExpenses']>;
 export type NormalizedNetIncomes = ReturnType<IncomeVsExpenseComponent['_normalizeNetIncomes']>;


### PR DESCRIPTION
# Update

**The screenshots revealed that, even though this change enables the report to not crash and ensures that `normalizedNetIncomes` sync the income and expenses each month, it does not fully restore expected functionality of the report. It appears that the table for the list that has less months  does not show the columns for those months and so causes the entire table to be offset from the one that is not missing any dates.**

**In the screenshots, you can see the first 2 months don't have any expenses, only incomes. This is leading to the expenses table starting on a different month than the income table. Thus causing the whole table to be offset.**

**Probably want to hold off on merging this until a more full solution can be found.**

# Original PR Description

GitHub Issue (if applicable): #3425 

## Explanation of Bugfix/Feature/Modification
The Income vs Expenses toolkit report goes blank for some users when an uncaught error occurs inside of the `IncomeVsExpenseComponent`. I traced the root of the exception to 2 places.

1. In `MonthlySavingsRatioRow`, when attempting to access `incomeMonthData.total` and `expenseMonthData.total` when `incomeMonthData` or `expenseMonthData` was undefined for the given month
2. In `IncomeVsExpenseComponent._normalizeNetIncomes`  when, again, attempting to access the total, date, or transactions of a `NormalizedExpense` or `NormalizedIncomes` object when that object was undefined.

These objects were undefined due to edge case where some months may only have expenses or only have incomes, causing the arrays of incomes and expenses to be of different lengths, but the code assuming they would always be the same length and attempting to use the same index for both to access the same month's data.

The times in which these edge cases would occur not fully understood. But from my own personal experience, it happens when you have an account with a starting amount transaction, but then you add in transactions to months that predate that starting amount. I don't remember the exact reason I did, since for me it was for an account added to YNAB way back in 2016. But, suffice to say its possible and the multiple people reporting the same issue have probably done something similar.

To solve this I have:

1. Added fallbacks to `0` when attempting to check the totals in `MonthlySavingsRatioRow`
2. Added additional logic to `_normalizeNetIncomes` to handle these edge cases.

I have also broken out the logic of `_normalizeNetIncomes` to a standalone `normalizeNetIncomes` function in a `normalizer` module to be able to more easily write unit tests for the function without needing to render the whole component. I have also added unit test for this function, filling in tests for the edge case and laying out some `todo` tests to cover the actual core functionality. These tests can be filled in by someone at a later date.

## Screenshots

### Before

Works when specific months are selected:
![Screenshot 2024-04-23 211907](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/14079950/f54b16d2-5ea2-4fdf-b40a-8603a2fe08ba)

Selecting the furthest back month, for me that's July 2016:
![Screenshot 2024-04-23 212239](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/14079950/9b3464d7-7f14-46c8-8800-20bd52bd858a)

As soon as you click done, the whole thing goes blank:
![Screenshot 2024-04-23 212344](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/14079950/ea1c29ad-b0a9-4a3c-8a3c-ce6cad0df5a7)

Same thing happens when selecting all dates as well (no screenshot for that one.

### After

~Works~ No longer crashes for the selected range that crashed previously. (Still has offset month in expenses table though):
![Screenshot 2024-04-23 212851](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/14079950/37e8a45f-c99f-4873-a034-11623fad18e9)

~Works~ No longer crashes for all dates (Still has offset month in expenses table though):
![Screenshot 2024-04-23 215808](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/14079950/f13637e7-326c-47f4-8eed-c99a549788a0)
