### PR TITLE
Update class name for referral button

### DIFF
--- a/src/extension/features/general/hide-referral-banner/index.css
+++ b/src/extension/features/general/hide-referral-banner/index.css
@@ -1,3 +1,3 @@
-div.referral-program {
+div.sidebar-referral-program {
   display: none !important;
 }


### PR DESCRIPTION
GitHub Issue (if applicable): #XXX

**Explanation of Bugfix/Feature/Modification:**
The `Hide Referral Banner` toggle was no longer working. I checked the class name that the Toolkit referenced to enable this option, and it was different from what YNAB had for that button, so I updated it in the code, tested locally, and it successfully hid the banner.

**Screenshots**
https://github.com/user-attachments/assets/6c917b19-56a5-4dda-9513-4f58b8592ac1