### PR TITLE
Fix Auto-Split Payee Not Actually Saving Bug

### DIFF
--- a/src/extension/features/accounts/split-transaction-auto-fill-payee/index.js
+++ b/src/extension/features/accounts/split-transaction-auto-fill-payee/index.js
@@ -15,6 +15,7 @@ export class SplitTransactionAutoFillPayee extends Feature {
       if (i !== 0 && !cell.dataset.tkAutoFilledPayee && !cell.value) {
         cell.dataset.tkAutoFilledPayee = true;
         cell.value = cells[0].value;
+        cell.dispatchEvent(new Event('input'));
         cell.dispatchEvent(new Event('change'));
         cell.dispatchEvent(new Event('blur'));
       }


### PR DESCRIPTION
GitHub Issue (if applicable): [#3373](https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/3373)

**Explanation of Bugfix/Feature/Modification:**
Adding a dispatchEvent for the input event appears to ensure that the auto-split payee feature gets saved. Also opting to keep the change event in case YNAB changes its implementation again.

**Screenshots**

https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/5080145/7b5ba16c-8be9-4d56-8d57-201f2c737afa

