### PR TITLE
fix(Budget): restore Live on Last Month's Income feature in Inspector pane

### DIFF
--- a/src/extension/features/budget/live-on-last-months-income/index.js
+++ b/src/extension/features/budget/live-on-last-months-income/index.js
@@ -52,15 +52,19 @@ export class LiveOnLastMonthsIncome extends Feature {
 
     // Add the income from last month section and structure, if not already in place
     if ($('#tk-last-months-income').length === 0) {
-      $('.budget-breakdown .card[class="card"]').after(
+      const summaryCard = $('.budget-breakdown .card').filter(function () {
+        return this.className.trim() === 'card';
+      });
+
+      summaryCard.after(
         $('<section>', {
           class: 'card',
           id: 'tk-last-months-income',
         })
           .append(
-            $('<button>', { class: 'card-roll-up', type: 'button' })
-              .append('<h2>')
-              .text("Live on Last Month's Income"),
+            $('<button>', { class: 'card-roll-up', type: 'button' }).append(
+              $('<h2>').text("Live on Last Month's Income"),
+            ),
           )
           .append(
             $('<div>', {


### PR DESCRIPTION
GitHub Issue (if applicable): #3593

**Explanation of Bugfix/Feature/Modification:**
It appears that YNAB changed their CSS class name from `.budget-breakdown-monthly-totals` to `.budget-breakdown` and also updated the HTML structure to use a `button` instead of a `div` for the title.

Updated live-on-last-months-income budget feature to use updated YNAB CSS style and structure. I attempted to use a CSS attribute selector however it did not appear to work consistently on my platform (Linux + Firefox) and so left it using an old-school CSS approach.

**Screenshots**
![image](https://github.com/user-attachments/assets/1708f624-fefa-4c80-a7a3-b88d13668245)

