### PR TITLE
Update cleared/unreconciled status for 0-value transactions

### DIFF
--- a/src/extension/features/general/uncleared-account-highlight/index.js
+++ b/src/extension/features/general/uncleared-account-highlight/index.js
@@ -69,7 +69,7 @@ export class UnclearedAccountHighlight extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (changedNodes.has('nav-account-value')) {
+    if (changedNodes.has('nav-account-value') || changedNodes.has('ynab-grid-body')) {
       this.debouncedInvoke();
     }
   }


### PR DESCRIPTION
Fixes: #3597

Listen for `ynab-grid-body` node changed in addition to `nav-account-value`. This refreshes the cleared status icons in the account sidebar when the transaction ledger changes.
