### PR TITLE
feat: enable category filtering in outflow over time report

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/report-context/reports-provider.tsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/reports-provider.tsx
@@ -42,7 +42,7 @@ const REPORT_COMPONENTS: SelectedReportContextPropType[] = [
     component: OutflowOverTime,
     key: ReportKeys.OutflowOverTime,
     filterSettings: {
-      disableCategoryFilter: true,
+      disableCategoryFilter: false,
       includeTrackingAccounts: true,
     },
   },

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
@@ -15,9 +15,9 @@ import { AdditionalReportSettings } from 'toolkit/extension/features/toolkit-rep
 import { ReportContextType } from '../../common/components/report-context';
 
 export const OutflowOverTimeComponent = ({
-  allReportableTransactions,
+  filteredTransactions,
   filters,
-}: Pick<ReportContextType, 'allReportableTransactions' | 'filters'>) => {
+}: Pick<ReportContextType, 'filteredTransactions' | 'filters'>) => {
   const [outflowSeries, setOutflowSeries] = useState<Highcharts.SeriesLineOptions[]>([]);
 
   // Using CumulativeSum will show a growing trendline over the dates.
@@ -47,7 +47,7 @@ export const OutflowOverTimeComponent = ({
         calculateOutflow(
           groupTransactions(
             filterTransactions(
-              filterTransactionsByDate(allReportableTransactions, fromDate, toDate),
+              filterTransactionsByDate(filteredTransactions, fromDate, toDate),
               includeInflows,
               filterOutAccounts,
             ),
@@ -55,7 +55,7 @@ export const OutflowOverTimeComponent = ({
         ),
       ),
     );
-  }, [allReportableTransactions, filters, cumulativeSum, includeInflows]);
+  }, [filteredTransactions, filters, cumulativeSum, includeInflows]);
 
   return (
     <div className="tk-flex tk-flex-column tk-flex-grow">

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/container.ts
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/container.ts
@@ -7,7 +7,7 @@ import { OutflowOverTimeComponent } from './OutflowOverTime';
 const mapReportContextToProps = (context: ReportContextType) => {
   return {
     filters: context.filters,
-    allReportableTransactions: context.allReportableTransactions,
+    filteredTransactions: context.filteredTransactions,
   };
 };
 export const OutflowOverTime = withReportContext(mapReportContextToProps)(OutflowOverTimeComponent);


### PR DESCRIPTION
GitHub Issue (if applicable): #3660 

**Explanation of Bugfix/Feature/Modification:**

This PR adds category filtering support to the **Outflow Over Time** report, allowing users to filter the report by specific categories (e.g., Groceries, Dining, etc.) to compare spending patterns across months for selected categories only.

### Changes Made:

1. **Enabled Category Filter** ([reports-provider.tsx](src/extension/features/toolkit-reports/common/components/report-context/reports-provider.tsx#L45))
   - Changed `disableCategoryFilter: true` → `false` for the OutflowOverTime report
   - This enables the "All Categories" / "Some Categories" button in the report filter UI

2. **Updated Container** ([container.ts](src/extension/features/toolkit-reports/pages/outflow-over-time/container.ts))
   - Changed to use `filteredTransactions` instead of `allReportableTransactions`
   - This ensures the component receives transactions that are already filtered by the selected categories

3. **Updated Component** ([OutflowOverTime.tsx](src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx))
   - Updated props to accept `filteredTransactions` instead of `allReportableTransactions`
   - Updated the dependency array in the useEffect hook

### Why This Change:

Previously, the Outflow Over Time report showed spending for ALL categories combined, making it impossible to analyze specific spending patterns (e.g., "How has my grocery spending changed month-to-month and day-to-day?"). This change aligns the report with other reports like Spending by Category and Income vs. Expense, which already support category filtering.

### How It Works:

The report context provider already handles category filtering logic. By setting `disableCategoryFilter: false` and using `filteredTransactions`, the Outflow Over Time report now automatically respects user-selected category filters, just like other reports in the toolkit.

**Screenshots**

Before: The category filter button was disabled (grayed out)
<img width="517" height="329" alt="Screenshot 2026-02-04 at 9 29 54 AM" src="https://github.com/user-attachments/assets/e08667f6-27b8-4d8f-a467-4fb7e4c061f6" />

After: Users can now click "All Categories" to select specific categories, and the graph updates to show only outflow data for the selected categories

All categories selected:
<img width="1017" height="883" alt="Screenshot 2026-02-04 at 9 28 06 AM" src="https://github.com/user-attachments/assets/a1940452-09a3-42ac-93ec-13c7fea14417" />

Only one category selected:
<img width="1026" height="886" alt="Screenshot 2026-02-04 at 9 31 04 AM" src="https://github.com/user-attachments/assets/a699f0d3-9f6c-4d38-a16d-a451f83e8c4f" />

