### PR TITLE
add inflows, which are not in ready to assign category, to the outflo…

### DIFF
--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
@@ -55,7 +55,7 @@ export const OutflowOverTimeComponent = ({
         )
       )
     );
-  }, [allReportableTransactions, filters, cumulativeSum]);
+  }, [allReportableTransactions, filters, cumulativeSum, includeInflows]);
 
   return (
     <div className="tk-flex tk-flex-column tk-flex-grow">

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
@@ -26,6 +26,12 @@ export const OutflowOverTimeComponent = ({
     true
   );
 
+  // Using IncludeInflows will include inflows which are not in category 'Inflow: Ready to Assign').
+  const [includeInflows, setIncludeInflows] = useLocalStorage(
+    'outflow-over-time-includeInflows',
+    true
+  );
+
   useEffect(() => {
     if (!filters) return;
     const filterOutAccounts = filters.accountFilterIds;
@@ -42,6 +48,7 @@ export const OutflowOverTimeComponent = ({
           groupTransactions(
             filterTransactions(
               filterTransactionsByDate(allReportableTransactions, fromDate, toDate),
+              includeInflows,
               filterOutAccounts
             )
           )
@@ -54,10 +61,16 @@ export const OutflowOverTimeComponent = ({
     <div className="tk-flex tk-flex-column tk-flex-grow">
       <AdditionalReportSettings>
         <LabeledCheckbox
-          id="tk-balance-over-time-stepgraph-option"
+          id="tk-outflow-over-time-cumulative-sum-option"
           checked={cumulativeSum}
           label="Cumulative sum"
           onChange={() => setCumulativeSum(!cumulativeSum)}
+        />
+        <LabeledCheckbox
+          id="tk-outflow-over-time-include-inflows-option"
+          checked={includeInflows}
+          label="Include inflows which are not in category 'Inflow: Ready to Assign')"
+          onChange={() => setIncludeInflows(!includeInflows)}
         />
       </AdditionalReportSettings>
       <OutflowGraph series={outflowSeries} />

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
@@ -69,7 +69,7 @@ export const OutflowOverTimeComponent = ({
         <LabeledCheckbox
           id="tk-outflow-over-time-include-inflows-option"
           checked={includeInflows}
-          label="Include inflows which are not in category 'Inflow: Ready to Assign')"
+          label="Include inflows which are not in category 'Inflow: Ready to Assign'"
           onChange={() => setIncludeInflows(!includeInflows)}
         />
       </AdditionalReportSettings>

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
@@ -10,7 +10,7 @@ declare module 'moment' {
 
 export function filterTransactions(
   transactions: YNABTransaction[],
-  includeInflow: boolean,
+  includeInflows: boolean,
   filterOutAccounts: ReadonlySet<string>
 ) {
   return transactions
@@ -21,7 +21,7 @@ export function filterTransactions(
         (transaction.inflow === undefined || transaction.inflow === 0);
 
       const isInflow =
-        includeInflow &&
+        includeInflows &&
         transaction.inflow !== undefined &&
         transaction.inflow > 0 &&
         transaction.subCategoryNameWrapped !== 'Inflow: Ready to Assign';

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
@@ -10,22 +10,30 @@ declare module 'moment' {
 
 export function filterTransactions(
   transactions: YNABTransaction[],
+  includeInflow: boolean,
   filterOutAccounts: ReadonlySet<string>
 ) {
   return transactions
     .filter((transaction) => {
-      return (
+      const isOutflow =
         transaction.outflow !== undefined &&
         transaction.outflow !== 0 &&
-        (transaction.inflow === undefined || transaction.inflow === 0)
-      );
+        (transaction.inflow === undefined || transaction.inflow === 0);
+
+      const isInflow =
+        includeInflow &&
+        transaction.inflow !== undefined &&
+        transaction.inflow > 0 &&
+        transaction.subCategoryNameWrapped !== 'Inflow: Ready to Assign';
+
+      return isOutflow || isInflow;
     })
-    .filter((transactionsWithoutInflow) => {
-      if (transactionsWithoutInflow.transferAccountId) {
+    .filter((transactions) => {
+      if (transactions.transferAccountId) {
         // discard unless it transfers outside the selected account list
-        return filterOutAccounts.has(transactionsWithoutInflow.transferAccountId);
+        return filterOutAccounts.has(transactions.transferAccountId);
       }
-      return !filterOutAccounts.has(transactionsWithoutInflow.accountId);
+      return !filterOutAccounts.has(transactions.accountId);
     });
 }
 
@@ -68,28 +76,39 @@ interface OutflowData {
 
 export function calculateOutflowPerDate(transactions: GroupedTransactions) {
   return mapValues(transactions, (monthData) =>
-    mapValues(
-      monthData,
-      (dateData): OutflowData => ({
+    mapValues(monthData, (dateData): OutflowData => {
+      const netOutflow = dateData.reduce((sum, tx) => {
+        const outflow = tx.outflow ?? 0;
+        const inflow = tx.inflow ?? 0;
+        return sum + outflow - inflow;
+      }, 0);
+
+      return {
         transactions: dateData,
-        value: dateData.reduce((s, a) => s + a.outflow!, 0),
-      })
-    )
+        value: netOutflow,
+      };
+    })
   );
 }
 
 export function calculateCumulativeOutflowPerDate(transactions: GroupedTransactions) {
-  return mapValues(calculateOutflowPerDate(transactions), (monthData) => {
-    const cumulativeSum = Object.entries(monthData).reduce((acc, [key, n]) => {
-      acc.push([
-        key,
-        {
-          ...n,
-          value: (acc.length > 0 ? acc[acc.length - 1][1].value : 0) + n.value,
-        },
-      ]);
-      return acc;
-    }, [] as [keyof typeof monthData, OutflowData][]);
+  const netOutflowByDate = calculateOutflowPerDate(transactions);
+
+  return mapValues(netOutflowByDate, (monthData) => {
+    const cumulativeSum = Object.entries(monthData)
+      .sort(([dateA], [dateB]) => parseInt(dateA) - parseInt(dateB))
+      .reduce((acc, [dayKey, outflowData]) => {
+        const previousValue = acc.length > 0 ? acc[acc.length - 1][1].value : 0;
+        const newValue = previousValue + outflowData.value;
+        acc.push([
+          dayKey,
+          {
+            ...outflowData,
+            value: newValue,
+          },
+        ]);
+        return acc;
+      }, [] as [string, OutflowData][]);
     return Object.fromEntries(cumulativeSum);
   });
 }


### PR DESCRIPTION
…w over time page

GitHub Issue (if applicable): #XXX

**Explanation of Bugfix/Feature/Modification:**
On the outflow over time page, I added a checkbox to include inflows from categories other than "Inflow: Ready to Assign". For me this feature is really helpful since Amazon return shipments, short-term loans for friends, and gifts for which I receive the money later, impact my outflow. But without my feature reimbursements are never counted.

**Screenshots**

https://github.com/user-attachments/assets/e9e8e17d-153b-456b-bb77-40f8547dd549



