### PR TITLE
makes Bulk Memo Edit input/buttons stack vertically for less cramping

### DIFF
--- a/src/extension/features/accounts/bulk-edit-memo/index.css
+++ b/src/extension/features/accounts/bulk-edit-memo/index.css
@@ -8,3 +8,10 @@
   padding: 0.4em 0.6em;
   margin-right: 5px;
 }
+
+.tk-memo-edit-container {
+  display: flex;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+}

--- a/src/extension/features/accounts/bulk-edit-memo/index.jsx
+++ b/src/extension/features/accounts/bulk-edit-memo/index.jsx
@@ -124,10 +124,10 @@ const EditMemo = () => {
             {editMode === ADD_SUFFIX_EDIT_MODE && (
               <li className="button-list button-disabled">{makeAddSuffixLabel()}</li>
             )}
-            <div className="button-list">
+            <div className="tk-memo-edit-container">
               <input
                 autoFocus
-                className="accounts-text-field"
+                className="accounts-text-field tk-memo-input"
                 value={memoInputValue}
                 onChange={(e) => setMemoInputValue(e.target.value)}
               />


### PR DESCRIPTION
This is a small tweak to the styling of the Bulk Edit Memos input which looks cramped and a little misaligned in its current form. An alternative here if the column layout is undesirable is at least to locally remove the bottom margin on the input so that the vertical misalignment between the buttons and input is fixed.


Current layout: 
<img width="268" alt="image" src="https://github.com/user-attachments/assets/24bb3192-b466-4e14-a984-b7e773de2d56" />

New column layout:
<img width="237" alt="image" src="https://github.com/user-attachments/assets/24a7ffa8-36ce-4004-bd44-afbd6bd2335b" />

