### PR TITLE
Update compact-income-vs-expense

### DIFF
--- a/src/extension/features/reports/compact-income-vs-expense/index.css
+++ b/src/extension/features/reports/compact-income-vs-expense/index.css
@@ -14,3 +14,7 @@
 .income-expense-level2 .income-expense-column:first-child {
   font-weight: 500;
 }
+
+.income-expense-table {
+  min-width: 100%;
+}


### PR DESCRIPTION
Change min-width from current dynamic value to 100% to show more columns on a single page.  This allows up to 12 months to appears in a single view.

GitHub Issue (if applicable): #XXX

**Explanation of Bugfix/Feature/Modification:**
Change min-width from current dynamic value to 100% to show more columns on a single page.  This allows up to 12 months to appears in a single view.


