### PR TITLE
fix: remove 'toolkit ember hooks'

### DIFF
--- a/src/extension/features/accounts/auto-distribute-splits/index.js
+++ b/src/extension/features/accounts/auto-distribute-splits/index.js
@@ -14,7 +14,7 @@ export class AutoDistributeSplits extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('register/grid-actions', 'didRender', this.injectDistributeButton);
+    // this.addToolkitEmberHook('register/grid-actions', 'didRender', this.injectDistributeButton);
   }
 
   injectDistributeButton(element) {

--- a/src/extension/features/accounts/auto-distribute-splits/settings.js
+++ b/src/extension/features/accounts/auto-distribute-splits/settings.js
@@ -6,4 +6,5 @@ module.exports = {
   title: 'Add "Auto Distribute" Button To Split Transactions',
   description:
     'Distributes the remaining total of a split transaction proportionally to all other splits which contain an amount.',
+  hidden: true,
 };

--- a/src/extension/features/accounts/spare-change/index.js
+++ b/src/extension/features/accounts/spare-change/index.js
@@ -1,9 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { isCurrentRouteAccountsPage, ynabRequire } from 'toolkit/extension/utils/ynab';
+import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
 import { containerLookup } from 'toolkit/extension/utils/ember';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
-
-const { once } = ynabRequire('@ember/runloop');
 
 export class SpareChange extends Feature {
   injectCSS() {
@@ -27,7 +25,7 @@ export class SpareChange extends Feature {
 
   calculateSpareChange() {
     // Running this code straight away in the callback seems to break some YNAB features - schedule it to run later
-    once(this, () => {
+    setTimeout(() => {
       const areChecked = containerLookup('service:accounts').areChecked;
       if (!areChecked.length) {
         $('#tk-spare-change').remove();
@@ -70,6 +68,6 @@ export class SpareChange extends Feature {
             .append($('<div>', { class: 'accounts-header-label', text: 'Spare Change' }))
         );
       }
-    });
+    }, 0);
   }
 }

--- a/src/extension/features/accounts/spare-change/settings.js
+++ b/src/extension/features/accounts/spare-change/settings.js
@@ -6,4 +6,5 @@ module.exports = {
   title: 'Spare Change',
   description:
     'Shows the total of "spare change" you would accumulate for the set of selected if you were to pay in whole dollars.',
+  hidden: true,
 };

--- a/src/extension/features/accounts/split-transaction-tab-expand/index.js
+++ b/src/extension/features/accounts/split-transaction-tab-expand/index.js
@@ -6,7 +6,7 @@ export class SplitTransactionTabExpand extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('register/grid-split', 'didRender', this.addEventListeners);
+    // this.addToolkitEmberHook('register/grid-split', 'didRender', this.addEventListeners);
   }
 
   addEventListeners() {

--- a/src/extension/features/accounts/striped-rows/index.js
+++ b/src/extension/features/accounts/striped-rows/index.js
@@ -19,8 +19,8 @@ export class AccountsStripedRows extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('register/grid-row', 'didRender', this.setTimeout);
-    this.addToolkitEmberHook('register/grid-sub', 'didRender', this.setTimeout);
+    // this.addToolkitEmberHook('register/grid-row', 'didRender', this.setTimeout);
+    // this.addToolkitEmberHook('register/grid-sub', 'didRender', this.setTimeout);
   }
 
   destroy() {

--- a/src/extension/features/accounts/striped-rows/settings.js
+++ b/src/extension/features/accounts/striped-rows/settings.js
@@ -7,6 +7,7 @@ module.exports = [
     title: 'Striped Transaction Rows',
     description:
       'Alternate backgrounds on every other transaction row. Set your own background color or use the default below.',
+    hidden: true,
   },
   {
     name: 'AccountsStripedRowsColor',
@@ -16,6 +17,7 @@ module.exports = [
     title: 'Striped Transaction Rows - Default/Classic Theme Color',
     description:
       'The color which will be used for the Default and Classic YNAB Themes. The default is #fafafa.',
+    hidden: true,
   },
   {
     name: 'AccountsStripedRowsDarkColor',
@@ -24,5 +26,6 @@ module.exports = [
     section: 'accounts',
     title: 'Striped Transaction Rows - Dark Theme Color',
     description: 'The color which will be used for the Dark YNAB Theme. The default is #1e1e1f.',
+    hidden: true,
   },
 ];

--- a/src/extension/features/budget/stealing-from-future/index.js
+++ b/src/extension/features/budget/stealing-from-future/index.js
@@ -12,7 +12,7 @@ export class StealingFromFuture extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('budget-header', 'didRender', this.updateReadyToAssign);
+    // this.addToolkitEmberHook('budget-header', 'didRender', this.updateReadyToAssign);
   }
 
   destroy() {

--- a/src/extension/features/budget/stealing-from-future/settings.js
+++ b/src/extension/features/budget/stealing-from-future/settings.js
@@ -5,4 +5,5 @@ module.exports = {
   section: 'budget',
   title: 'Stealing From Future Warning',
   description: `Adds a red button next to "Ready to Assign" when you've gone negative at some point in you budget's future.`,
+  hidden: true,
 };

--- a/src/extension/features/budget/target-balance-warning/index.js
+++ b/src/extension/features/budget/target-balance-warning/index.js
@@ -8,7 +8,7 @@ export class TargetBalanceWarning extends Feature {
   }
 
   invoke() {
-    this.addToolkitEmberHook('budget-table-row', 'didRender', this.modifyBudgetRow);
+    // this.addToolkitEmberHook('budget-table-row', 'didRender', this.modifyBudgetRow);
   }
 
   observe(changedNodes) {

--- a/src/extension/features/budget/target-balance-warning/settings.js
+++ b/src/extension/features/budget/target-balance-warning/settings.js
@@ -6,4 +6,5 @@ module.exports = {
   title: 'Emphasize Unmet Target Balances',
   description:
     'Add warning emphasis to categories with Target Balances that have not yet been met.',
+  hidden: true,
 };

--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -1,7 +1,4 @@
 import { withToolkitError } from 'toolkit/core/common/errors/with-toolkit-error';
-import { ynabRequire } from '../utils/ynab';
-
-const { later } = ynabRequire('@ember/runloop');
 
 const IGNORE_UPDATES = new Set([
   // every time you hover a budget row, one of these nodes change which is _just a lot_.
@@ -123,7 +120,7 @@ export class ObserveListener {
     this.features.forEach((feature) => {
       const observe = feature.observe.bind(feature, this.changedNodes);
       const wrapped = withToolkitError(observe, feature);
-      later(() => {
+      setTimeout(() => {
         const startFeatureObserve = Date.now();
 
         wrapped();

--- a/src/extension/listeners/routeChangeListener.js
+++ b/src/extension/listeners/routeChangeListener.js
@@ -1,8 +1,5 @@
 import { withToolkitError } from 'toolkit/core/common/errors/with-toolkit-error';
 import { getRouter } from 'toolkit/extension/utils/ember';
-import { ynabRequire } from '../utils/ynab';
-
-const { later, scheduleOnce } = ynabRequire('@ember/runloop');
 
 export class RouteChangeListener {
   constructor() {
@@ -14,7 +11,7 @@ export class RouteChangeListener {
       routeChangeListener.features.forEach((feature) => {
         const observe = feature.onRouteChanged.bind(feature, currentRoute);
         const wrapped = withToolkitError(observe, feature);
-        later(wrapped, 0);
+        setTimeout(wrapped, 0);
       });
     }
 
@@ -23,17 +20,17 @@ export class RouteChangeListener {
       routeChangeListener.features.forEach((feature) => {
         const observe = feature.onBudgetChanged.bind(feature, currentRoute);
         const wrapped = withToolkitError(observe, feature);
-        later(wrapped, 0);
+        setTimeout(wrapped, 0);
       });
     }
 
     getRouter().addObserver('currentState', ({ location, targetState: { routerJsState } }) => {
       if (routerJsState && routerJsState.params && routerJsState.params.index) {
         if (location.location.href.includes(routerJsState.params.index.budgetVersionId)) {
-          scheduleOnce('afterRender', null, emitSameBudgetRouteChange);
+          setTimeout(emitSameBudgetRouteChange, 0);
         } else {
-          scheduleOnce('afterRender', null, emitBudgetRouteChange);
-          scheduleOnce('afterRender', null, emitSameBudgetRouteChange);
+          setTimeout(emitBudgetRouteChange, 0);
+          setTimeout(emitSameBudgetRouteChange, 0);
         }
       }
     });

--- a/src/extension/utils/ember.ts
+++ b/src/extension/utils/ember.ts
@@ -1,13 +1,7 @@
 import type { YNABRouter } from 'toolkit/types/ynab/controllers/YNABRouter';
-import type { Ember as EmberInstance } from 'toolkit/types/ynab/ember';
-import type {
-  EmberView,
-  EmberViewRegistry,
-  RenderTreeNode,
-} from 'toolkit/types/ynab/ember/ember-view';
+import type { EmberView, EmberViewRegistry } from 'toolkit/types/ynab/ember/ember-view';
 
-export const Ember = window.requireModule<{ default: EmberInstance }>('ember').default;
-export const __ynabapp__ = Ember.Namespace.NAMESPACES[0];
+export const __ynabapp__ = YNAB.NAMESPACES[0];
 
 const viewCache = new Map();
 

--- a/src/extension/utils/toolkit.ts
+++ b/src/extension/utils/toolkit.ts
@@ -1,12 +1,4 @@
-import {
-  EMBER_COMPONENT_TOOLKIT_HOOKS,
-  emberComponentToolkitHookKey,
-  SupportedEmberHook,
-} from 'toolkit/extension/ynab-toolkit';
-import { factoryLookup } from 'toolkit/extension/utils/ember';
 import type { YNABAccountType } from 'toolkit/types/ynab/window/ynab-enums';
-import { Feature } from '../features/feature';
-import type { EmberComponent } from 'toolkit/types/ynab/ember';
 
 const MONTHS_SHORT = [
   'Jan',
@@ -105,50 +97,5 @@ export function l10nAccountType(accountType: YNABAccountType) {
       return l10n('OtherAsset', 'Asset (e.g. Investment)');
     case ynab.enums.AccountType.OtherLiability:
       return l10n('OtherLiability', 'Liability (e.g. Mortgage)');
-  }
-}
-
-export function addToolkitEmberHook(
-  context: Feature,
-  componentKey: string,
-  lifecycleHook: SupportedEmberHook,
-  fn: (element: HTMLElement) => void,
-  guard?: (element: HTMLElement) => boolean
-) {
-  const componentPrototype = factoryLookup<EmberComponent>(componentKey)?.class?.prototype;
-  if (!componentPrototype) {
-    return;
-  }
-
-  if (!EMBER_COMPONENT_TOOLKIT_HOOKS.includes(lifecycleHook)) {
-    return;
-  }
-
-  let hooks = componentPrototype[emberComponentToolkitHookKey(lifecycleHook)];
-  if (!hooks) {
-    hooks = [{ context, fn, guard }];
-    componentPrototype[emberComponentToolkitHookKey(lifecycleHook)] = hooks;
-  } else if (hooks && !hooks.some(({ fn: fnExists }) => fn === fnExists)) {
-    hooks.push({ context, fn, guard });
-  }
-
-  ynabToolKit.hookedComponents.add(componentKey);
-}
-
-export function removeToolkitEmberHook(
-  componentKey: string,
-  lifecycleHook: SupportedEmberHook,
-  fn: (element: HTMLElement) => void
-) {
-  const componentPrototype = factoryLookup<EmberComponent>(componentKey)?.class?.prototype;
-  if (!componentPrototype) {
-    return;
-  }
-
-  let hooks = componentPrototype[emberComponentToolkitHookKey(lifecycleHook)];
-  if (hooks) {
-    componentPrototype[emberComponentToolkitHookKey(lifecycleHook)] = hooks.filter(
-      (hook) => hook.fn !== fn
-    );
   }
 }

--- a/src/extension/utils/ynab.ts
+++ b/src/extension/utils/ynab.ts
@@ -5,10 +5,6 @@ import type { YNABAccountsService } from 'toolkit/types/ynab/services/YNABAccoun
 import type { YNABRegisterGridService } from 'toolkit/types/ynab/services/YNABRegisterGridService';
 import type { YNABApplicationService } from 'toolkit/types/ynab/services/YNABApplicationService';
 
-export function ynabRequire<T = any>(module: string): T {
-  return window.requireModule<T>(module);
-}
-
 export function getEntityManager() {
   return ynab.YNABSharedLib.defaultInstance.entityManager;
 }

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,5 +1,4 @@
 import { Chrome } from 'toolkit/test/mocks/web-extensions/chrome';
-import { Ember } from 'toolkit/test/mocks/ember';
 import { allToolkitSettings } from 'toolkit/core/settings/settings';
 import $ from 'jquery';
 
@@ -12,34 +11,11 @@ function resetWebExtensionsAPI() {
 }
 
 export function readyYNAB(options = {}) {
-  const ember = new Ember();
   const toolkitOptions = allToolkitSettings.reduce((settings, current) => {
     settings[current.name] = false;
     return settings;
   }, {});
 
-  global.requireModule = (module) => {
-    switch (module) {
-      case 'ember':
-        return {
-          default: {
-            ...ember,
-            Namespace: {
-              NAMESPACES: [
-                {
-                  lookup: jest.fn(),
-                  __container__: {
-                    cache: {},
-                  },
-                },
-              ],
-            },
-          },
-        };
-      case '@ember/runloop':
-        return ember.run;
-    }
-  };
   global.$ = $;
   global.ynabToolKit = options.ynabToolKit || { options: toolkitOptions };
 }

--- a/src/types/toolkit/index.ts
+++ b/src/types/toolkit/index.ts
@@ -6,7 +6,6 @@ export interface YNABToolkitObject {
   };
   environment: 'development' | 'beta' | 'production';
   extensionId: string;
-  hookedComponents: Set<string>;
   invokeFeature(featureName: FeatureName, options?: { force: boolean }): void;
   destroyFeature(featureName: FeatureName): void;
   options: {

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,4 +1,4 @@
-import type { YNABGlobal } from './ynab/window';
+import type { YNABApp, YNABGlobal } from './ynab/window';
 import type { YNABToolkitObject } from './toolkit';
 
 declare global {
@@ -6,9 +6,12 @@ declare global {
   const ynabToolKit: YNABToolkitObject;
   const __toolkitUtils: unknown;
 
+  const YNAB: {
+    NAMESPACES: [YNABApp];
+  };
+
   interface Window {
     __toolkitUtils: unknown;
     ynabToolKit: YNABToolkitObject;
-    requireModule<T>(moduleName: string): T;
   }
 }

--- a/src/types/ynab/ember/index.ts
+++ b/src/types/ynab/ember/index.ts
@@ -1,14 +1,6 @@
 import Component from '@ember/component';
-import { run } from '@ember/runloop';
-import { Feature } from 'toolkit/extension/features/feature';
 import type { YNABApp } from '../window';
 import { RenderTreeNode } from './ember-view';
-
-interface ToolkitEmberHook {
-  context: Feature;
-  fn(element: HTMLElement): void;
-  guard?: (element: HTMLElement) => boolean;
-}
 
 interface EmberComponentPrototype {
   element: Element;
@@ -20,10 +12,6 @@ interface EmberComponentPrototype {
   willRender: Component['willRender'];
   willUpdate: Component['willUpdate'];
   didInsertElement(): void;
-
-  _tk_didRender_hooks_?: ToolkitEmberHook[];
-  _tk_didInsertElement_hooks_?: ToolkitEmberHook[];
-  _tk_didUpdate_hooks_?: ToolkitEmberHook[];
 }
 
 export interface EmberComponent extends Component, EmberComponentPrototype {
@@ -35,7 +23,6 @@ export interface EmberComponent extends Component, EmberComponentPrototype {
 
 export interface Ember {
   _captureRenderTree(app: YNABApp['__container__']): RenderTreeNode[];
-  run: typeof run;
   Component: EmberComponent;
   Namespace: {
     NAMESPACES: [YNABApp];


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
Removing concept of the fragile "toolkit ember hooks" - many features have already been migrated off this capability but I just hid the ones that would be otherwise broken for now.