### PR TITLE
feat(RowSplitMonths): Create "Visually separate transactions between months" feature

### DIFF
--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -403,6 +403,10 @@ Change the default credit card payment value to use the Cleared Balance instead 
 
 <details><summary>Reports (Click to Expand/Collapse)</summary>
 
+## Visually separate transactions between months
+
+Add a thick line in the transactions table after the last transactions of a month to visually separate from the next month.
+
 ## Compact Income vs. Expense
 
 Modifies styling of the Income vs. Expense report so it doesn't use too much white space on the page.

--- a/src/extension/features/accounts/row-split-months/index.css
+++ b/src/extension/features/accounts/row-split-months/index.css
@@ -1,0 +1,3 @@
+.tk-rsm-last {
+  border-bottom-width: 0.5rem;
+}

--- a/src/extension/features/accounts/row-split-months/index.js
+++ b/src/extension/features/accounts/row-split-months/index.js
@@ -1,0 +1,52 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isCurrentRouteAccountsPage, getRegisterGridService } from 'toolkit/extension/utils/ynab';
+
+export class RowSplitMonths extends Feature {
+  shouldInvoke() {
+    return isCurrentRouteAccountsPage();
+  }
+
+  injectCSS() {
+    let css = require('./index.css');
+    return css;
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (changedNodes.has('ynab-grid-body')) {
+      this.invoke();
+    }
+  }
+
+  invoke() {
+    const allRows = $('.ynab-grid-body-row');
+
+    allRows.each((ix, element) => {
+      const nextRow = allRows.eq(ix + 1)?.[0];
+
+      if (!nextRow) {
+        return;
+      }
+
+      const transaction = getRegisterGridService().visibleTransactionDisplayItems.find(
+        ({ entityId }) => {
+          return entityId === element.dataset.rowId;
+        }
+      );
+      const nextTransaction = getRegisterGridService().visibleTransactionDisplayItems.find(
+        ({ entityId }) => {
+          return entityId === nextRow.dataset.rowId;
+        }
+      );
+
+      if (!transaction || !nextTransaction) {
+        return;
+      }
+
+      if (transaction.month !== nextTransaction.month) {
+        element.classList.add('tk-rsm-last');
+      }
+    });
+  }
+}

--- a/src/extension/features/accounts/row-split-months/settings.js
+++ b/src/extension/features/accounts/row-split-months/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'RowSplitMonths',
+  type: 'checkbox',
+  default: false,
+  section: 'accounts',
+  title: 'Visually separate transactions between months',
+  description:
+    'Add a thick line in the transactions table after the last transactions of a month to visually separate from the next month.',
+};


### PR DESCRIPTION
GitHub Issue: https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues/2667

**Explanation of Bugfix/Feature/Modification:**

Created a new feature:

- Name: `RowSplitMonths`
- Title: Visually separate transactions between months
- Type: checkbox
- Description: Add a thick line in the transactions table after the last transactions of a month to visually separate from the next month.


**Screenshots**

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/e2a49293-4cc0-4f77-b746-20c1229b41b9">
