### PR TITLE
style: set budget header boxes to equal height

### DIFF
--- a/src/extension/features/budget/highlight-current-month/index.css
+++ b/src/extension/features/budget/highlight-current-month/index.css
@@ -53,3 +53,8 @@ body.theme-dark {
 .budget-header .tk-highlight-current-month .budget-header-calendar-note {
   color: var(--tk-current-month-note-color);
 }
+
+/* Set equal height */
+.to-be-budgeted {
+  height: 100%;
+}


### PR DESCRIPTION
I didn't get a response on discord so I'm just throwing this out here.

**Explanation of Bugfix/Feature/Modification:**
When the "Emphasize Current Month" setting is enabled, both boxes in the budget header are different sized which I see as a big eyesore. This PR increases the "To be Budgeted" box slightly, to match the box size of the current month.

**Screenshots**
Before:
![image](https://github.com/user-attachments/assets/7fa081d4-105d-42d0-8311-116dc781cb26)

After:
![image](https://github.com/user-attachments/assets/7c2ac718-94a7-4b7a-be98-d5c0f82622b2)
