### PR TITLE
Change how savings rate is calculated

### DIFF
--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.tsx
@@ -44,7 +44,7 @@ export const MonthlySavingsRatioRow = ({
           const expenseMonthData = monthlyExpenses[index];
           const incomeTotal = incomeMonthData?.total ?? 0;
           const expenseTotal = expenseMonthData?.total ?? 0;
-          let ratio = undefined;
+          let ratio: undefined | number = undefined;
           if (incomeTotal !== 0) {
             // Clamp ratio to range [0, 1]
             ratio = Math.min(Math.max(expenseTotal / incomeTotal + 1, 0), 1);

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.tsx
@@ -21,16 +21,25 @@ export const MonthlySavingsRatioRow = ({
     (reduced, monthData) => reduced + monthData.total,
     0
   );
-  const allMonthsExpenseTotal = Math.abs(
-    monthlyExpenses.reduce((reduced, monthData) => reduced + monthData.total, 0)
+  const allMonthsExpenseTotal = monthlyExpenses.reduce(
+    (reduced, monthData) => reduced + monthData.total,
+    0
   );
 
-  let allMonthsRatioTotal = 0;
-  if (allMonthsIncomeTotal !== 0 && allMonthsIncomeTotal >= allMonthsExpenseTotal) {
-    allMonthsRatioTotal = 1 - allMonthsExpenseTotal / allMonthsIncomeTotal;
+  let allMonthsRatioTotal: undefined | number = undefined;
+  if (allMonthsIncomeTotal !== 0) {
+    allMonthsRatioTotal = Math.min(
+      Math.max(allMonthsExpenseTotal / allMonthsIncomeTotal + 1, 0),
+      1
+    );
   }
 
-  const allMonthsSuffix = allMonthsRatioTotal < threshold ? '--negative' : '--positive';
+  const allMonthsSuffix =
+    allMonthsRatioTotal === undefined
+      ? ''
+      : allMonthsRatioTotal < threshold
+      ? '--negative'
+      : '--positive';
   const allMonthsClassName = classnames('tk-monthly-totals-row__data-cell', {
     [`tk-monthly-totals-row__data-cell${allMonthsSuffix}`]: emphasizeTotals,
   });
@@ -70,6 +79,8 @@ export const MonthlySavingsRatioRow = ({
         <div key="average" className={allMonthsClassName}>
           {titles ? (
             'Average'
+          ) : allMonthsRatioTotal === undefined ? (
+            'N/A'
           ) : (
             <Percentage pretty numbersAfterPoint={1} value={allMonthsRatioTotal} />
           )}
@@ -77,6 +88,8 @@ export const MonthlySavingsRatioRow = ({
         <div key="total" className={allMonthsClassName}>
           {titles ? (
             'Total'
+          ) : allMonthsRatioTotal === undefined ? (
+            'N/A'
           ) : (
             <Percentage pretty numbersAfterPoint={1} value={allMonthsRatioTotal} />
           )}

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/components/monthly-savings-ratio-row/component.tsx
@@ -43,13 +43,14 @@ export const MonthlySavingsRatioRow = ({
         {monthlyIncomes.map((incomeMonthData, index) => {
           const expenseMonthData = monthlyExpenses[index];
           const incomeTotal = incomeMonthData?.total ?? 0;
-          const expenseTotal = Math.abs(expenseMonthData?.total ?? 0);
-          let ratio = 0;
-          if (incomeTotal !== 0 && incomeTotal >= expenseTotal) {
-            ratio = 1 - expenseTotal / incomeTotal;
+          const expenseTotal = expenseMonthData?.total ?? 0;
+          let ratio = undefined;
+          if (incomeTotal !== 0) {
+            // Clamp ratio to range [0, 1]
+            ratio = Math.min(Math.max(expenseTotal / incomeTotal + 1, 0), 1);
           }
 
-          const suffix = ratio < threshold ? '--negative' : '--positive';
+          const suffix = ratio === undefined ? '' : ratio < threshold ? '--negative' : '--positive';
           const className = classnames('tk-monthly-totals-row__data-cell', {
             [`tk-monthly-totals-row__data-cell${suffix}`]: emphasizeTotals,
           });
@@ -58,6 +59,8 @@ export const MonthlySavingsRatioRow = ({
             <div key={incomeMonthData.date.toISOString()} className={className}>
               {titles ? (
                 localizedMonthAndYear(incomeMonthData.date, MonthStyle.Short)
+              ) : ratio === undefined ? (
+                'N/A'
               ) : (
                 <Percentage pretty numbersAfterPoint={1} value={ratio} />
               )}

--- a/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/inflow-outflow/components/legend/component.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import { Currency } from 'toolkit/extension/features/toolkit-reports/common/components/currency';
 import { Percentage } from 'toolkit/extension/features/toolkit-reports/common/components/percentage';
 import './styles.scss';
@@ -46,7 +45,7 @@ export const Legend = (props: LegendProps) => (
     >
       <div className="tk-flex tk-mg-b-05 tk-align-items-center">
         <div className="tk-inflow-outflow-legend__icon-inflow-outflows" />
-        <div className="tk-mg-l-05">Difference</div>
+        <div>Difference</div>
       </div>
       <div>
         <Currency value={props.diffs} />
@@ -56,7 +55,7 @@ export const Legend = (props: LegendProps) => (
       <div className="tk-mg-05 tk-pd-r-1">
         <div className="tk-flex tk-mg-b-05 tk-align-items-center">
           <div className="tk-inflow-outflow-legend__icon-inflow-outflows" />
-          <div className="tk-mg-l-05">Savings Ratio</div>
+          <div>Savings Ratio</div>
         </div>
         <Percentage value={props.savings} numbersAfterPoint={1} pretty />
       </div>


### PR DESCRIPTION
GitHub Issue (if applicable): #3465

**Explanation of Bugfix/Feature/Modification:**
This PR changes how savings ratio is calculated in income-vs-expense report to ensure correct work in cases when total expenses are positive. Additionally, savings ratio now clamped to range between 0% and 100% (can't exceed 100% even if total expenses are positive). For months where there is no income it now shows N/A (instead of 0% in previous versions)

**Screenshots**
![CleanShot 2024-05-29 at 11 58 13](https://github.com/toolkit-for-ynab/toolkit-for-ynab/assets/7430438/e5e0cc38-de1c-4014-b7c1-66e793177ffd)
