### PR TITLE
Skip rejected transactions in uncleared-account-highlight

### DIFF
--- a/src/extension/features/general/uncleared-account-highlight/index.js
+++ b/src/extension/features/general/uncleared-account-highlight/index.js
@@ -9,7 +9,11 @@ const INDICATOR_ICON_CLEARED = '#icon_sprite_cleared_circle_fill';
 const INDICATOR_ELEMENT = `<svg class="ynab-new-icon ${INDICATOR_CLASS} " width="16" height="16"><use href="${INDICATOR_ICON_CLEARED}"></use></svg>`;
 
 function isUnclearedTransaction(transaction) {
-  return transaction && transaction.cleared === ynab.constants.TransactionState.Uncleared;
+  return (
+    transaction &&
+    transaction.accepted &&
+    transaction.cleared === ynab.constants.TransactionState.Uncleared
+  );
 }
 
 function isUnreconciledTransaction(transaction) {


### PR DESCRIPTION
See: #3589

I don't have an account with linked transaction import that generates uncleared transactions, so I can't test the specifics of the bug reported.

I did encounter this issue with cleared transactions in the past. This change applies the same logic we use to the uncleared transactions