### PR TITLE
Fix hide closed accounts

### DIFF
--- a/src/extension/features/general/hide-closed-accounts/HideClosedButton.tsx
+++ b/src/extension/features/general/hide-closed-accounts/HideClosedButton.tsx
@@ -17,13 +17,11 @@ export const HideClosedButton = ({ toggleHiddenState }: Props) => {
   };
 
   return (
-    <li onClick={toggleHidden} id="tk-hide-closed-accounts">
-      <button>
-        <svg className="ynab-new-icon" width="16" height="16">
-          <use href="#icon_sprite_lock"></use>
-        </svg>
-        {` ${label}`} Closed Accounts
-      </button>
-    </li>
+    <button onClick={toggleHidden} id="tk-hide-closed-accounts" className="menu-item js-menu-item">
+      <svg className="ynab-new-icon" width="16" height="16">
+        <use href="#icon_sprite_lock"></use>
+      </svg>
+      {` ${label}`} Closed Accounts
+    </button>
   );
 };

--- a/src/extension/features/general/hide-closed-accounts/index.css
+++ b/src/extension/features/general/hide-closed-accounts/index.css
@@ -1,3 +1,20 @@
 body.tk-hide-closed .sidebar .nav-accounts .nav-account.closed {
   display: none !important;
 }
+
+#tk-hide-closed-accounts {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  gap: 0.75rem;
+  border-radius: 0.25rem;
+}
+
+#tk-hide-closed-accounts:hover {
+  background-color: var(--backgroundSecondaryElevated);
+}
+#tk-hide-closed-accounts svg {
+  color: rgb(155, 156, 170);
+}

--- a/src/extension/features/general/hide-closed-accounts/index.tsx
+++ b/src/extension/features/general/hide-closed-accounts/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { componentAppend } from 'toolkit/extension/utils/react';
+import { componentAfter } from 'toolkit/extension/utils/react';
 import { Feature } from 'toolkit/extension/features/feature';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 import { HideClosedButton } from './HideClosedButton';
@@ -30,16 +30,16 @@ export class HideClosedAccounts extends Feature {
   }
 
   observe(changedNodes: Set<string>) {
-    if (changedNodes.has('modal-overlay active ynab-u ynab-new-settings-menu')) {
+    if (changedNodes.has('ynab-new-settings-menu')) {
       this.invoke();
     }
   }
 
   insertHideClosed(element: Element) {
     if ($('#tk-hide-closed-accounts').length === 0) {
-      componentAppend(
+      componentAfter(
         <HideClosedButton toggleHiddenState={this.setHiddenState} />,
-        element.getElementsByClassName('modal-list')[0],
+        element.getElementsByClassName('modal-select-import-from')[0],
       );
     }
   }

--- a/src/extension/features/general/hide-closed-accounts/index.tsx
+++ b/src/extension/features/general/hide-closed-accounts/index.tsx
@@ -12,7 +12,7 @@ export class HideClosedAccounts extends Feature {
   }
 
   shouldInvoke() {
-    return false;
+    return true;
   }
 
   invoke() {


### PR DESCRIPTION
GitHub Issue: #3173

**Explanation of Bugfix/Feature/Modification:**
Fixes a few things:

1. Actually invokes the hide-closed-account setting logic by changing shouldInvoke to return true
2. Updates the logic in `observe` so that it properly detects when the account settings modal is open and injects the menu toggle button
3. Changes the positioning logic; the prior "append to `modal-list` subelement" logic didn't work because as far as I can tell nothing in the DOM matches that query. Now inserts the button at what feels like a reasonable place in the menu
4. Adds some more css to make the button fit in better in the menu

I think some very similar fixes are needed for Hide Help Button but will PR that separately
**Screenshots**
<img width="237" height="338" alt="image" src="https://github.com/user-attachments/assets/a6d3768e-50ef-4915-96f7-6209855fe0c7" />

