### PR TITLE
Fix Hide Help Button menu stuff

### DIFF
--- a/src/extension/features/general/hide-help/HideHelpButton.tsx
+++ b/src/extension/features/general/hide-help/HideHelpButton.tsx
@@ -17,13 +17,11 @@ export const HideHelpButton = ({ toggleHiddenState }: Props) => {
   };
 
   return (
-    <li onClick={toggleHidden} id="tk-hide-help">
-      <button>
-        <svg className="ynab-new-icon" width="16" height="16">
-          <use href="#icon_sprite_question_mark_circle"></use>
-        </svg>
-        {` ${label}`} Help Button
-      </button>
-    </li>
+    <button onClick={toggleHidden} id="tk-hide-help">
+      <svg className="ynab-new-icon" width="16" height="16">
+        <use href="#icon_sprite_question_mark_circle"></use>
+      </svg>
+      {` ${label}`} Help Button
+    </button>
   );
 };

--- a/src/extension/features/general/hide-help/index.css
+++ b/src/extension/features/general/hide-help/index.css
@@ -5,3 +5,19 @@ body.toolkit-hide-help .chat-widget {
 body.toolkit-hide-help #beacon-container {
   display: none !important;
 }
+#tk-hide-help {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  gap: 0.75rem;
+  border-radius: 0.25rem;
+}
+
+#tk-hide-help:hover {
+  background-color: var(--backgroundSecondaryElevated);
+}
+#tk-hide-help svg {
+  color: rgb(155, 156, 170);
+}

--- a/src/extension/features/general/hide-help/index.tsx
+++ b/src/extension/features/general/hide-help/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { componentAppend } from 'toolkit/extension/utils/react';
+import { componentAfter } from 'toolkit/extension/utils/react';
 import { Feature } from 'toolkit/extension/features/feature';
 import { getToolkitStorageKey, setToolkitStorageKey } from 'toolkit/extension/utils/toolkit';
 import { HideHelpButton } from './HideHelpButton';
@@ -20,9 +20,9 @@ export class HideHelp extends Feature {
       return;
     }
 
-    componentAppend(
+    componentAfter(
       <HideHelpButton toggleHiddenState={this.setHiddenState} />,
-      element.getElementsByClassName('modal-list')[0],
+      element.getElementsByClassName('modal-select-import-from')[0],
     );
   }
 
@@ -39,7 +39,7 @@ export class HideHelp extends Feature {
   }
 
   observe(nodes: Set<string>) {
-    if (nodes.has('modal-overlay active ynab-u ynab-new-settings-menu')) {
+    if (nodes.has('ynab-new-settings-menu')) {
       this.invoke();
     }
   }


### PR DESCRIPTION
GitHub Issue (if applicable): #3637

**Explanation of Bugfix/Feature/Modification:**
Makes a toggle for the Hide Help Button option correctly appear in the User Menu.

Sister PR to [similar fix for Hide Closed Accounts](https://github.com/toolkit-for-ynab/toolkit-for-ynab/pull/3636)

This fixes some logic around both the `observe` function looking for the existence/modification of the menu, and the logic for injecting the `HideHelpButton` component into it once observed

**Screenshots**
<img width="215" height="344" alt="image" src="https://github.com/user-attachments/assets/8b77299b-7ed6-4344-8a61-c2b8058df5ba" />

