### PR TITLE
fix: Don't log uncleared transactions to the console

### DIFF
--- a/src/extension/features/general/uncleared-account-highlight/index.js
+++ b/src/extension/features/general/uncleared-account-highlight/index.js
@@ -39,8 +39,6 @@ export class UnclearedAccountHighlight extends Feature {
         return;
       }
 
-      console.log(unclearedTransactions);
-
       const isIndicatorShowing = navAccount.querySelector(`.${INDICATOR_CLASS}`) !== null;
       const navAccountIconsRight = navAccount.querySelector('.nav-account-icons-right');
 


### PR DESCRIPTION
Minor nit. The `uncleared-account-highlight` extensions currently logs all matching transactions via `console.log`. I'm making the assumption this was a debugging aid, and is no longer required.
