### PR TITLE
Fix CSS var name for callouts

### DIFF
--- a/src/extension/features/budget/check-credit-balances/index.css
+++ b/src/extension/features/budget/check-credit-balances/index.css
@@ -21,8 +21,8 @@
 }
 
 span.cc-budget-mismatch {
-  border: 1px solid var(--calloutSectionWarningAccent);
-  color: var(--calloutSectionWarningAccent);
+  border: 1px solid var(--calloutWarningAccent);
+  color: var(--calloutWarningAccent);
   border-radius: 0.5em;
   margin-left: 0.25em;
   padding: 0 0.25em;

--- a/src/extension/features/budget/to-be-budgeted-warning/index.css
+++ b/src/extension/features/budget/to-be-budgeted-warning/index.css
@@ -12,10 +12,8 @@
 }
 
 body {
-  --budget_balance_warning_background: var(--calloutSectionWarningProminentBackground);
-  --banner_warning_button_background: var(--calloutSectionWarningButtonBackground);
-  --banner_warning_button_background_active: var(
-    --calloutSectionWarningProminentBackgroundEmphasis
-  );
-  --banner_warning_button_label: var(--calloutSectionWarningButtonForeground);
+  --budget_balance_warning_background: var(--calloutWarningProminentBackground);
+  --banner_warning_button_background: var(--calloutWarningButtonBackground);
+  --banner_warning_button_background_active: var(--calloutWarningProminentBackgroundEmphasis);
+  --banner_warning_button_label: var(--calloutWarningButtonForeground);
 }

--- a/src/extension/features/general/customize-colour-scheme/index.scss
+++ b/src/extension/features/general/customize-colour-scheme/index.scss
@@ -29,19 +29,17 @@ body {
   */
 
     /* Negative */
-    --calloutSectionNegativeAccent: var(--tk-custom-colours-negative-l100c100) !important;
-    --calloutSectionNegativeButtonBackground: var(--tk-custom-colours-negative-l100c100) !important;
-    --calloutSectionNegativeButtonBackgroundActive: var(
-      --tk-custom-colours-negative-l075c080
-    ) !important;
-    --calloutSectionNegativeButtonForeground: var(--tk-custom-colours-negative-l215c010) !important;
-    --calloutSectionNegativeLabel: var(--tk-custom-colours-negative-l025c035) !important;
-    --calloutSectionNegativeStrongBackground: var(--tk-custom-colours-negative-l175c040) !important;
-    --calloutSectionNegativeStrongBackgroundEmphasis: var(
+    --calloutNegativeAccent: var(--tk-custom-colours-negative-l100c100) !important;
+    --calloutNegativeButtonBackground: var(--tk-custom-colours-negative-l100c100) !important;
+    --calloutNegativeButtonBackgroundActive: var(--tk-custom-colours-negative-l075c080) !important;
+    --calloutNegativeButtonForeground: var(--tk-custom-colours-negative-l215c010) !important;
+    --calloutNegativeLabel: var(--tk-custom-colours-negative-l025c035) !important;
+    --calloutNegativeProminentBackground: var(--tk-custom-colours-negative-l175c040) !important;
+    --calloutNegativeProminentBackgroundEmphasis: var(
       --tk-custom-colours-negative-l150c070
     ) !important;
-    --calloutSectionNegativeSubtleBackground: var(--tk-custom-colours-negative-l215c010) !important;
-    --calloutSectionNegativeSubtleBackgroundEmphasis: var(
+    --calloutNegativeSubtleBackground: var(--tk-custom-colours-negative-l215c010) !important;
+    --calloutNegativeSubtleBackgroundEmphasis: var(
       --tk-custom-colours-negative-l175c040
     ) !important;
     --categoryBalanceAlternateNegativeBackground: var(
@@ -62,19 +60,17 @@ body {
     --statusNegative: var(--tk-custom-colours-negative-l100c100) !important;
 
     /* Positive */
-    --calloutSectionPositiveAccent: var(--tk-custom-colours-positive-l100c100) !important;
-    --calloutSectionPositiveButtonBackground: var(--tk-custom-colours-positive-l075c080) !important;
-    --calloutSectionPositiveButtonBackgroundActive: var(
-      --tk-custom-colours-positive-l050c060
-    ) !important;
-    --calloutSectionPositiveButtonForeground: var(--tk-custom-colours-positive-l140c010) !important;
-    --calloutSectionPositiveLabel: var(--tk-custom-colours-positive-l025c030) !important;
-    --calloutSectionPositiveStrongBackground: var(--tk-custom-colours-positive-l125c055) !important;
-    --calloutSectionPositiveStrongbackgroundEmphasis: var(
+    --calloutPositiveAccent: var(--tk-custom-colours-positive-l100c100) !important;
+    --calloutPositiveButtonBackground: var(--tk-custom-colours-positive-l075c080) !important;
+    --calloutPositiveButtonBackgroundActive: var(--tk-custom-colours-positive-l050c060) !important;
+    --calloutPositiveButtonForeground: var(--tk-custom-colours-positive-l140c010) !important;
+    --calloutPositiveLabel: var(--tk-custom-colours-positive-l025c030) !important;
+    --calloutPositiveProminentBackground: var(--tk-custom-colours-positive-l125c055) !important;
+    --calloutPositiveProminentbackgroundEmphasis: var(
       --tk-custom-colours-positive-l115c100
     ) !important;
-    --calloutSectionPositiveSubtleBackground: var(--tk-custom-colours-positive-l140c010) !important;
-    --calloutSectionPositiveSubtleBackgroundEmphasis: var(
+    --calloutPositiveSubtleBackground: var(--tk-custom-colours-positive-l140c010) !important;
+    --calloutPositiveSubtleBackgroundEmphasis: var(
       --tk-custom-colours-positive-l125c055
     ) !important;
     --categoryBalancePositiveBackground: var(--tk-custom-colours-positive-l125c055) !important;
@@ -88,25 +84,17 @@ body {
     --statusPositive: var(--tk-custom-colours-positive-l100c100) !important;
 
     /* Warning */
-    --calloutSectionWarningAccent: var(--tk-custom-colours-warning-l190c165) !important;
-    --calloutSectionWarningButtonBackground: var(--tk-custom-colours-warning-l220c175) !important;
-    --calloutSectionWarningButtonForeground: var(--tk-custom-colours-warning-l050c055) !important;
-    --calloutSectionWarningProminentBackground: var(
-      --tk-custom-colours-warning-l240c100
-    ) !important;
-    --calloutSectionWarningProminentBackgroundEmphasis: var(
+    --calloutWarningAccent: var(--tk-custom-colours-warning-l190c165) !important;
+    --calloutWarningButtonBackground: var(--tk-custom-colours-warning-l220c175) !important;
+    --calloutWarningButtonForeground: var(--tk-custom-colours-warning-l050c055) !important;
+    --calloutWarningProminentBackground: var(--tk-custom-colours-warning-l240c100) !important;
+    --calloutWarningProminentBackgroundEmphasis: var(
       --tk-custom-colours-warning-l190c165
     ) !important;
-    --calloutSectionWarningProminentBackgroundLabel: var(
-      --tk-custom-colours-warning-l050c055
-    ) !important;
-    --calloutSectionWarningSubtleBackground: var(--tk-custom-colours-warning-l260c015) !important;
-    --calloutSectionWarningSubtleBackgroundEmphasis: var(
-      --tk-custom-colours-warning-l240c100
-    ) !important;
-    --calloutSectionWarningSubtleBackgroundLabel: var(
-      --tk-custom-colours-warning-l050c055
-    ) !important;
+    --calloutWarningProminentBackgroundLabel: var(--tk-custom-colours-warning-l050c055) !important;
+    --calloutWarningSubtleBackground: var(--tk-custom-colours-warning-l260c015) !important;
+    --calloutWarningSubtleBackgroundEmphasis: var(--tk-custom-colours-warning-l240c100) !important;
+    --calloutWarningSubtleBackgroundLabel: var(--tk-custom-colours-warning-l050c055) !important;
     --categoryBalanceAlternateWarningBackground: var(
       --tk-custom-colours-warning-l220c175
     ) !important;

--- a/src/extension/features/general/customize-colour-scheme/themer.html
+++ b/src/extension/features/general/customize-colour-scheme/themer.html
@@ -192,15 +192,15 @@ SOFTWARE.
     <p>
       <label for="rulesIn">Rules in: </label><br />
       <textarea id="rulesIn" autocomplete="off">
-        --calloutSectionNegativeAccent: #c72c1e;
-        --calloutSectionNegativeButtonBackground: #c72c1e;
-        --calloutSectionNegativeButtonBackgroundActive: #962116;
-        --calloutSectionNegativeButtonForeground: #feedeb;
-        --calloutSectionNegativeLabel: #3c0d09;
-        --calloutSectionNegativeStrongBackground: #faada5;
-        --calloutSectionNegativeStrongBackgroundEmphasis: #f77f73;
-        --calloutSectionNegativeSubtleBackground: #feedeb;
-        --calloutSectionNegativeSubtleBackgroundEmphasis: #faada5;
+        --calloutNegativeAccent: #c72c1e;
+        --calloutNegativeButtonBackground: #c72c1e;
+        --calloutNegativeButtonBackgroundActive: #962116;
+        --calloutNegativeButtonForeground: #feedeb;
+        --calloutNegativeLabel: #3c0d09;
+        --calloutNegativeProminentBackground: #faada5;
+        --calloutNegativeProminentBackgroundEmphasis: #f77f73;
+        --calloutNegativeSubtleBackground: #feedeb;
+        --calloutNegativeSubtleBackgroundEmphasis: #faada5;
         --categoryBalanceAlternateNegativeBackground: #c72c1e;
         --categoryBalanceAlternateNegativeBackgroundActive: #962116;
         --categoryBalanceAlternateNegativeLabel: #feedeb;


### PR DESCRIPTION
GitHub Issue (if applicable): #3496 (also a dupe, #3503)

**Explanation of Bugfix/Feature/Modification:**
It looks like YNAB renamed some CSS vars for callout by removing the `Section` prefix and renaming "Strong" to "Prominent".

I have found 3 features using the renamed vars:
- Paid in Full Credit Card Assist
- Emphasize Available to Assign
- Modify Currency Colors

CSS vars renamed:
- `--calloutSection*` to `--callout*`
- `--calloutNegativeStrong*` to `--calloutNegativeProminent*`
- `--calloutPositiveStrong*` to `--calloutPositiveProminent*`

**Screenshots**
![image](https://github.com/user-attachments/assets/08d1bdbd-c7b2-48ee-9584-191068270f58)

![image](https://github.com/user-attachments/assets/dee86bc5-9084-46e9-905f-c4e12ba50012)

