### PR TITLE
Fix income vs expense

### DIFF
--- a/src/extension/features/budget/pacing/index.js
+++ b/src/extension/features/budget/pacing/index.js
@@ -8,10 +8,7 @@ import {
 } from 'toolkit/extension/utils/pacing';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 import { l10n } from 'toolkit/extension/utils/toolkit';
-import {
-  budgetRowInChangesSet,
-  getBudgetMonthDisplaySubCategory,
-} from 'toolkit/extension/features/budget/utils';
+import { getBudgetMonthDisplaySubCategory } from 'toolkit/extension/features/budget/utils';
 
 export class Pacing extends Feature {
   injectCSS() {
@@ -58,7 +55,9 @@ export class Pacing extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (budgetRowInChangesSet(changedNodes)) {
+    if (
+      changedNodes.has('budget-table-row js-budget-table-row budget-table-row-ul is-sub-category')
+    ) {
       this.debouncedInvoke();
     }
   }

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/component.tsx
@@ -11,7 +11,6 @@ import { MonthlySavingsRatioRow } from './components/monthly-savings-ratio-row';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 import { ReportContextType } from '../../common/components/report-context';
 import { YNABTransaction } from 'toolkit/types/ynab/data/transaction';
-import { Moment } from 'moment';
 import {
   MonthlyTotalsMap,
   PayeeMap,
@@ -202,12 +201,12 @@ export class IncomeVsExpenseComponent extends React.Component<
 
     const incomes: Incomes = {
       payees: {},
-      monthlyTotals: {},
+      monthlyTotals: this._createEmptyMonthMapFromFilters(),
     };
 
     const expenses: Expenses = {
       masterCategories: {},
-      monthlyTotals: {},
+      monthlyTotals: this._createEmptyMonthMapFromFilters(),
     };
 
     this.props.filteredTransactions.forEach((transaction) => {
@@ -321,12 +320,10 @@ export class IncomeVsExpenseComponent extends React.Component<
     const { fromDate, toDate } = this.props.filters!.dateFilter;
     const date = fromDate.clone();
     const dates = {
-      // TODO: is this DateWithoutTime or Moment? Or is it the same shit?
       [date.toISOString()]: createMonthlyTotalsMap(date),
     };
 
     while (!date.isAfter(toDate)) {
-      // TODO: is this DateWithoutTime or Moment? Or is it the same shit?
       dates[date.toISOString()] = createMonthlyTotalsMap(date);
       date.addMonths(1);
     }


### PR DESCRIPTION
GitHub Issue (if applicable): https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/3425

**Explanation of Bugfix/Feature/Modification:**
I missed setting correct initial value for `monthlyTotals` in my recent PR where I migrated reports to TypeScript. This was causing exception if expenses and incomes were of different length (e.g. there were no expenses in one month, only income). This is now fixed.

I also removed a couple of TODOs (which were intended to be my working notes, rather than be actually pushed 😅). This PR is based on #3437, as those PR fixes issue which polluted console too much and was making debugging a bit miserable.

A HUGE THANKS goes to @willpoorman for helping with debugging this problem and actually figuring out what causes it. 

