### PR TITLE
feat: Add an option to show unreconciled accounts in sidebar

### DIFF
--- a/src/extension/features/general/uncleared-account-highlight/index.js
+++ b/src/extension/features/general/uncleared-account-highlight/index.js
@@ -4,10 +4,20 @@ import { getAccountsService } from 'toolkit/extension/utils/ynab';
 import debounce from 'debounce';
 
 const INDICATOR_CLASS = 'tk-uncleared-account-indicator';
-const INDICATOR_ELEMENT = `<svg class="ynab-new-icon ${INDICATOR_CLASS} " width="16" height="16"><use href="#icon_sprite_cleared_circle"></use></svg>`;
+const INDICATOR_ICON_UNCLEARED = '#icon_sprite_cleared_circle';
+const INDICATOR_ICON_CLEARED = '#icon_sprite_cleared_circle_fill';
+const INDICATOR_ELEMENT = `<svg class="ynab-new-icon ${INDICATOR_CLASS} " width="16" height="16"><use href="${INDICATOR_ICON_CLEARED}"></use></svg>`;
 
 function isUnclearedTransaction(transaction) {
   return transaction && transaction.cleared === ynab.constants.TransactionState.Uncleared;
+}
+
+function isUnreconciledTransaction(transaction) {
+  return (
+    transaction &&
+    transaction.accepted &&
+    transaction.cleared === ynab.constants.TransactionState.Cleared
+  );
 }
 
 export class UnclearedAccountHighlight extends Feature {
@@ -32,7 +42,12 @@ export class UnclearedAccountHighlight extends Feature {
         .getTransactions()
         .filter((transaction) => isUnclearedTransaction(transaction));
 
-      if (unclearedTransactions.length === 0) {
+      const unreconciledTransactions =
+        this.settings.enabled === '2'
+          ? account.getTransactions().filter(isUnreconciledTransaction)
+          : [];
+
+      if (unclearedTransactions.length === 0 && unreconciledTransactions.length === 0) {
         if (navAccount.querySelector(`.${INDICATOR_CLASS}`) !== null) {
           navAccount.querySelector(`.${INDICATOR_CLASS}`).remove();
         }
@@ -50,6 +65,13 @@ export class UnclearedAccountHighlight extends Feature {
 
       if (!isIndicatorShowing) {
         $(navAccountIconsRight).append(INDICATOR_ELEMENT);
+      }
+
+      const iconUseElement = navAccountIconsRight.querySelector(`.${INDICATOR_CLASS} use`);
+      if (unclearedTransactions.length !== 0) {
+        iconUseElement.setAttribute('href', INDICATOR_ICON_UNCLEARED);
+      } else if (unreconciledTransactions.length !== 0) {
+        iconUseElement.setAttribute('href', INDICATOR_ICON_CLEARED);
       }
 
       if (hasOtherNavAccountRightIcons) {

--- a/src/extension/features/general/uncleared-account-highlight/settings.js
+++ b/src/extension/features/general/uncleared-account-highlight/settings.js
@@ -1,9 +1,13 @@
 module.exports = {
   name: 'UnclearedAccountHighlight',
-  type: 'checkbox',
+  type: 'select',
   default: false,
   section: 'general',
   title: 'Emphasize Uncleared Accounts',
   description:
     'Add a small indicator next to account balances on the sidebar to indicate not all transactions are cleared.',
+  options: [
+    { name: 'Uncleared Accounts', value: '1' },
+    { name: 'Uncleared and Unreconciled Accounts', value: '2' },
+  ],
 };


### PR DESCRIPTION
This adds a settings option to the `uncleared-account-highlight` extension to highlight unreconciled accounts in addition to uncleared accounts.

When applied, accounts with cleared transactions in the register will display the "filled" cleared transaction sprite next to the account in the sidebar. This is in addition to continuing to display the "unfilled" cleared transaction sprite for accounts with uncleared transactions in the register.

**Screenshots**
Example of the "filled" icon for accounts that have cleared, but not reconciled, transactions in the register:
<img width="335" alt="image" src="https://github.com/user-attachments/assets/c5bb1e71-a13a-48a4-8379-9cd00b4e8367" />

