### PR TITLE
Fix for #3472 - Crash on toolkit report accounts selector

### DIFF
--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.tsx
@@ -46,9 +46,7 @@ export class AccountFilterComponent extends React.Component<
   get closedAccounts(): YNABAccount[] {
     const closedAccounts = this._accountsCollection.getClosedAccounts();
     return (closedAccounts as YNABAccount[]).filter((account) => {
-      if (!account.onBudget && !this.props.includeTrackingAccounts) {
-        return false;
-      }
+      return account.onBudget || this.props.includeTrackingAccounts;
     });
   }
 

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.tsx
@@ -45,8 +45,10 @@ export class AccountFilterComponent extends React.Component<
 
   get closedAccounts(): YNABAccount[] {
     const closedAccounts = this._accountsCollection.getClosedAccounts();
-    return (closedAccounts as YNABAccount[]).filter((account) => {
-      return !(!account.onBudget && !this.props.includeTrackingAccounts);
+    return (closedAccounts.toArray() as YNABAccount[]).filter((account) => {
+      if (!account.onBudget && !this.props.includeTrackingAccounts) {
+        return false;
+      }
     });
   }
 

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.tsx
@@ -26,7 +26,7 @@ export class AccountFilterComponent extends React.Component<
 
   get onBudgetAccounts(): YNABAccount[] {
     const onBudgetAccounts = this._accountsCollection.getOnBudgetAccounts();
-    return onBudgetAccounts ? onBudgetAccounts.toArray() : [];
+    return onBudgetAccounts ? onBudgetAccounts : [];
   }
 
   get offBudgetAccounts(): YNABAccount[] {
@@ -35,22 +35,18 @@ export class AccountFilterComponent extends React.Component<
     }
 
     const offBudgetAccounts = this._accountsCollection.getTrackingAccounts();
-    return offBudgetAccounts ? offBudgetAccounts.toArray() : [];
+    return offBudgetAccounts ? offBudgetAccounts : [];
   }
 
   get loanAccounts(): YNABAccount[] {
     const loanAccounts = this._accountsCollection.getLoanAccounts();
-    return loanAccounts ? loanAccounts.toArray() : [];
+    return loanAccounts ? loanAccounts : [];
   }
 
   get closedAccounts(): YNABAccount[] {
     const closedAccounts = this._accountsCollection.getClosedAccounts();
-    return (closedAccounts.toArray() as YNABAccount[]).filter((account) => {
-      if (account.onBudget === false && !this.props.includeTrackingAccounts) {
-        return false;
-      }
-
-      return true;
+    return (closedAccounts as YNABAccount[]).filter((account) => {
+      return !(!account.onBudget && !this.props.includeTrackingAccounts);
     });
   }
 

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/account-filter/component.tsx
@@ -45,7 +45,7 @@ export class AccountFilterComponent extends React.Component<
 
   get closedAccounts(): YNABAccount[] {
     const closedAccounts = this._accountsCollection.getClosedAccounts();
-    return (closedAccounts.toArray() as YNABAccount[]).filter((account) => {
+    return (closedAccounts as YNABAccount[]).filter((account) => {
       if (!account.onBudget && !this.props.includeTrackingAccounts) {
         return false;
       }


### PR DESCRIPTION
Fixes #3472 

Error in console was `onBudgetAccounts.toArray is not a function` as `onBudgetAccounts` was already an array. Removing `.toArray()` resolves the issue.
