### PR TITLE
Remove check for current month

### DIFF
--- a/src/extension/features/budget/fund-half/index.ts
+++ b/src/extension/features/budget/fund-half/index.ts
@@ -49,7 +49,7 @@ export class FundHalf extends Feature {
   }
 
   updateDOM() {
-    if (!isCurrentMonthSelected()) return;
+    // if (!isCurrentMonthSelected()) return;
     if (!$('.budget-inspector').length) return;
     if (!$('.inspector-quick-budget').length) return;
     if ($('.budget-inspector-button.fund-half').length) return;


### PR DESCRIPTION
GitHub Issue (if applicable): #3467

**Explanation of Bugfix/Feature/Modification:**
There is a check that only allows the Fund Half functionality to happen in the current month.  By commenting out that line, Fund Half is usable in any month.


