### PR TITLE
Fix for #3466 Render total monthly goals on another changed node

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@swc/core": "^1.3.103",
     "@types/archiver": "^5.3.1",
     "@types/chrome": "^0.0.202",
+    "@types/debounce": "^1.2.4",
     "@types/ember": "^4.0.3",
     "@types/jest": "^29.5.12",
     "@types/jquery": "^3.5.14",

--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -218,7 +218,7 @@ export class DisplayTotalMonthlyGoals extends Feature {
       return;
     }
 
-    if (changedNodes.has('budget-inspector-button')) {
+    if (changedNodes.has('to-be-budgeted-amount')) {
       this.addMonthlyGoalsOverview();
     }
   }

--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -1,3 +1,4 @@
+import debounce from 'debounce';
 import React from 'react';
 import { Feature } from 'toolkit/extension/features/feature';
 import { componentBefore } from 'toolkit/extension/utils/react';
@@ -209,17 +210,13 @@ export class DisplayTotalMonthlyGoals extends Feature {
     );
   }
 
-  invoke() {
-    return null;
-  }
+  debouncedInvoke = debounce(this.addMonthlyGoalsOverview, 100);
 
   observe(changedNodes) {
-    if (!this.shouldInvoke()) {
-      return;
-    }
+    if (!this.shouldInvoke()) return;
 
-    if (changedNodes.has('to-be-budgeted-amount')) {
-      this.addMonthlyGoalsOverview();
+    if (changedNodes.has('budget-inspector-button')) {
+      this.debouncedInvoke();
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,6 +1864,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/debounce@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.4.tgz#cb7e85d9ad5ababfac2f27183e8ac8b576b2abb3"
+  integrity sha512-jBqiORIzKDOToaF63Fm//haOCHuwQuLa2202RK4MozpA6lh93eCBc+/8+wZn5OzjJt3ySdc+74SXWXB55Ewtyw==
+
 "@types/debug@^4.0.0":
   version "4.1.7"
   resolved "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz"


### PR DESCRIPTION
Fixes #3466

The total monthly goals card was rendered on the changed node of `budget-inspector-button`, when switching months, this node re-rendered 3 times, causing our total monthly goals card to render 3 times as well.

This happens quick, so our guard against re-rendering the card multiple times doesn't trigger.

The proposed fix is to render the goals card on a node that's only rendered once upon changing months within the budget page.