### PR TITLE
Use a specific selector for uncleared-account-highlight

### DIFF
--- a/src/extension/features/general/uncleared-account-highlight/index.css
+++ b/src/extension/features/general/uncleared-account-highlight/index.css
@@ -9,5 +9,8 @@
 .nav-accounts .nav-account-icons-right {
   display: flex;
   align-items: center;
+}
+
+.nav-account-row .nav-account-icons.nav-account-icons-right {
   width: 2rem;
 }


### PR DESCRIPTION
The change in upstream YNAB moved their CSS selector to a more specific matching rule. Update ours so it properly overrides instead of being ignored.

Fixes: #3655

Updated rendering:
<img width="83" height="242" alt="image" src="https://github.com/user-attachments/assets/bf0e4c4c-cfa8-45a7-92c3-a13ae6c732d0" />
