### PR TITLE
fix: Update layout so cleared & synced icons do not overlap

### DIFF
--- a/src/extension/features/general/uncleared-account-highlight/index.css
+++ b/src/extension/features/general/uncleared-account-highlight/index.css
@@ -2,11 +2,11 @@
   font-size: 0.8rem;
 }
 
-.tk-nav-account-icons-right-space .nav-account-icons-right svg {
+.nav-accounts .nav-account-icons-right svg {
   position: static !important;
 }
 
-.tk-nav-account-icons-right-space .nav-account-icons-right {
+.nav-accounts .nav-account-icons-right {
   display: flex;
   align-items: center;
   width: 2rem;

--- a/src/extension/features/general/uncleared-account-highlight/index.js
+++ b/src/extension/features/general/uncleared-account-highlight/index.js
@@ -24,8 +24,6 @@ export class UnclearedAccountHighlight extends Feature {
     // cleared icon to it, that's not enough space if there's already an icon in the space
     // so we need to add a class which overrides it to 2rem.
     $('.nav-account-row').each((_, navAccount) => {
-      let hasOtherNavAccountRightIcons = false;
-
       const account = getAccountsService().getAccountById(navAccount.dataset.accountId);
 
       const unclearedTransactions = account
@@ -44,18 +42,8 @@ export class UnclearedAccountHighlight extends Feature {
       const isIndicatorShowing = navAccount.querySelector(`.${INDICATOR_CLASS}`) !== null;
       const navAccountIconsRight = navAccount.querySelector('.nav-account-icons-right');
 
-      if ($(navAccountIconsRight).children(`:not(.${INDICATOR_CLASS})`).length) {
-        hasOtherNavAccountRightIcons = true;
-      }
-
       if (!isIndicatorShowing) {
         $(navAccountIconsRight).append(INDICATOR_ELEMENT);
-      }
-
-      if (hasOtherNavAccountRightIcons) {
-        navAccount.classList.add('tk-nav-account-icons-right-space');
-      } else {
-        navAccount.classList.remove('tk-nav-account-icons-right-space');
       }
     });
   }


### PR DESCRIPTION
Fixes: #3500

The extension originally added a `.tk-nav-account-icons-right-space` style dynamically at runtime to each individual `.nav-account-row` element. It appears the tooltip code for the synced transactions icon will rewrite the `nav-account-row` removing the applied style

We therefore move the extra space CSS class to the parent `.nav-accounts` element. This achieves two purposes:
 - The synced transactions tooltip does not remove the style class when rewriting the `nav-account-row` element
 - The account list balances remain aligned regardless of the presence of the uncleared status icon

Screenshot of layout post change with `uncleared-account-highlight` extension enabled:
<img width="50" alt="image" src="https://github.com/user-attachments/assets/9b90c3a9-b074-45bc-8e84-94799808ed2c" />
