### PR TITLE
Add invoke method to the DisplayTotalMonthlyGoals feature class and h…

### DIFF
--- a/src/extension/features/budget/display-total-monthly-goals/index.jsx
+++ b/src/extension/features/budget/display-total-monthly-goals/index.jsx
@@ -36,6 +36,10 @@ export class DisplayTotalMonthlyGoals extends Feature {
     return true;
   }
 
+  invoke() {
+    this.addMonthlyGoalsOverview();
+  }
+
   destroy() {
     document.querySelector('.' + this.containerClass)?.remove();
   }
@@ -83,6 +87,10 @@ export class DisplayTotalMonthlyGoals extends Feature {
 
   getCreditActivity() {
     const budgetService = getBudgetService();
+    if (!budgetService?.budgetMonthDisplayItems) {
+      return 0;
+    }
+
     const category = budgetService.budgetMonthDisplayItems.find((item) => {
       return item.isCreditCardPaymentCategory;
     });


### PR DESCRIPTION
…andle undefined budget month display items

Issue (if applicable): #3628

**Explanation of Bugfix:**

This adds the missing invoke method that is required of all feature classes as well as a catch for when `budgetService?.budgetMonthDisplayItems` is falsy.

Note that I have not fully tested whether this comprehensively fixes the problem from #3628, as I need more information on how this feature is supposed to work to check if this truly fixes it. This code exists simply to address the more obvious problems ASAP.