### PR TITLE
feat: add toggle to reword "Plan" to "Budget" in navigation menu

### DIFF
--- a/src/extension/features/general/reword-plan-to-budget/index.js
+++ b/src/extension/features/general/reword-plan-to-budget/index.js
@@ -1,0 +1,24 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { isYNABReady } from 'toolkit/extension/utils/ynab';
+
+export class RewordPlanToBudget extends Feature {
+  shouldInvoke() {
+    return isYNABReady();
+  }
+
+  observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
+    if (changedNodes.has('navlink-budget')) {
+      this.invoke();
+    }
+  }
+
+  invoke() {
+    const button = document.querySelector('.navlink-budget .ember-view .navlink-label');
+    if (button && button.textContent !== 'Budget') {
+      button.textContent = 'Budget';
+      button.setAttribute('title', 'Budget');
+    }
+  }
+}

--- a/src/extension/features/general/reword-plan-to-budget/settings.js
+++ b/src/extension/features/general/reword-plan-to-budget/settings.js
@@ -1,0 +1,8 @@
+module.exports = {
+  name: 'RewordPlanToBudget',
+  type: 'checkbox',
+  default: false,
+  section: 'general',
+  title: 'Reword "Plan" to "Budget"',
+  description: 'Change navigation button title from "Plan" back to "Budget"',
+};


### PR DESCRIPTION
GitHub Issue (if applicable): #3604

Explanation of Bugfix/Feature/Modification:
Adds a toggle option to change the Plan tab back to Budget. The toggle is set false as default and has been placed in the 'General' settings section. Only the button has been altered, but this feature can be expanded if someone wants to remove all mentions of 'plan' in the budget settings menu.

Screenshots
https://github.com/user-attachments/assets/519d0ea3-6c7b-4639-964e-7f350dd70a35