### PR TITLE
fix: update class name for show-available-after-savings

### DIFF
--- a/src/extension/features/budget/show-available-after-savings/index.js
+++ b/src/extension/features/budget/show-available-after-savings/index.js
@@ -22,10 +22,10 @@ export class ShowAvailableAfterSavings extends Feature {
   handleBudgetBreakdown() {
     this.removeAvailableAfterSavings();
 
-    const $budgetBreakdownMonthlyTotals = $('.budget-breakdown-monthly-totals');
-    if (!$budgetBreakdownMonthlyTotals.length) return;
+    const $budgetBreakdown = $('.budget-breakdown');
+    if (!$budgetBreakdown.length) return;
 
-    this.showAvailableAfterSavings($budgetBreakdownMonthlyTotals);
+    this.showAvailableAfterSavings($budgetBreakdown);
   }
 
   showAvailableAfterSavings(context) {


### PR DESCRIPTION
GitHub Issue (if applicable): #3626

**Explanation of Bugfix/Feature/Modification:**
The `showAvailableAfterSavings` function was no longer being called, as a result of a class name update. Fixed the class name in local dev and confirmed expected behavior (screenshot below).

**Screenshots**
<img width="265" height="382" alt="Screenshot 2026-01-16 at 15 08 04" src="https://github.com/user-attachments/assets/7f6c38ed-520c-48c9-aa87-dc8fd6dbf7f7" />
