### PR TITLE
Add URL-based navigation for Toolkit Reports

### DIFF
--- a/src/extension/features/toolkit-reports/README.md
+++ b/src/extension/features/toolkit-reports/README.md
@@ -1,0 +1,92 @@
+# Toolkit Reports URL Navigation
+
+This feature adds URL-based navigation to the Toolkit Reports, allowing users to navigate directly to specific report tabs and share links to reports.
+
+## URL Format
+
+The URL format follows the pattern:
+
+```
+https://app.ynab.com/{budgetId}/budget#toolkit-reports/{reportTab}
+```
+
+Where:
+
+- `{budgetId}` is the UUID of the current budget
+- `{reportTab}` is the URL-encoded name of the report tab (optional)
+
+## Supported Report Tabs
+
+The following report tabs are supported with their corresponding URL paths:
+
+| Report Name          | URL Path               |
+| -------------------- | ---------------------- |
+| Net Worth            | `net-worth`            |
+| Inflow/Outflow       | `inflow-outflow`       |
+| Spending By Category | `spending-by-category` |
+| Spending By Payee    | `spending-by-payee`    |
+| Income vs. Expense   | `income-vs-expense`    |
+| Income Breakdown     | `income-breakdown`     |
+| Balance Over Time    | `balance-over-time`    |
+| Outflow Over Time    | `outflow-over-time`    |
+| Forecast             | `forecast`             |
+
+## Examples
+
+- Navigate to Toolkit Reports (default tab): `https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports`
+- Navigate to Net Worth report: `https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports/net-worth`
+- Navigate to Forecast report: `https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports/forecast`
+
+## Features
+
+### Automatic URL Updates
+
+When a user clicks on a report tab, the URL automatically updates to reflect the current report.
+
+### Browser Navigation Support
+
+Users can use browser back/forward buttons to navigate between different report tabs.
+
+### Direct URL Access
+
+Users can navigate directly to a specific report tab by entering the URL in the browser address bar.
+
+### Fallback Behavior
+
+If an invalid report tab is specified in the URL, the system falls back to the last accessed report tab or the default (Net Worth).
+
+### State Persistence
+
+The last accessed report tab is stored and will be used when navigating to the base toolkit reports URL.
+
+## Implementation Details
+
+### URL Navigation Utilities (`utils/url-navigation.ts`)
+
+- `isToolkitReportsURL()`: Checks if a URL is a toolkit reports URL
+- `parseToolkitReportsURL()`: Parses toolkit reports URLs to extract budget ID and report tab
+- `buildToolkitReportsURL()`: Builds toolkit reports URLs
+- `navigateToToolkitReports()`: Programmatically navigates to toolkit reports
+- `isValidReportTab()`: Validates report tab names
+- `getDefaultReportTab()`: Returns the default report tab
+
+### Integration Points
+
+- **ToolkitReports Feature**: Handles URL-based navigation and browser events
+- **Report Context Provider**: Manages report state and URL synchronization
+- **Report Selector**: Updates URLs when report tabs are clicked
+
+### Event Handling
+
+- `popstate` events: Handle browser back/forward navigation
+- `toolkit-reports-url-changed` events: Handle programmatic URL changes
+
+## Browser Compatibility
+
+This feature uses the HTML5 History API (`pushState`, `popstate`) and is compatible with all modern browsers that support YNAB.
+
+## Error Handling
+
+- Invalid URLs are gracefully handled with fallback to default behavior
+- Missing budget IDs result in console errors but don't break functionality
+- Invalid report tabs fall back to the last accessed tab or default

--- a/src/extension/features/toolkit-reports/utils/url-navigation.test.ts
+++ b/src/extension/features/toolkit-reports/utils/url-navigation.test.ts
@@ -1,0 +1,347 @@
+import {
+  isToolkitReportsURL,
+  parseToolkitReportsURL,
+  buildToolkitReportsURL,
+  navigateToToolkitReports,
+  getCurrentBudgetId,
+  isValidReportTab,
+  getDefaultReportTab,
+  urlToReportKey,
+} from './url-navigation';
+import { ReportKeys } from '../common/constants/report-types';
+
+// Mock the toolkit storage module
+jest.mock('toolkit/extension/utils/toolkit', () => ({
+  getToolkitStorageKey: jest.fn(),
+}));
+
+// Mock window.location for testing
+const mockLocation = {
+  origin: 'https://app.ynab.com',
+  href: 'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget',
+  pathname: '/12345678-1234-1234-1234-123456789012/budget',
+};
+
+// Mock console.error to suppress error logs during tests
+const originalConsoleError = console.error;
+
+// Mock window.location before each test
+beforeEach(() => {
+  Object.defineProperty(window, 'location', {
+    value: mockLocation,
+    writable: true,
+  });
+
+  // Suppress console.error during tests
+  console.error = jest.fn();
+});
+
+afterEach(() => {
+  // Restore console.error after each test
+  console.error = originalConsoleError;
+});
+
+describe('URL Navigation Utilities', () => {
+  describe('isToolkitReportsURL', () => {
+    it('should return true for toolkit reports URLs', () => {
+      expect(isToolkitReportsURL('https://app.ynab.com/budget-id/budget#toolkit-reports')).toBe(
+        true,
+      );
+      expect(
+        isToolkitReportsURL('https://app.ynab.com/budget-id/budget#toolkit-reports/net-worth'),
+      ).toBe(true);
+    });
+
+    it('should return false for non-toolkit reports URLs', () => {
+      expect(isToolkitReportsURL('https://app.ynab.com/budget-id/budget')).toBe(false);
+      expect(isToolkitReportsURL('https://app.ynab.com/budget-id/accounts')).toBe(false);
+    });
+  });
+
+  describe('parseToolkitReportsURL', () => {
+    it.each([
+      {
+        url: 'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports',
+        expected: {
+          budgetId: '12345678-1234-1234-1234-123456789012',
+          reportTab: null,
+        },
+      },
+      {
+        url: 'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports/net-worth',
+        expected: {
+          budgetId: '12345678-1234-1234-1234-123456789012',
+          reportTab: 'net-worth',
+        },
+      },
+      {
+        url: 'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports/forecast',
+        expected: {
+          budgetId: '12345678-1234-1234-1234-123456789012',
+          reportTab: 'forecast',
+        },
+      },
+      {
+        url: 'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget',
+        expected: null,
+      },
+    ])('should parse "%s" correctly', ({ url, expected }) => {
+      const result = parseToolkitReportsURL(url);
+      expect(result).toEqual(expected);
+    });
+
+    it('should return null for invalid URLs', () => {
+      const result = parseToolkitReportsURL('not-a-valid-url');
+      expect(result).toBe(null);
+    });
+
+    it('should return null for URLs without toolkit-reports hash', () => {
+      const result = parseToolkitReportsURL('https://app.ynab.com/budget-id/budget#other-hash');
+      expect(result).toBe(null);
+    });
+
+    it('should return null for URLs with hash that does not start with toolkit-reports', () => {
+      const result = parseToolkitReportsURL('https://app.ynab.com/budget-id/budget#something-else');
+      expect(result).toBe(null);
+    });
+
+    it('should return null for URLs with hash starting with different prefix', () => {
+      const result = parseToolkitReportsURL(
+        'https://app.ynab.com/budget-id/budget#other-toolkit-reports',
+      );
+      expect(result).toBe(null);
+    });
+
+    it('should return null for URLs with no hash', () => {
+      const result = parseToolkitReportsURL('https://app.ynab.com/budget-id/budget');
+      expect(result).toBe(null);
+    });
+
+    it('should return null for URLs with hash starting with different prefix', () => {
+      const result = parseToolkitReportsURL(
+        'https://app.ynab.com/budget-id/budget#completely-different',
+      );
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('buildToolkitReportsURL', () => {
+    it('should build URL without report tab', () => {
+      const result = buildToolkitReportsURL();
+      expect(result).toBe(
+        'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports',
+      );
+    });
+
+    it('should build URL with report tab', () => {
+      const result = buildToolkitReportsURL('net-worth');
+      expect(result).toBe(
+        'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports/net-worth',
+      );
+    });
+
+    it('should return current href when no budgetId is available', () => {
+      // Mock window.location with empty pathname
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...mockLocation,
+          pathname: '/',
+          href: 'https://app.ynab.com/',
+        },
+        writable: true,
+      });
+
+      const result = buildToolkitReportsURL('net-worth');
+      expect(result).toBe('https://app.ynab.com/');
+    });
+  });
+
+  describe('navigateToToolkitReports', () => {
+    let mockPushState: jest.Mock;
+    let mockDispatchEvent: jest.Mock;
+    let mockGetToolkitStorageKey: jest.Mock;
+
+    beforeEach(() => {
+      // Mock window.history.pushState
+      mockPushState = jest.fn();
+      Object.defineProperty(window.history, 'pushState', {
+        value: mockPushState,
+        writable: true,
+      });
+
+      // Mock window.dispatchEvent
+      mockDispatchEvent = jest.fn();
+      Object.defineProperty(window, 'dispatchEvent', {
+        value: mockDispatchEvent,
+        writable: true,
+      });
+
+      // Get the mocked function
+      const toolkitUtils = require('toolkit/extension/utils/toolkit');
+      mockGetToolkitStorageKey = toolkitUtils.getToolkitStorageKey;
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should navigate with provided report tab', () => {
+      navigateToToolkitReports('net-worth');
+
+      expect(mockPushState).toHaveBeenCalledWith(
+        {},
+        '',
+        'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports/net-worth',
+      );
+
+      expect(mockDispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toolkit-reports-url-changed',
+          detail: { reportTab: 'net-worth' },
+        }),
+      );
+    });
+
+    it('should use stored report tab when none provided', () => {
+      mockGetToolkitStorageKey.mockReturnValue('stored-tab');
+
+      navigateToToolkitReports();
+
+      expect(mockGetToolkitStorageKey).toHaveBeenCalledWith('active-report', 'net-worth');
+      expect(mockPushState).toHaveBeenCalledWith(
+        {},
+        '',
+        'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports/stored-tab',
+      );
+      expect(mockDispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toolkit-reports-url-changed',
+          detail: { reportTab: 'stored-tab' },
+        }),
+      );
+    });
+
+    it('should use default report tab when storage returns null', () => {
+      mockGetToolkitStorageKey.mockReturnValue(null);
+
+      navigateToToolkitReports();
+
+      expect(mockGetToolkitStorageKey).toHaveBeenCalledWith('active-report', 'net-worth');
+      expect(mockPushState).toHaveBeenCalledWith(
+        {},
+        '',
+        'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports',
+      );
+      expect(mockDispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toolkit-reports-url-changed',
+          detail: { reportTab: null },
+        }),
+      );
+    });
+
+    it('should use default report tab when storage returns undefined', () => {
+      mockGetToolkitStorageKey.mockReturnValue(undefined);
+
+      navigateToToolkitReports();
+
+      expect(mockGetToolkitStorageKey).toHaveBeenCalledWith('active-report', 'net-worth');
+      expect(mockPushState).toHaveBeenCalledWith(
+        {},
+        '',
+        'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports',
+      );
+      expect(mockDispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toolkit-reports-url-changed',
+          detail: { reportTab: undefined },
+        }),
+      );
+    });
+
+    it('should handle different report tabs correctly', () => {
+      navigateToToolkitReports('forecast');
+
+      expect(mockPushState).toHaveBeenCalledWith(
+        {},
+        '',
+        'https://app.ynab.com/12345678-1234-1234-1234-123456789012/budget#toolkit-reports/forecast',
+      );
+      expect(mockDispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'toolkit-reports-url-changed',
+          detail: { reportTab: 'forecast' },
+        }),
+      );
+    });
+  });
+
+  describe('getCurrentBudgetId', () => {
+    it('should extract budget ID from pathname', () => {
+      const result = getCurrentBudgetId();
+      expect(result).toBe('12345678-1234-1234-1234-123456789012');
+    });
+
+    it('should return null for empty pathname', () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...mockLocation,
+          pathname: '',
+        },
+        writable: true,
+      });
+
+      const result = getCurrentBudgetId();
+      expect(result).toBe(null);
+    });
+
+    it('should handle pathname parsing errors', () => {
+      // Mock window.location to cause an error
+      Object.defineProperty(window, 'location', {
+        value: null,
+        writable: true,
+      });
+
+      const result = getCurrentBudgetId();
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('isValidReportTab', () => {
+    it('should return true for valid report tabs', () => {
+      expect(isValidReportTab('net-worth')).toBe(true);
+      expect(isValidReportTab('forecast')).toBe(true);
+      expect(isValidReportTab('income-vs-expense')).toBe(true);
+    });
+
+    it('should return false for invalid report tabs', () => {
+      expect(isValidReportTab('invalid-tab')).toBe(false);
+      expect(isValidReportTab('')).toBe(false);
+    });
+  });
+
+  describe('getDefaultReportTab', () => {
+    it('should return NetWorth as default', () => {
+      expect(getDefaultReportTab()).toBe(ReportKeys.NetWorth);
+    });
+  });
+
+  describe('urlToReportKey', () => {
+    it('should convert URL paths to report keys', () => {
+      expect(urlToReportKey('net-worth')).toBe(ReportKeys.NetWorth);
+      expect(urlToReportKey('inflow-outflow')).toBe(ReportKeys.InflowOutflow);
+      expect(urlToReportKey('spending-by-category')).toBe(ReportKeys.SpendingByCategory);
+      expect(urlToReportKey('spending-by-payee')).toBe(ReportKeys.SpendingByPayee);
+      expect(urlToReportKey('income-vs-expense')).toBe(ReportKeys.IncomeVsExpense);
+      expect(urlToReportKey('income-breakdown')).toBe(ReportKeys.IncomeBreakdown);
+      expect(urlToReportKey('balance-over-time')).toBe(ReportKeys.BalanceOverTime);
+      expect(urlToReportKey('outflow-over-time')).toBe(ReportKeys.OutflowOverTime);
+      expect(urlToReportKey('forecast')).toBe(ReportKeys.Forecast);
+    });
+
+    it('should return null for unknown URL paths', () => {
+      expect(urlToReportKey('unknown-path')).toBe(null);
+      expect(urlToReportKey('')).toBe(null);
+    });
+  });
+});

--- a/src/extension/features/toolkit-reports/utils/url-navigation.ts
+++ b/src/extension/features/toolkit-reports/utils/url-navigation.ts
@@ -1,0 +1,109 @@
+import { ReportKeys } from '../common/constants/report-types';
+
+export interface ToolkitReportsURLParams {
+  budgetId: string | null;
+  reportTab?: string | null;
+}
+
+export function isToolkitReportsURL(url: string): boolean {
+  return url.includes('#toolkit-reports');
+}
+
+export function parseToolkitReportsURL(url: string): ToolkitReportsURLParams | null {
+  try {
+    const urlObj = new URL(url);
+    const hash = urlObj.hash;
+
+    // Expected format: #toolkit-reports/{reportTab?}
+    if (!hash.startsWith('#toolkit-reports')) {
+      return null;
+    }
+
+    const hashParts = hash.substring(1).split('/'); // Remove # and split
+
+    const budgetId = getCurrentBudgetId();
+    const reportTab = hashParts[1] || null;
+
+    return {
+      budgetId,
+      reportTab,
+    };
+  } catch (error) {
+    console.error('Error parsing toolkit reports URL:', error);
+    return null;
+  }
+}
+
+export function buildToolkitReportsURL(reportTab?: string): string {
+  const budgetId = getCurrentBudgetId();
+
+  if (!budgetId) {
+    return window.location.href;
+  }
+
+  const baseURL = `${window.location.origin}/${budgetId}/budget`;
+  const hash = reportTab ? `#toolkit-reports/${reportTab}` : '#toolkit-reports';
+
+  return `${baseURL}${hash}`;
+}
+
+export function navigateToToolkitReports(reportTab?: string) {
+  // If no report tab is specified, get the last visited tab from storage
+  let targetReportTab = reportTab;
+  if (!targetReportTab) {
+    const { getToolkitStorageKey } = require('toolkit/extension/utils/toolkit');
+    const ACTIVE_REPORT_KEY = 'active-report';
+    targetReportTab = getToolkitStorageKey(ACTIVE_REPORT_KEY, getDefaultReportTab());
+  }
+
+  const newURL = buildToolkitReportsURL(targetReportTab);
+
+  // Use pushState to update the URL without triggering a page reload
+  window.history.pushState({}, '', newURL);
+
+  // Dispatch a custom event to notify components of the URL change
+  window.dispatchEvent(
+    new CustomEvent('toolkit-reports-url-changed', {
+      detail: { reportTab: targetReportTab },
+    }),
+  );
+}
+
+export function getCurrentBudgetId(): string | null {
+  try {
+    const pathParts = window.location.pathname.split('/').filter(Boolean);
+    // The budgetId is always the first part of the path
+    if (pathParts.length > 0) {
+      return pathParts[0];
+    }
+    return null;
+  } catch (error) {
+    console.error('Error getting current budget ID:', error);
+    return null;
+  }
+}
+
+export function isValidReportTab(reportTab: string): boolean {
+  return Object.values(ReportKeys).includes(reportTab as any);
+}
+
+export function getDefaultReportTab(): string {
+  return ReportKeys.NetWorth;
+}
+
+// Helper function to convert URL format back to report key
+export function urlToReportKey(urlPath: string): string | null {
+  const urlToKeyMap: Record<string, string> = {
+    'net-worth': ReportKeys.NetWorth,
+    'inflow-outflow': ReportKeys.InflowOutflow,
+    'spending-by-category': ReportKeys.SpendingByCategory,
+    'spending-by-payee': ReportKeys.SpendingByPayee,
+    'income-vs-expense': ReportKeys.IncomeVsExpense,
+    'income-breakdown': ReportKeys.IncomeBreakdown,
+    'balance-over-time': ReportKeys.BalanceOverTime,
+    'outflow-over-time': ReportKeys.OutflowOverTime,
+    forecast: ReportKeys.Forecast,
+  };
+
+  return urlToKeyMap[urlPath] || null;
+}


### PR DESCRIPTION
Issue (if applicable): N/A

**Explanation of Bugfix/Feature/Modification:**
- Implements URL navigation for Toolkit Reports, allowing direct linking to specific report tabs and browser navigation support.
- Adds utilities for parsing, building, and validating report URLs, updates report context provider to sync state with URLs, and integrates event handling for navigation changes.
- Includes tests for URL navigation utilities and documentation in README.

**Screenshots**
<img width="962" height="174" alt="Screenshot 2025-07-16 at 10 20 29 PM" src="https://github.com/user-attachments/assets/e540f8d8-2a4a-465d-9b6f-562416e5d2b5" />
<img width="977" height="178" alt="Screenshot 2025-07-16 at 10 20 21 PM" src="https://github.com/user-attachments/assets/b6e5cca3-68d3-4175-bf48-191bf9bfc4f6" />

