### PR TITLE
feat: add forecasting and scheduled transaction context to Outflow Over Time toolkit report

### DIFF
--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import {
+  calculateAverageDailyForecast,
   calculateCumulativeOutflowPerDate,
   calculateOutflowPerDate,
   filterTransactions,
@@ -16,11 +18,12 @@ import { ReportContextType } from '../../common/components/report-context';
 
 export const OutflowOverTimeComponent = ({
   filteredTransactions,
+  allReportableTransactions,
   allScheduledTransactions,
   filters,
 }: Pick<
   ReportContextType,
-  'filteredTransactions' | 'allScheduledTransactions' | 'filters'
+  'filteredTransactions' | 'allReportableTransactions' | 'allScheduledTransactions' | 'filters'
 >) => {
   const [outflowSeries, setOutflowSeries] = useState<Highcharts.SeriesLineOptions[]>([]);
 
@@ -38,6 +41,13 @@ export const OutflowOverTimeComponent = ({
 
   // Show forecast overlays dotted series for scheduled transactions.
   const [showForecast, setShowForecast] = useLocalStorage('outflow-over-time-showForecast', false);
+
+  // Show average forecast based on historical spending in the last N months.
+  const [showAverageForecast, setShowAverageForecast] = useLocalStorage(
+    'outflow-over-time-showAverageForecast',
+    false,
+  );
+  const [averageMonths, setAverageMonths] = useLocalStorage('outflow-over-time-averageMonths', 3);
 
   useEffect(() => {
     if (!filters) return;
@@ -60,6 +70,8 @@ export const OutflowOverTimeComponent = ({
         ),
       ),
     );
+
+    const combined = [...regularSeries];
 
     if (showForecast) {
       // Scheduled sub-transactions (split children) carry per-category amounts but not the
@@ -105,17 +117,52 @@ export const OutflowOverTimeComponent = ({
           })
         : forecastSeries;
 
-      setOutflowSeries([...regularSeries, ...adjustedForecastSeries]);
-    } else {
-      setOutflowSeries(regularSeries);
+      combined.push(...adjustedForecastSeries);
     }
+
+    if (showAverageForecast) {
+      const avgData = calculateAverageDailyForecast(
+        filterTransactions(allReportableTransactions, includeInflows, filterOutAccounts),
+        averageMonths,
+        moment(),
+      );
+
+      if (avgData.length > 0) {
+        let cumulativeOffset = 0;
+        if (cumulativeSum) {
+          const currentMonthName = moment().format('MMM YYYY');
+          const actualSeries = regularSeries.find((s) => s.name === currentMonthName);
+          const actualData = actualSeries?.data as Array<{ x: number; y: number }> | undefined;
+          cumulativeOffset = actualData?.length ? actualData[actualData.length - 1].y : 0;
+        }
+
+        let runningTotal = cumulativeOffset;
+        combined.push({
+          name: `${averageMonths}-mo average`,
+          type: 'line',
+          dashStyle: 'LongDash',
+          data: avgData.map(({ day, value }) => {
+            if (cumulativeSum) {
+              runningTotal += value;
+              return { x: day, y: runningTotal, custom: [] };
+            }
+            return { x: day, y: value, custom: [] };
+          }),
+        });
+      }
+    }
+
+    setOutflowSeries(combined);
   }, [
     filteredTransactions,
+    allReportableTransactions,
     allScheduledTransactions,
     filters,
     cumulativeSum,
     includeInflows,
     showForecast,
+    showAverageForecast,
+    averageMonths,
   ]);
 
   return (
@@ -139,6 +186,31 @@ export const OutflowOverTimeComponent = ({
           label="Show forecast (scheduled transactions)"
           onChange={() => setShowForecast(!showForecast)}
         />
+        <LabeledCheckbox
+          id="tk-outflow-over-time-show-average-forecast-option"
+          checked={showAverageForecast}
+          label="Show average forecast (historical spending)"
+          onChange={() => setShowAverageForecast(!showAverageForecast)}
+        />
+        {showAverageForecast && (
+          <div
+            className="tk-flex tk-align-items-center tk-gap-small"
+            style={{ marginLeft: '24px' }}
+          >
+            <label htmlFor="tk-outflow-over-time-average-months">Months to average:</label>
+            <select
+              id="tk-outflow-over-time-average-months"
+              value={averageMonths}
+              onChange={(e) => setAverageMonths(parseInt(e.target.value, 10))}
+            >
+              {Array.from({ length: 12 }, (_, i) => i + 1).map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
       </AdditionalReportSettings>
       <OutflowGraph series={outflowSeries} />
     </div>

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowOverTime.tsx
@@ -16,8 +16,12 @@ import { ReportContextType } from '../../common/components/report-context';
 
 export const OutflowOverTimeComponent = ({
   filteredTransactions,
+  allScheduledTransactions,
   filters,
-}: Pick<ReportContextType, 'filteredTransactions' | 'filters'>) => {
+}: Pick<
+  ReportContextType,
+  'filteredTransactions' | 'allScheduledTransactions' | 'filters'
+>) => {
   const [outflowSeries, setOutflowSeries] = useState<Highcharts.SeriesLineOptions[]>([]);
 
   // Using CumulativeSum will show a growing trendline over the dates.
@@ -32,6 +36,9 @@ export const OutflowOverTimeComponent = ({
     true,
   );
 
+  // Show forecast overlays dotted series for scheduled transactions.
+  const [showForecast, setShowForecast] = useLocalStorage('outflow-over-time-showForecast', false);
+
   useEffect(() => {
     if (!filters) return;
     const filterOutAccounts = filters.accountFilterIds;
@@ -42,20 +49,74 @@ export const OutflowOverTimeComponent = ({
       ? calculateCumulativeOutflowPerDate
       : calculateOutflowPerDate;
 
-    setOutflowSeries(
-      toHighchartsSeries(
+    const regularSeries = toHighchartsSeries(
+      calculateOutflow(
+        groupTransactions(
+          filterTransactions(
+            filterTransactionsByDate(filteredTransactions, fromDate, toDate),
+            includeInflows,
+            filterOutAccounts,
+          ),
+        ),
+      ),
+    );
+
+    if (showForecast) {
+      // Scheduled sub-transactions (split children) carry per-category amounts but not the
+      // parent's recurrence frequency, while the split parent carries the total amount (which
+      // would double-count against its own children). Summing amounts only needs leaf rows.
+      const leafScheduledTransactions = allScheduledTransactions.filter(
+        (transaction) => !transaction.isSplit,
+      );
+
+      const forecastSeries = toHighchartsSeries(
         calculateOutflow(
           groupTransactions(
             filterTransactions(
-              filterTransactionsByDate(filteredTransactions, fromDate, toDate),
+              filterTransactionsByDate(leafScheduledTransactions, fromDate, toDate),
               includeInflows,
               filterOutAccounts,
             ),
           ),
         ),
-      ),
-    );
-  }, [filteredTransactions, filters, cumulativeSum, includeInflows]);
+        { dashStyle: 'ShortDot', nameSuffix: ' (Scheduled)' },
+      );
+
+      // In cumulative mode, offset each forecast series so it continues from
+      // where the actual series for that month ends.
+      const adjustedForecastSeries = cumulativeSum
+        ? forecastSeries.map((series) => {
+            const monthName = (series.name as string).replace(' (Scheduled)', '');
+            const actualSeries = regularSeries.find((s) => s.name === monthName);
+            const lastActualData = actualSeries?.data as
+              | Array<{ x: number; y: number }>
+              | undefined;
+            const offset =
+              lastActualData && lastActualData.length > 0
+                ? lastActualData[lastActualData.length - 1].y
+                : 0;
+            if (offset === 0) return series;
+            return {
+              ...series,
+              data: (series.data as Array<{ x: number; y: number; custom: unknown[] }>).map(
+                (point) => ({ ...point, y: point.y + offset }),
+              ),
+            };
+          })
+        : forecastSeries;
+
+      setOutflowSeries([...regularSeries, ...adjustedForecastSeries]);
+    } else {
+      setOutflowSeries(regularSeries);
+    }
+  }, [
+    filteredTransactions,
+    allScheduledTransactions,
+    filters,
+    cumulativeSum,
+    includeInflows,
+    showForecast,
+  ]);
 
   return (
     <div className="tk-flex tk-flex-column tk-flex-grow">
@@ -71,6 +132,12 @@ export const OutflowOverTimeComponent = ({
           checked={includeInflows}
           label="Include inflows which are not in category 'Inflow: Ready to Assign'"
           onChange={() => setIncludeInflows(!includeInflows)}
+        />
+        <LabeledCheckbox
+          id="tk-outflow-over-time-show-forecast-option"
+          checked={showForecast}
+          label="Show forecast (scheduled transactions)"
+          onChange={() => setShowForecast(!showForecast)}
         />
       </AdditionalReportSettings>
       <OutflowGraph series={outflowSeries} />

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/container.ts
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/container.ts
@@ -8,6 +8,7 @@ const mapReportContextToProps = (context: ReportContextType) => {
   return {
     filters: context.filters,
     filteredTransactions: context.filteredTransactions,
+    allReportableTransactions: context.allReportableTransactions,
     allScheduledTransactions: context.allScheduledTransactions,
   };
 };

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/container.ts
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/container.ts
@@ -8,6 +8,7 @@ const mapReportContextToProps = (context: ReportContextType) => {
   return {
     filters: context.filters,
     filteredTransactions: context.filteredTransactions,
+    allScheduledTransactions: context.allScheduledTransactions,
   };
 };
 export const OutflowOverTime = withReportContext(mapReportContextToProps)(OutflowOverTimeComponent);

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.test.js
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.test.js
@@ -4,6 +4,7 @@ import {
   calculateOutflowPerDate,
   calculateCumulativeOutflowPerDate,
   toHighchartsSeries,
+  calculateAverageDailyForecast,
 } from './utils';
 import moment from 'moment';
 
@@ -210,6 +211,122 @@ describe('Utils', () => {
       ];
 
       expect(toHighchartsSeries(transactions)).toEqual(excpected);
+    });
+
+    it('should append nameSuffix to each series name', () => {
+      const transactions = { '2022-01': { 4: { value: 100, transactions: [] } } };
+      const result = toHighchartsSeries(transactions, { nameSuffix: ' (Scheduled)' });
+      expect(result[0].name).toBe('Jan 2022 (Scheduled)');
+    });
+
+    it('should apply dashStyle to each series', () => {
+      const transactions = { '2022-01': { 4: { value: 100, transactions: [] } } };
+      const result = toHighchartsSeries(transactions, { dashStyle: 'ShortDot' });
+      expect(result[0].dashStyle).toBe('ShortDot');
+    });
+
+    it('should apply both nameSuffix and dashStyle together', () => {
+      const transactions = { '2022-01': { 4: { value: 100, transactions: [] } } };
+      const result = toHighchartsSeries(transactions, {
+        nameSuffix: ' (Scheduled)',
+        dashStyle: 'LongDash',
+      });
+      expect(result[0].name).toBe('Jan 2022 (Scheduled)');
+      expect(result[0].dashStyle).toBe('LongDash');
+    });
+  });
+
+  describe('calculateAverageDailyForecast', () => {
+    // Helpers — mirror the shape the real YNAB objects expose to these functions.
+    const tx = (month, isoDate, outflow, inflow = 0) => ({
+      month,
+      outflow,
+      inflow,
+      date: { toUTCMoment: () => moment(isoDate) },
+    });
+
+    // Anchor: March 29 2024 → 2 days remaining (days 30 and 31).
+    // Feb 2024 has 29 days (leap year); last 2 = Feb 28 & Feb 29.
+    // Jan 2024 has 31 days;            last 2 = Jan 30 & Jan 31.
+    const TODAY = moment('2024-03-29');
+
+    it('should return an empty array when today is the last day of the month', () => {
+      expect(calculateAverageDailyForecast([], 3, moment('2024-03-31'))).toEqual([]);
+    });
+
+    it('should return one entry per remaining day with the correct day numbers', () => {
+      const result = calculateAverageDailyForecast([], 1, TODAY);
+      expect(result).toHaveLength(2);
+      expect(result[0].day).toBe(30);
+      expect(result[1].day).toBe(31);
+    });
+
+    it('should return zero values when no lookback months have transactions', () => {
+      const result = calculateAverageDailyForecast([], 3, TODAY);
+      expect(result.every((r) => r.value === 0)).toBe(true);
+    });
+
+    it('should return per-day spending from a single lookback month', () => {
+      const transactions = [
+        tx('2024-02', '2024-02-28', 100), // position 0 → day 30
+        tx('2024-02', '2024-02-29', 200), // position 1 → day 31
+      ];
+      const result = calculateAverageDailyForecast(transactions, 1, TODAY);
+      expect(result[0]).toEqual({ day: 30, value: 100 });
+      expect(result[1]).toEqual({ day: 31, value: 200 });
+    });
+
+    it('should average spending across multiple lookback months', () => {
+      const transactions = [
+        tx('2024-02', '2024-02-28', 100), // position 0
+        tx('2024-02', '2024-02-29', 200), // position 1
+        tx('2024-01', '2024-01-30', 300), // position 0
+        tx('2024-01', '2024-01-31', 400), // position 1
+      ];
+      const result = calculateAverageDailyForecast(transactions, 2, TODAY);
+      expect(result[0]).toEqual({ day: 30, value: (100 + 300) / 2 });
+      expect(result[1]).toEqual({ day: 31, value: (200 + 400) / 2 });
+    });
+
+    it('should skip lookback months with no transactions entirely', () => {
+      // Only Feb has data; Jan is empty and must not dilute the average.
+      const transactions = [tx('2024-02', '2024-02-28', 100), tx('2024-02', '2024-02-29', 200)];
+      const result = calculateAverageDailyForecast(transactions, 2, TODAY);
+      // Average is over 1 month, not 2.
+      expect(result[0]).toEqual({ day: 30, value: 100 });
+      expect(result[1]).toEqual({ day: 31, value: 200 });
+    });
+
+    it('should count days with no transactions within a valid month as zero', () => {
+      // Feb has a transaction on Feb 29 only; Feb 28 (position 0) is $0.
+      const transactions = [tx('2024-02', '2024-02-29', 200)];
+      const result = calculateAverageDailyForecast(transactions, 1, TODAY);
+      expect(result[0]).toEqual({ day: 30, value: 0 });
+      expect(result[1]).toEqual({ day: 31, value: 200 });
+    });
+
+    it('should compute net spending as outflow minus inflow', () => {
+      const transactions = [
+        tx('2024-02', '2024-02-28', 0), // position 0 — no spend
+        tx('2024-02', '2024-02-29', 300, 50), // position 1 — net 250
+      ];
+      const result = calculateAverageDailyForecast(transactions, 1, TODAY);
+      expect(result[0]).toEqual({ day: 30, value: 0 });
+      expect(result[1]).toEqual({ day: 31, value: 250 });
+    });
+
+    it('should handle a short lookback month gracefully (fewer days than daysRemaining)', () => {
+      // today = Jan 31 2024 → daysRemaining = 0. Use Jan 30 instead.
+      // today = March 3 → daysRemaining = 28. Feb 2024 has 29 days → histStartDay = 2.
+      // All 28 positions should map to valid Feb days (Feb 2–29).
+      const today = moment('2024-03-03');
+      const transactions = [tx('2024-02', '2024-02-29', 100)];
+      const result = calculateAverageDailyForecast(transactions, 1, today);
+      expect(result).toHaveLength(28);
+      // Position 27 (last) → histDay = 2 + 27 = 29 → Feb 29
+      expect(result[27]).toEqual({ day: 31, value: 100 });
+      // All other positions have no transactions → zero
+      expect(result.slice(0, 27).every((r) => r.value === 0)).toBe(true);
     });
   });
 });

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
@@ -8,6 +8,15 @@ declare module 'moment' {
   }
 }
 
+/**
+ * Filter transactions to only outflows, and optionally non-Ready to Assign inflows.
+ * Transfers are kept only when the counterpart account is itself filtered out
+ * (i.e. the transfer leaves the visible account set).
+ * @param transactions The transactions to filter.
+ * @param includeInflows When true, inflows not categorised as "Inflow: Ready to Assign" are included.
+ * @param filterOutAccounts Account IDs whose transactions should be excluded.
+ * @returns Filtered transactions.
+ */
 export function filterTransactions(
   transactions: YNABTransaction[],
   includeInflows: boolean,
@@ -56,6 +65,11 @@ export function filterTransactionsByDate(
 
 type GroupedTransactions = Record<string, Record<string, YNABTransaction[]>>;
 
+/**
+ * Group transactions into a two-level map of month key → day-of-month → transactions.
+ * @param transactions The transactions to group.
+ * @returns A record keyed by 'YYYY-MM', whose values are records keyed by day-of-month.
+ */
 export function groupTransactions(transactions: YNABTransaction[]) {
   const groupedByMonth = groupBy(transactions, 'month');
   const groupedByMonthAndDate: GroupedTransactions = {};
@@ -74,6 +88,11 @@ interface OutflowData {
   value: number;
 }
 
+/**
+ * Compute the net outflow (outflow minus inflow) for each day within each month.
+ * @param transactions Grouped transactions produced by {@link groupTransactions}.
+ * @returns A two-level record of month key → day-of-month → OutflowData.
+ */
 export function calculateOutflowPerDate(transactions: GroupedTransactions) {
   return mapValues(transactions, (monthData) =>
     mapValues(monthData, (dateData): OutflowData => {
@@ -91,6 +110,12 @@ export function calculateOutflowPerDate(transactions: GroupedTransactions) {
   );
 }
 
+/**
+ * Compute a running cumulative net outflow per day within each month.
+ * Each day's value is the sum of all net outflows from day 1 through that day.
+ * @param transactions Grouped transactions produced by {@link groupTransactions}.
+ * @returns A two-level record of month key → day-of-month → cumulative OutflowData.
+ */
 export function calculateCumulativeOutflowPerDate(transactions: GroupedTransactions) {
   const netOutflowByDate = calculateOutflowPerDate(transactions);
 
@@ -113,6 +138,76 @@ export function calculateCumulativeOutflowPerDate(transactions: GroupedTransacti
   });
 }
 
+/**
+ * Forecast the average daily spending for the remaining days of the current month
+ * by examining the same positional window (last N calendar days) across recent
+ * historical months.
+ *
+ * For each lookback month, the last `daysRemaining` days of that month are
+ * examined.
+ * Months with no transactions at all are skipped to avoid diluting the average
+ * with periods that predate YNAB tracking.
+ *
+ * @param transactions All reportable transactions, filtered for accounts and inflows
+ *   but NOT filtered by the report date range (lookback needs unrestricted history).
+ * @param lookbackMonths Number of historical months to average over (1–12).
+ * @param today The current date, used to determine days remaining and the lookback window.
+ * @returns An array of `{ day, value }` pairs where `day` is the calendar day in the
+ *   current month and `value` is the average net outflow for that positional slot.
+ *   Returns an empty array when today is the last day of the month.
+ */
+export function calculateAverageDailyForecast(
+  transactions: YNABTransaction[],
+  lookbackMonths: number,
+  today: Moment,
+): Array<{ day: number; value: number }> {
+  const currentDay = today.date();
+  const daysInCurrentMonth = today.daysInMonth();
+  const daysRemaining = daysInCurrentMonth - currentDay;
+
+  if (daysRemaining === 0) return [];
+
+  // For each positional slot (0 = first remaining day), collect daily spending from historical months.
+  const spendingByPosition: number[][] = Array.from({ length: daysRemaining }, () => []);
+
+  for (let i = 1; i <= lookbackMonths; i++) {
+    const hist = today.clone().subtract(i, 'months');
+    const histMonthKey = hist.format('YYYY-MM');
+    const daysInHistMonth = hist.daysInMonth();
+
+    // Option B: take the last `daysRemaining` days of the historical month.
+    const histStartDay = daysInHistMonth - daysRemaining + 1;
+
+    const monthTxs = transactions.filter((t) => t.month === histMonthKey);
+    // Skip months with no transactions — they likely predate YNAB tracking and
+    // would dilute the average with artificial zeros.
+    if (monthTxs.length === 0) continue;
+
+    const byDay = groupBy(monthTxs, (t) => t.date.toUTCMoment().date());
+
+    for (let pos = 0; pos < daysRemaining; pos++) {
+      const histDay = histStartDay + pos;
+      if (histDay < 1 || histDay > daysInHistMonth) continue;
+      const dayTxs = byDay[histDay] ?? [];
+      const spending = dayTxs.reduce((sum, t) => sum + (t.outflow ?? 0) - (t.inflow ?? 0), 0);
+      spendingByPosition[pos].push(spending);
+    }
+  }
+
+  return spendingByPosition.map((values, pos) => ({
+    day: currentDay + 1 + pos,
+    value: values.length > 0 ? values.reduce((a, b) => a + b, 0) / values.length : 0,
+  }));
+}
+
+/**
+ * Convert a month/day outflow map into Highcharts line series, one series per month.
+ * @param transactions A two-level record of month key ('YYYY-MM') → day-of-month → OutflowData.
+ * @param options Optional display overrides applied to every produced series.
+ * @param options.dashStyle Highcharts dash style (e.g. 'ShortDot' for forecast overlays).
+ * @param options.nameSuffix String appended to each series name (e.g. ' (Scheduled)').
+ * @returns An array of Highcharts SeriesLineOptions, one entry per month.
+ */
 export function toHighchartsSeries(
   transactions: Record<string, Record<string, OutflowData>>,
   options?: { dashStyle?: Highcharts.DashStyleValue; nameSuffix?: string },

--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/utils.ts
@@ -115,10 +115,12 @@ export function calculateCumulativeOutflowPerDate(transactions: GroupedTransacti
 
 export function toHighchartsSeries(
   transactions: Record<string, Record<string, OutflowData>>,
+  options?: { dashStyle?: Highcharts.DashStyleValue; nameSuffix?: string },
 ): Highcharts.SeriesLineOptions[] {
   return Object.entries(transactions).map(([month, data]) => ({
-    name: moment(month, 'YYYY-MM').format('MMM YYYY'),
+    name: moment(month, 'YYYY-MM').format('MMM YYYY') + (options?.nameSuffix ?? ''),
     type: 'line',
+    dashStyle: options?.dashStyle,
     data: Object.entries(data).map(([date, { value, transactions }]) => ({
       x: parseInt(date),
       y: value,


### PR DESCRIPTION
# Add Scheduled & Historical Average Forecasts to Outflow Over Time

## Overview

The Outflow Over Time report previously only showed completed transactions. This PR adds two independent forecast overlays that help you anticipate where your spending will land by the end of the current month.

**Scheduled transactions forecast** — a dotted line (`···`) that projects spending you have already planned through the rest of the month. If you are in cumulative mode, the line picks up exactly where your actual spending line ends today. This answers the question: *"Based on what I've already scheduled, where will I be?"*

**Historical average forecast** — a dashed line (`---`) that projects spending based on what you actually spent during the same positional window (the last n-calendar days; if you have 10 days left in your current month, it will look back at the last 10 days of the selected months, so in March that would be 22-31 and February that would be 19-28) across the last 1–12 months of your history. The n-month selection only shows up when the toggle is set to true. This answers the question: *"Based on how I typically spend at this point in the month, where will I likely end up?"* I'm open to other selection choices, but this seemed like an easy way to limit the impact of unusual months (like a heavy-spend holiday month can be partially mitigated by extending the number of months).

The two forecasts are independent toggles and can be displayed together, letting you compare your scheduled commitments against your historical patterns. The gap between the two lines is meaningful: if your historical average consistently runs higher than your scheduled transactions, that gap represents habitual unscheduled spending that doesn't appear as a discrete scheduled transaction. I try to schedule most things, but groceries, gas, etc aren't scheduled and have a tendency to make me think my budget is better than it is near the end of the month.

---

## What Was Added

### Outflow Over Time — Scheduled Transactions Forecast
- New **"Show forecast (scheduled transactions)"** checkbox in Additional Settings
- Scheduled transactions are sourced from YNAB's own scheduled transaction list and filtered through the same account and inflow rules as the regular series
- Series renders with a `ShortDot` dash style and is labelled `MMM YYYY (Scheduled)`
- In cumulative sum mode the forecast line is offset by the last actual data point for that month, so it continues the curve rather than resetting to zero

### Outflow Over Time — Historical Average Forecast
- New **"Show average forecast (historical spending)"** checkbox in Additional Settings
- When enabled, a **"Months to average"** dropdown (1–12) appears beneath the checkbox
- For each lookback month the algorithm examines the last *N* calendar days of that month (where *N* = days remaining in the current month), then averages the per-day spending across all included months — end-of-month anchored so the comparison window is consistent regardless of month length
- Months with no transactions are skipped so that periods predating YNAB tracking do not dilute the average
- In cumulative sum mode the line starts from the current month's last actual data point and accumulates forward
- Series renders with a `LongDash` style; label format is `N-mo average`
- Both the toggle and the month count are persisted in `localStorage` across sessions

### Report Context
- `allScheduledTransactions: YNABTransaction[]` added to `ReportContextType` and its default value
- Provider (`reports-provider.tsx`) now collects scheduled transactions alongside reportable transactions in `componentDidMount` and exposes them through context

### Utils (`utils.ts`)
- New exported function `calculateAverageDailyForecast(transactions, lookbackMonths, today)` implementing the positional window averaging described above
- `toHighchartsSeries` extended with an optional `options` argument (`dashStyle`, `nameSuffix`) so forecast series can be styled and labelled without duplicating the conversion logic
- JSDoc added to all exported functions

### Tests (`utils.test.js`)
- `calculateAverageDailyForecast`: 8 new cases covering empty input, correct day-number output, single- and multi-month averaging, empty-month skipping, zero-spend days within a valid month, net outflow (outflow − inflow), and short lookback months (fewer days than `daysRemaining`)
- `toHighchartsSeries`: 3 new cases covering `nameSuffix`, `dashStyle`, and both options together

---

## What Was Changed

| File | Change |
|---|---|
| `report-context/component.tsx` | Added `allScheduledTransactions` field to `ReportContextType` and context default |
| `report-context/reports-provider.tsx` | Added `allScheduledTransactions` to HOC state type, initial state, `setState` call, and `ReportContextProvider` value |
| `outflow-over-time/container.ts` | Added `allScheduledTransactions` to `mapReportContextToProps` |
| `outflow-over-time/OutflowOverTime.tsx` | Added two forecast toggles, localStorage state, `useEffect` logic for both forecasts, cumulative offset continuation, and UI controls |
| `outflow-over-time/utils.ts` | Extended `toHighchartsSeries` signature; added `calculateAverageDailyForecast`; added JSDoc to all exported functions |
| `outflow-over-time/utils.test.js` | Added import for `calculateAverageDailyForecast`; added 11 new test cases |

---

## Screenshots

Current and Prior month of actual transactions, includes scheduled transactions and forecasted transactions based on last 1 month of history
<img width="1574" height="827" alt="image" src="https://github.com/user-attachments/assets/0b4590b8-dc64-4be8-b656-b68667b8ab92" />

Current and Prior month of actual transactions, includes scheduled transactions and forecasted transactions based on last 12 month of history
<img width="1593" height="808" alt="image" src="https://github.com/user-attachments/assets/688839d1-9ed7-4df2-9e33-012cb684cd49" />

Only scheduled transactions
<img width="1591" height="824" alt="image" src="https://github.com/user-attachments/assets/a2887f9e-3189-45cc-8457-3b747c6170ee" />

Only forecasted transactions based on last 5 months of history
<img width="1568" height="820" alt="image" src="https://github.com/user-attachments/assets/c61c21ce-b421-466b-9480-3ad6302943ee" />

Not using cumulative sum, 4 months of history average and scheduled transactions
<img width="1591" height="827" alt="image" src="https://github.com/user-attachments/assets/d081534b-8bfc-47d6-99da-4912a8cf216d" />

Not using cumulative sum, 1 month of history average, to really show the line is the same as the last x days of the past month
<img width="1592" height="827" alt="image" src="https://github.com/user-attachments/assets/4d707c51-9467-445f-868a-3bb3bee60981" />

More months gets noisy, but last 6 months of history, plus schedule transactions, plus 9 month average
<img width="1596" height="841" alt="image" src="https://github.com/user-attachments/assets/de77cdb9-ab2b-4efb-b683-b97ecac31f35" />
