### PR TITLE
fix: sort transactions before calculating week range in forecast report

### DIFF
--- a/src/extension/features/toolkit-reports/pages/forecast/functions.ts
+++ b/src/extension/features/toolkit-reports/pages/forecast/functions.ts
@@ -15,8 +15,14 @@ function range(start: number, end: number) {
 function makeWeeks(transactions: YNABTransaction[]): Record<number, number> {
   if (!transactions?.length) return [];
 
-  const startWeek = getWeekNumber(transactions[0].date.toUTCMoment());
-  const endWeek = getWeekNumber(transactions[transactions.length - 1].date.toUTCMoment());
+  const sortedTransactions = [...transactions].sort((a, b) => {
+    return a.date.toUTCMoment().valueOf() - b.date.toUTCMoment().valueOf();
+  });
+
+  const startWeek = getWeekNumber(sortedTransactions[0].date.toUTCMoment());
+  const endWeek = getWeekNumber(
+    sortedTransactions[sortedTransactions.length - 1].date.toUTCMoment(),
+  );
 
   return range(startWeek, endWeek).reduce((accumulator, current) => {
     const matches = transactions.filter(


### PR DESCRIPTION
GitHub Issue: #3665 & #3668

**Explanation of Bugfix/Feature/Modification:**
Resolves `RangeError: Invalid array length` when rendering the Forecast report where the `range()` function was receiving a negative value from `makeWeeks()`, which assumed YNAB always sends transactions in chronological order.

**Changes:**
I updated `makeWeeks()` to sort the transactions by date before it tries to calculate the start and end weeks. This ensures the date range is always valid so `range()` doesn't get a negative number.

**Error Reference:**
RangeError: Invalid array length at range (functions.ts:12:14)
at makeWeeks (functions.ts:21:10)
at generateForecasts (functions.ts:56:17)
at component.tsx:22:43