### PR TITLE
Fix hide closed accounts

### DIFF
--- a/src/extension/features/general/hide-closed-accounts/HideClosedButton.tsx
+++ b/src/extension/features/general/hide-closed-accounts/HideClosedButton.tsx
@@ -17,13 +17,11 @@ export const HideClosedButton = ({ toggleHiddenState }: Props) => {
   };
 
   return (
-    <li onClick={toggleHidden} id="tk-hide-closed-accounts">
-      <button>
-        <svg className="ynab-new-icon" width="16" height="16">
-          <use href="#icon_sprite_lock"></use>
-        </svg>
-        {` ${label}`} Closed Accounts
-      </button>
-    </li>
+    <button onClick={toggleHidden} id="tk-hide-closed-accounts" className="menu-item js-menu-item">
+      <svg className="ynab-new-icon" width="16" height="16">
+        <use href="#icon_sprite_lock"></use>
+      </svg>
+      {` ${label}`} Closed Accounts
+    </button>
   );
 };

--- a/src/extension/features/general/hide-closed-accounts/index.css
+++ b/src/extension/features/general/hide-closed-accounts/index.css
@@ -1,3 +1,20 @@
 body.tk-hide-closed .sidebar .nav-accounts .nav-account.closed {
   display: none !important;
 }
+
+#tk-hide-closed-accounts {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  gap: 0.75rem;
+  border-radius: 0.25rem;
+}
+
+#tk-hide-closed-accounts:hover {
+  background-color: var(--backgroundSecondaryElevated);
+}
+#tk-hide-closed-accounts svg {
+  color: rgb(155, 156, 170);
+}

--- a/src/extension/features/general/hide-closed-accounts/index.tsx
+++ b/src/extension/features/general/hide-closed-accounts/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { componentAppend } from 'toolkit/extension/utils/react';
+import { componentAfter } from 'toolkit/extension/utils/react';
 import { Feature } from 'toolkit/extension/features/feature';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 import { HideClosedButton } from './HideClosedButton';
@@ -30,16 +30,16 @@ export class HideClosedAccounts extends Feature {
   }
 
   observe(changedNodes: Set<string>) {
-    if (changedNodes.has('modal-overlay active ynab-u ynab-new-settings-menu')) {
+    if (changedNodes.has('ynab-new-settings-menu')) {
       this.invoke();
     }
   }
 
   insertHideClosed(element: Element) {
     if ($('#tk-hide-closed-accounts').length === 0) {
-      componentAppend(
+      componentAfter(
         <HideClosedButton toggleHiddenState={this.setHiddenState} />,
-        element.getElementsByClassName('modal-list')[0],
+        element.getElementsByClassName('modal-select-import-from')[0],
       );
     }
   }

--- a/src/extension/features/general/hide-closed-accounts/index.tsx
+++ b/src/extension/features/general/hide-closed-accounts/index.tsx
@@ -12,7 +12,7 @@ export class HideClosedAccounts extends Feature {
   }
 
   shouldInvoke() {
-    return false;
+    return true;
   }
 
   invoke() {

--- a/src/extension/features/toolkit-reports/index.test.js
+++ b/src/extension/features/toolkit-reports/index.test.js
@@ -1,0 +1,80 @@
+jest.mock('toolkit/extension/features/feature');
+
+describe('ToolkitReports Feature Flag Tests', () => {
+  let ToolkitReports;
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // Mock ynabToolKit
+    global.ynabToolKit = {
+      options: {},
+    };
+
+    // Mock the utils module
+    jest.doMock('./utils/url-navigation', () => ({
+      navigateToToolkitReports: jest.fn(),
+      isToolkitReportsURL: jest.fn(),
+    }));
+
+    // Import the feature after mocking
+    ToolkitReports = require('./index').ToolkitReports;
+  });
+
+  describe('_isURLNavigationEnabled', () => {
+    let feature;
+
+    beforeEach(() => {
+      feature = new ToolkitReports();
+    });
+
+    it('should return true when ToolkitReportsURLNavigation is enabled', () => {
+      global.ynabToolKit.options.ToolkitReportsURLNavigation = true;
+      expect(feature._isURLNavigationEnabled()).toBe(true);
+    });
+
+    it('should return false when ToolkitReportsURLNavigation is disabled', () => {
+      global.ynabToolKit.options.ToolkitReportsURLNavigation = false;
+      expect(feature._isURLNavigationEnabled()).toBe(false);
+    });
+
+    it('should return false when ToolkitReportsURLNavigation is undefined', () => {
+      global.ynabToolKit.options.ToolkitReportsURLNavigation = undefined;
+      expect(feature._isURLNavigationEnabled()).toBe(false);
+    });
+
+    it('should return false when ynabToolKit.options is undefined', () => {
+      global.ynabToolKit.options = undefined;
+      expect(feature._isURLNavigationEnabled()).toBe(false);
+    });
+
+    it('should return false when ynabToolKit is undefined', () => {
+      global.ynabToolKit = undefined;
+      expect(feature._isURLNavigationEnabled()).toBe(false);
+    });
+  });
+
+  describe('Feature flag integration', () => {
+    let feature;
+
+    beforeEach(() => {
+      feature = new ToolkitReports();
+    });
+
+    it('should respect the feature flag setting', () => {
+      // Test with flag enabled
+      global.ynabToolKit.options.ToolkitReportsURLNavigation = true;
+      expect(feature._isURLNavigationEnabled()).toBe(true);
+
+      // Test with flag disabled
+      global.ynabToolKit.options.ToolkitReportsURLNavigation = false;
+      expect(feature._isURLNavigationEnabled()).toBe(false);
+    });
+
+    it('should default to false when setting is not present', () => {
+      delete global.ynabToolKit.options.ToolkitReportsURLNavigation;
+      expect(feature._isURLNavigationEnabled()).toBe(false);
+    });
+  });
+});

--- a/src/extension/features/toolkit-reports/url-navigation/index.js
+++ b/src/extension/features/toolkit-reports/url-navigation/index.js
@@ -1,0 +1,19 @@
+import { Feature } from 'toolkit/extension/features/feature';
+import { getToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
+
+export class ToolkitReportsURLNavigation extends Feature {
+  shouldInvoke() {
+    // Check if URL navigation is enabled in settings
+    return getToolkitStorageKey('ToolkitReportsURLNavigation', false);
+  }
+
+  invoke() {
+    // This feature doesn't need to do anything on its own
+    // The URL navigation functionality is handled by the main ToolkitReports feature
+    // This just acts as a gate to enable/disable that functionality
+  }
+
+  onRouteChanged() {
+    // No action needed
+  }
+}

--- a/src/extension/features/toolkit-reports/url-navigation/settings.js
+++ b/src/extension/features/toolkit-reports/url-navigation/settings.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'ToolkitReportsURLNavigation',
+  type: 'checkbox',
+  default: false,
+  section: 'toolkitReports',
+  title: 'Enable URL Navigation for Toolkit Reports',
+  description:
+    'Enable URL-based navigation for Toolkit Reports. This allows you to navigate directly to specific report tabs and share links to reports.',
+};

--- a/src/extension/features/toolkit-reports/utils/url-navigation.test.ts
+++ b/src/extension/features/toolkit-reports/utils/url-navigation.test.ts
@@ -179,14 +179,26 @@ describe('URL Navigation Utilities', () => {
       // Get the mocked function
       const toolkitUtils = require('toolkit/extension/utils/toolkit');
       mockGetToolkitStorageKey = toolkitUtils.getToolkitStorageKey;
+
+      // Use fake timers for testing debounced functions
+      jest.useFakeTimers();
     });
 
     afterEach(() => {
       jest.clearAllMocks();
+      jest.useRealTimers();
+
+      // Reset the isUpdatingFromEvent flag by advancing timers
+      jest.useFakeTimers();
+      jest.advanceTimersByTime(101);
+      jest.useRealTimers();
     });
 
-    it('should navigate with provided report tab', () => {
+    it('should navigate with provided report tab', async () => {
       navigateToToolkitReports('net-worth');
+
+      // Advance timers to trigger the debounced function and the setTimeout
+      jest.advanceTimersByTime(51);
 
       expect(mockPushState).toHaveBeenCalledWith(
         {},
@@ -202,10 +214,13 @@ describe('URL Navigation Utilities', () => {
       );
     });
 
-    it('should use stored report tab when none provided', () => {
+    it('should use stored report tab when none provided', async () => {
       mockGetToolkitStorageKey.mockReturnValue('stored-tab');
 
       navigateToToolkitReports();
+
+      // Advance timers to trigger the debounced function and the setTimeout
+      jest.advanceTimersByTime(51);
 
       expect(mockGetToolkitStorageKey).toHaveBeenCalledWith('active-report', 'net-worth');
       expect(mockPushState).toHaveBeenCalledWith(
@@ -221,10 +236,13 @@ describe('URL Navigation Utilities', () => {
       );
     });
 
-    it('should use default report tab when storage returns null', () => {
+    it('should use default report tab when storage returns null', async () => {
       mockGetToolkitStorageKey.mockReturnValue(null);
 
       navigateToToolkitReports();
+
+      // Advance timers to trigger the debounced function and the setTimeout
+      jest.advanceTimersByTime(51);
 
       expect(mockGetToolkitStorageKey).toHaveBeenCalledWith('active-report', 'net-worth');
       expect(mockPushState).toHaveBeenCalledWith(
@@ -240,10 +258,13 @@ describe('URL Navigation Utilities', () => {
       );
     });
 
-    it('should use default report tab when storage returns undefined', () => {
+    it('should use default report tab when storage returns undefined', async () => {
       mockGetToolkitStorageKey.mockReturnValue(undefined);
 
       navigateToToolkitReports();
+
+      // Advance timers to trigger the debounced function and the setTimeout
+      jest.advanceTimersByTime(51);
 
       expect(mockGetToolkitStorageKey).toHaveBeenCalledWith('active-report', 'net-worth');
       expect(mockPushState).toHaveBeenCalledWith(
@@ -259,8 +280,11 @@ describe('URL Navigation Utilities', () => {
       );
     });
 
-    it('should handle different report tabs correctly', () => {
+    it('should handle different report tabs correctly', async () => {
       navigateToToolkitReports('forecast');
+
+      // Advance timers to trigger the debounced function and the setTimeout
+      jest.advanceTimersByTime(51);
 
       expect(mockPushState).toHaveBeenCalledWith(
         {},


### PR DESCRIPTION
GitHub Issue: #3173

**Explanation of Bugfix/Feature/Modification:**
Fixes a few things:

1. Actually invokes the hide-closed-account setting logic by changing shouldInvoke to return true
2. Updates the logic in `observe` so that it properly detects when the account settings modal is open and injects the menu toggle button
3. Changes the positioning logic; the prior "append to `modal-list` subelement" logic didn't work because as far as I can tell nothing in the DOM matches that query. Now inserts the button at what feels like a reasonable place in the menu
4. Adds some more css to make the button fit in better in the menu

I think some very similar fixes are needed for Hide Help Button but will PR that separately
**Screenshots**
<img width="237" height="338" alt="image" src="https://github.com/user-attachments/assets/a6d3768e-50ef-4915-96f7-6209855fe0c7" />

