### PR TITLE
fix(ui): update ynab dark theme css class name

### DIFF
--- a/src/core/components/toolkit-release-modal/styles.scss
+++ b/src/core/components/toolkit-release-modal/styles.scss
@@ -29,7 +29,7 @@
   }
 }
 
-body.theme-dark .tk-release-modal__logo {
+body.theme-var-dark .tk-release-modal__logo {
   -webkit-filter: invert(1) hue-rotate(180deg) brightness(1.2);
   filter: invert(1) hue-rotate(180deg) brightness(1.2);
 }

--- a/src/extension/features/accounts/emphasized-inflows/index.css
+++ b/src/extension/features/accounts/emphasized-inflows/index.css
@@ -4,7 +4,7 @@ body.theme-new-default {
   --tk-emphasize-inflow-color-selected: #248f24;
 }
 
-body.theme-dark,
+body.theme-var-dark,
 body.theme-classic {
   --tk-emphasize-inflow-color: #33cc33;
   --tk-emphasize-inflow-color-selected: #70db70;

--- a/src/extension/features/accounts/reconciled-text-color/darkgray.css
+++ b/src/extension/features/accounts/reconciled-text-color/darkgray.css
@@ -4,7 +4,7 @@ body.theme-classic {
   --tk-reconciled-font-color: #8e9fb0;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-reconciled-font-color: #5a5a5a;
 }
 

--- a/src/extension/features/accounts/reconciled-text-color/darkgraybg.css
+++ b/src/extension/features/accounts/reconciled-text-color/darkgraybg.css
@@ -5,7 +5,7 @@ body.theme-classic {
   --tk-reconciled-background-color: #e7faeb;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-reconciled-font-color: #5a5a5a;
   --tk-reconciled-background-color: #07190a;
 }

--- a/src/extension/features/accounts/reconciled-text-color/lightgray.css
+++ b/src/extension/features/accounts/reconciled-text-color/lightgray.css
@@ -4,7 +4,7 @@ body.theme-classic {
   --tk-reconciled-font-color: #cfd5d7;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-reconciled-font-color: #8e9fb0;
 }
 

--- a/src/extension/features/accounts/striped-rows/index.css
+++ b/src/extension/features/accounts/striped-rows/index.css
@@ -4,7 +4,7 @@ body.theme-classic {
   --tk-striped-transaction-row-color: #fafafa;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-striped-transaction-row-color: #1e1e1f;
 }
 

--- a/src/extension/features/budget/budget-progress-bars/index.css
+++ b/src/extension/features/budget/budget-progress-bars/index.css
@@ -5,7 +5,7 @@ body.theme-new-default {
   --tk-color-progress-bar-month-indicator: gray;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-color-goal-fill: #16a3364d;
   --tk-color-pacing-fill: #405f86;
 }

--- a/src/extension/features/budget/color-master-category-row/index.css
+++ b/src/extension/features/budget/color-master-category-row/index.css
@@ -4,7 +4,7 @@ body.theme-new-default {
   --tk-master-category-row-color: var(--neutral300);
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-master-category-row-color: var(--neutral700);
 }
 

--- a/src/extension/features/budget/goal-warning-color/index.css
+++ b/src/extension/features/budget/goal-warning-color/index.css
@@ -6,7 +6,7 @@
   --tk-color-goal-warning-underfunded-message-border: #70b3ff;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-color-goal-warning-underfunded: #429aff;
   --tk-color-goal-warning-underfunded-hover: #61abff;
   --tk-color-goal-warning-underfunded-message-bg: #0f1e2d;

--- a/src/extension/features/budget/highlight-budget-rows-on-hover/index.css
+++ b/src/extension/features/budget/highlight-budget-rows-on-hover/index.css
@@ -7,7 +7,7 @@ body.theme-classic {
   --tk-hovered-budget-row-color: #e3e3e3;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-hovered-budget-row-color: #3f3f43;
 }
 

--- a/src/extension/features/budget/highlight-current-month/index.css
+++ b/src/extension/features/budget/highlight-current-month/index.css
@@ -12,7 +12,7 @@ body.theme-classic {
   --tk-current-month-note-color: rgba(255, 255, 255, 0.6);
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-current-month-control-color: #ffffff;
   --tk-current-month-header-color: #ffffff;
   --tk-current-month-note-color: rgba(255, 255, 255, 0.6);

--- a/src/extension/features/budget/striped-budget-rows/index.css
+++ b/src/extension/features/budget/striped-budget-rows/index.css
@@ -10,7 +10,7 @@ body.theme-classic {
   --tk-striped-budget-row-selected-color: #094e5f;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-striped-budget-row-color: #2b2b2e;
   --tk-striped-budget-row-selected-color: #2f4969;
   --backgroundTableHeader: #343437;

--- a/src/extension/features/reports/income-expense-hover-highlight/index.css
+++ b/src/extension/features/reports/income-expense-hover-highlight/index.css
@@ -1,4 +1,4 @@
-body.theme-dark,
+body.theme-var-dark,
 body.theme-classic {
   --tk-expense-rep-hl-color: #fcffff;
   --tk-expense-rep-hl-pos: #b4d888;

--- a/src/extension/features/toolkit-reports/pages/income-vs-expense/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/income-vs-expense/styles.scss
@@ -13,7 +13,7 @@ body.theme-classic {
   --tk-ive-report-positive-color: #edf5e6;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-ive-report-header-background-color: var(--headerBackground);
   --tk-ive-report-border-color: #545458;
   --tk-ive-report-negative-color: #631f32;

--- a/src/extension/ynab-toolkit.css
+++ b/src/extension/ynab-toolkit.css
@@ -17,7 +17,7 @@ body.theme-classic {
   --tk-zero-currency-color: #cfd5d8;
 }
 
-body.theme-dark {
+body.theme-var-dark {
   --tk-modal-backdrop: rgba(99, 99, 99, 0.5);
   --tk-default-background-color: #2c2c2e;
   --tk-default-font-color: #ffffff;


### PR DESCRIPTION
GitHub Issue (if applicable): #3579 and #3581 

**Explanation of Bugfix/Feature/Modification:**
YNAB recently pushed an update to their dark mode class name, from `theme-dark` to `theme-var-dark`. This broke the current CSS for the toolkit. This PR updates the class name in relevant areas of code.