### PR TITLE
add latest 12 months option to time range

### DIFF
--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/component.tsx
@@ -9,8 +9,9 @@ import { DateWithoutTime } from 'toolkit/types/ynab/window/ynab-utilities';
 const Options = {
   ThisMonth: 'This Month',
   LastMonth: 'Last Month',
-  LatestThree: 'Latest Three Months',
-  LatestSix: 'Latest Six Months',
+  LastThree: 'Last 3 Months',
+  LastSix: 'Last 6 Months',
+  LastTwelve: 'Last 12 Months',
   ThisYear: 'This Year',
   LastYear: 'Last Year',
   AllDates: 'All Dates',
@@ -66,18 +67,25 @@ export class DateFilterComponent extends React.Component<DateFilterProps, DateFi
             {Options.LastMonth}
           </button>
           <button
-            name={Options.LatestThree}
+            name={Options.LastThree}
             className="tk-button tk-button--small tk-button--text tk-mg-l-05"
             onClick={this._handleOptionSelected}
           >
-            {Options.LatestThree}
+            {Options.LastThree}
           </button>
           <button
-            name={Options.LatestSix}
+            name={Options.LastSix}
             className="tk-button tk-button--small tk-button--text tk-mg-l-05"
             onClick={this._handleOptionSelected}
           >
-            {Options.LatestSix}
+            {Options.LastSix}
+          </button>
+          <button
+            name={Options.LastTwelve}
+            className="tk-button tk-button--small tk-button--text tk-mg-l-05"
+            onClick={this._handleOptionSelected}
+          >
+            {Options.LastTwelve}
           </button>
           <button
             name={Options.ThisYear}
@@ -275,11 +283,14 @@ export class DateFilterComponent extends React.Component<DateFilterProps, DateFi
         const lastMonth = today.clone().subtractMonths(1);
         selectedDates = this._getSelectedFromDates(lastMonth, lastMonth);
         break;
-      case Options.LatestThree:
+      case Options.LastThree:
         selectedDates = this._getSelectedFromDates(today.clone().subtractMonths(2), today);
         break;
-      case Options.LatestSix:
+      case Options.LastSix:
         selectedDates = this._getSelectedFromDates(today.clone().subtractMonths(5), today);
+        break;
+      case Options.LastTwelve:
+        selectedDates = this._getSelectedFromDates(today.clone().subtractMonths(11), today);
         break;
       case Options.ThisYear:
         selectedDates = this._getSelectedFromDates(today.clone().startOfYear(), today);

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/component.tsx
@@ -9,9 +9,9 @@ import { DateWithoutTime } from 'toolkit/types/ynab/window/ynab-utilities';
 const Options = {
   ThisMonth: 'This Month',
   LastMonth: 'Last Month',
-  LastThree: 'Last 3 Months',
-  LastSix: 'Last 6 Months',
-  LastTwelve: 'Last 12 Months',
+  LatestThree: 'Latest 3 Months',
+  LatestSix: 'Latest 6 Months',
+  LatestTwelve: 'Latest 12 Months',
   ThisYear: 'This Year',
   LastYear: 'Last Year',
   AllDates: 'All Dates',
@@ -67,25 +67,25 @@ export class DateFilterComponent extends React.Component<DateFilterProps, DateFi
             {Options.LastMonth}
           </button>
           <button
-            name={Options.LastThree}
+            name={Options.LatestThree}
             className="tk-button tk-button--small tk-button--text tk-mg-l-05"
             onClick={this._handleOptionSelected}
           >
-            {Options.LastThree}
+            {Options.LatestThree}
           </button>
           <button
-            name={Options.LastSix}
+            name={Options.LatestSix}
             className="tk-button tk-button--small tk-button--text tk-mg-l-05"
             onClick={this._handleOptionSelected}
           >
-            {Options.LastSix}
+            {Options.LatestSix}
           </button>
           <button
-            name={Options.LastTwelve}
+            name={Options.LatestTwelve}
             className="tk-button tk-button--small tk-button--text tk-mg-l-05"
             onClick={this._handleOptionSelected}
           >
-            {Options.LastTwelve}
+            {Options.LatestTwelve}
           </button>
           <button
             name={Options.ThisYear}
@@ -283,13 +283,13 @@ export class DateFilterComponent extends React.Component<DateFilterProps, DateFi
         const lastMonth = today.clone().subtractMonths(1);
         selectedDates = this._getSelectedFromDates(lastMonth, lastMonth);
         break;
-      case Options.LastThree:
+      case Options.LatestThree:
         selectedDates = this._getSelectedFromDates(today.clone().subtractMonths(2), today);
         break;
-      case Options.LastSix:
+      case Options.LatestSix:
         selectedDates = this._getSelectedFromDates(today.clone().subtractMonths(5), today);
         break;
-      case Options.LastTwelve:
+      case Options.LatestTwelve:
         selectedDates = this._getSelectedFromDates(today.clone().subtractMonths(11), today);
         break;
       case Options.ThisYear:


### PR DESCRIPTION
GitHub Issue (if applicable): #3567

**Explanation of Bugfix/Feature/Modification:**
In the time range modal I added a "Latest 12 months" range.


**Screenshots**
![image](https://github.com/user-attachments/assets/bc27f979-517f-44e8-b023-16aefeeb6d9f)

