### PR TITLE
Fix hiding of help button

### DIFF
--- a/src/extension/features/general/hide-help/index.css
+++ b/src/extension/features/general/hide-help/index.css
@@ -1,4 +1,4 @@
-body.toolkit-hide-help .self-service {
+body.toolkit-hide-help .chat-widget {
   display: none !important;
 }
 


### PR DESCRIPTION
Fixes #3533

GitHub Issue (if applicable): #3533

The blue help button changed its class name from `self-service` to `chat-widget`