### PR TITLE
fix(security): harden messaging channel and validation

### DIFF
--- a/src/core/background/background.js
+++ b/src/core/background/background.js
@@ -92,10 +92,6 @@ export class Background {
     }
   };
 
-  _handleUpdateAvailable = () => {
-    this._browser.runtime.reload();
-  };
-
   _initializeSentry() {
     const environment = getEnvironment();
     const context = {

--- a/src/core/common/errors/with-toolkit-error.test.ts
+++ b/src/core/common/errors/with-toolkit-error.test.ts
@@ -1,5 +1,6 @@
 import { logToolkitError, withToolkitError } from './with-toolkit-error';
 import { readyYNAB } from 'toolkit/test/setup';
+import { OutboundMessageType, TOOLKIT_MESSAGE_CHANNEL } from 'toolkit/core/messages';
 
 describe('toolkit error utils', () => {
   const originalConsoleWarn = global.console.warn.bind(global.console);
@@ -97,6 +98,7 @@ describe('toolkit error utils', () => {
 
       expect(postMessageSpy).toHaveBeenCalledWith(
         {
+          channel: TOOLKIT_MESSAGE_CHANNEL,
           context: {
             featureName: 'mock feature',
             featureSetting: 'false',
@@ -104,9 +106,9 @@ describe('toolkit error utils', () => {
             routeName: '/omitted/budget/201802',
             serializedError: mockError!.stack!.toString(),
           },
-          type: 'ynab-toolkit-error',
+          type: OutboundMessageType.ToolkitError,
         },
-        '*',
+        window.location.origin,
       );
     });
   });

--- a/src/core/common/errors/with-toolkit-error.ts
+++ b/src/core/common/errors/with-toolkit-error.ts
@@ -1,4 +1,7 @@
 import { Feature } from 'toolkit/extension/features/feature';
+import { OutboundMessageType, TOOLKIT_MESSAGE_CHANNEL } from 'toolkit/core/messages';
+
+const TRUSTED_ORIGIN = window.location.origin;
 
 export function withToolkitError(wrappedFunction: Function, feature: Feature | FeatureName) {
   if (typeof wrappedFunction !== 'function') {
@@ -62,7 +65,8 @@ export function logToolkitError({
   const serializedError = errorStack ? errorStack.toString() : errorMessage;
   window.postMessage(
     {
-      type: 'ynab-toolkit-error',
+      channel: TOOLKIT_MESSAGE_CHANNEL,
+      type: OutboundMessageType.ToolkitError,
       context: {
         featureName,
         featureSetting,
@@ -71,6 +75,6 @@ export function logToolkitError({
         serializedError,
       },
     },
-    '*',
+    TRUSTED_ORIGIN,
   );
 }

--- a/src/core/content-scripts/extension-bridge.js
+++ b/src/core/content-scripts/extension-bridge.js
@@ -14,8 +14,8 @@ const validateFeatureSettingValue = createFeatureSettingValidator(allToolkitSett
 function postToolkitMessage(payload) {
   window.postMessage(
     {
-      channel: TOOLKIT_MESSAGE_CHANNEL,
       ...payload,
+      channel: TOOLKIT_MESSAGE_CHANNEL,
     },
     TRUSTED_ORIGIN,
   );

--- a/src/core/content-scripts/extension-bridge.js
+++ b/src/core/content-scripts/extension-bridge.js
@@ -2,47 +2,70 @@ import { getBrowser } from 'toolkit/core/common/web-extensions';
 import { ToolkitStorage, FEATURE_SETTING_PREFIX } from 'toolkit/core/common/storage';
 import { allToolkitSettings, getUserSettings } from 'toolkit/core/settings';
 import { getEnvironment } from 'toolkit/core/common/web-extensions';
-import { InboundMessageType, OutboundMessageType } from '../messages';
+import { createFeatureSettingValidator } from 'toolkit/core/content-scripts/feature-setting-validation';
+import { InboundMessageType, OutboundMessageType, TOOLKIT_MESSAGE_CHANNEL } from '../messages';
 
 const storage = new ToolkitStorage();
 
 let toolkitInitiated = false;
+const TRUSTED_ORIGIN = window.location.origin;
+const validateFeatureSettingValue = createFeatureSettingValidator(allToolkitSettings);
+
+function postToolkitMessage(payload) {
+  window.postMessage(
+    {
+      channel: TOOLKIT_MESSAGE_CHANNEL,
+      ...payload,
+    },
+    TRUSTED_ORIGIN,
+  );
+}
+
+function isTrustedToolkitMessage(event) {
+  return (
+    event &&
+    event.source === window &&
+    event.origin === TRUSTED_ORIGIN &&
+    event.data?.channel === TOOLKIT_MESSAGE_CHANNEL &&
+    typeof event.data?.type === 'string'
+  );
+}
 
 function sendToolkitBootstrap(options) {
   const browser = getBrowser();
   const environment = getEnvironment();
   const manifest = browser.runtime.getManifest();
 
-  window.postMessage(
-    {
-      type: InboundMessageType.Bootstrap,
-      ynabToolKit: {
-        assets: {
-          logo: browser.runtime.getURL('assets/images/logos/toolkitforynab-logo-200.png'),
-        },
-        environment,
-        extensionId: browser.runtime.id,
-        name: manifest.name,
-        options,
-        version: manifest.version,
+  postToolkitMessage({
+    type: InboundMessageType.Bootstrap,
+    ynabToolKit: {
+      assets: {
+        logo: browser.runtime.getURL('assets/images/logos/toolkitforynab-logo-200.png'),
       },
+      environment,
+      extensionId: browser.runtime.id,
+      name: manifest.name,
+      options,
+      version: manifest.version,
     },
-    '*',
-  );
+  });
 }
 
 function toolkitMessageHandler(event) {
-  if (event.data && event.data.type) {
-    switch (event.data.type) {
-      case OutboundMessageType.ToolkitLoaded:
-        initializeYNABToolkit();
-        break;
-      case 'ynab-toolkit-error':
-        handleToolkitError(event.data.context);
-        break;
-      case 'ynab-toolkit-set-setting':
-        handleSetFeatureSetting(event.data.setting);
-    }
+  if (!isTrustedToolkitMessage(event)) {
+    return;
+  }
+
+  switch (event.data.type) {
+    case OutboundMessageType.ToolkitLoaded:
+      initializeYNABToolkit();
+      break;
+    case OutboundMessageType.ToolkitError:
+      handleToolkitError(event.data.context);
+      break;
+    case 'ynab-toolkit-set-setting':
+      handleSetFeatureSetting(event.data.setting);
+      break;
   }
 }
 
@@ -51,12 +74,18 @@ function handleToolkitError(context) {
 }
 
 function handleSetFeatureSetting({ name, value }) {
-  storage.setFeatureSetting(name, value);
+  const normalizedValue = validateFeatureSettingValue(name, value);
+  if (normalizedValue === null) {
+    console.warn('Ignoring invalid feature setting update', { name, value });
+    return;
+  }
+
+  storage.setFeatureSetting(name, normalizedValue);
 }
 
 function handleFeatureSettingChanged(settingName, newValue) {
   if (settingName.startsWith(FEATURE_SETTING_PREFIX)) {
-    window.postMessage({
+    postToolkitMessage({
       type: InboundMessageType.SettingChanged,
       setting: {
         name: settingName.slice(FEATURE_SETTING_PREFIX.length),

--- a/src/core/content-scripts/feature-setting-validation.test.ts
+++ b/src/core/content-scripts/feature-setting-validation.test.ts
@@ -1,0 +1,63 @@
+import { createFeatureSettingValidator } from './feature-setting-validation';
+
+const mockSettings = [
+  {
+    name: 'CheckboxFeature' as FeatureName,
+    type: 'checkbox' as const,
+    default: false,
+    section: 'general' as const,
+    title: 'checkbox',
+    description: 'checkbox',
+  },
+  {
+    name: 'SelectFeature' as FeatureName,
+    type: 'select' as const,
+    default: false,
+    section: 'general' as const,
+    title: 'select',
+    description: 'select',
+    options: [
+      { name: 'one', value: '1' },
+      { name: 'two', value: '2' },
+    ],
+  },
+  {
+    name: 'ColorFeature' as FeatureName,
+    type: 'color' as const,
+    default: '#ffffff',
+    section: 'general' as const,
+    title: 'color',
+    description: 'color',
+  },
+];
+
+describe('feature-setting-validation', () => {
+  const validate = createFeatureSettingValidator(mockSettings);
+
+  it('returns normalized boolean for checkbox values', () => {
+    expect(validate('CheckboxFeature' as FeatureName, 'true')).toBe(true);
+    expect(validate('CheckboxFeature' as FeatureName, false)).toBe(false);
+  });
+
+  it('rejects checkbox values with unexpected types', () => {
+    expect(validate('CheckboxFeature' as FeatureName, 'invalid')).toBeNull();
+  });
+
+  it('allows select option values and disabled state', () => {
+    expect(validate('SelectFeature' as FeatureName, '2')).toBe('2');
+    expect(validate('SelectFeature' as FeatureName, false)).toBe(false);
+  });
+
+  it('rejects select values not defined in options', () => {
+    expect(validate('SelectFeature' as FeatureName, '5')).toBeNull();
+  });
+
+  it('validates color values using hex format', () => {
+    expect(validate('ColorFeature' as FeatureName, '#abc')).toBe('#abc');
+    expect(validate('ColorFeature' as FeatureName, 'rgb(0,0,0)')).toBeNull();
+  });
+
+  it('returns null for unknown feature names', () => {
+    expect(validate('UnknownFeature' as FeatureName, true)).toBeNull();
+  });
+});

--- a/src/core/content-scripts/feature-setting-validation.ts
+++ b/src/core/content-scripts/feature-setting-validation.ts
@@ -1,0 +1,58 @@
+import type { FeatureSetting, FeatureSettingConfig } from 'toolkit/types/toolkit/features';
+
+const HEX_COLOR_REGEX = /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+export function createFeatureSettingValidator(allSettings: FeatureSettingConfig[]) {
+  const settingMap = new Map<FeatureName, FeatureSettingConfig>();
+  for (const setting of allSettings) {
+    settingMap.set(setting.name, setting);
+  }
+
+  return function validateFeatureSettingValue(
+    name: FeatureName,
+    value: FeatureSetting | string | boolean,
+  ): FeatureSetting | null {
+    const setting = settingMap.get(name);
+    if (!setting) {
+      return null;
+    }
+
+    const normalizedValue = normalizeIncomingValue(value);
+
+    if (!isValidForSetting(setting, normalizedValue)) {
+      return null;
+    }
+
+    return normalizedValue;
+  };
+}
+
+function normalizeIncomingValue(value: FeatureSetting | string | boolean): FeatureSetting {
+  if (value === 'true' || value === 'false') {
+    return value === 'true';
+  }
+
+  return value as FeatureSetting;
+}
+
+function isValidForSetting(setting: FeatureSettingConfig, value: FeatureSetting) {
+  switch (setting.type) {
+    case 'checkbox':
+      return typeof value === 'boolean';
+    case 'select':
+      if (value === false) {
+        return true;
+      }
+
+      return (
+        typeof value === 'string' &&
+        Boolean(setting.options?.some((option) => option.value === value))
+      );
+    case 'color':
+      return typeof value === 'string' && HEX_COLOR_REGEX.test(value);
+    default:
+      return typeof value === 'string' || typeof value === 'boolean';
+  }
+}
+
+export { normalizeIncomingValue, isValidForSetting };

--- a/src/core/messages/index.ts
+++ b/src/core/messages/index.ts
@@ -1,29 +1,40 @@
 import type { YNABToolkitObject } from 'toolkit/types/toolkit';
 import type { FeatureSetting } from 'toolkit/types/toolkit/features';
 
+export const TOOLKIT_MESSAGE_CHANNEL = 'ynab-toolkit-channel' as const;
+
+type ToolkitMessageEnvelope<TPayload> = TPayload & {
+  channel: typeof TOOLKIT_MESSAGE_CHANNEL;
+};
+
 export enum InboundMessageType {
   Bootstrap = 'tk-bootstrap',
   SettingChanged = 'tk-setting-changed',
 }
 
-export type BootstrapMessage = MessageEvent<{
-  type: InboundMessageType.Bootstrap;
-  ynabToolKit: Pick<
-    YNABToolkitObject,
-    'assets' | 'environment' | 'extensionId' | 'name' | 'options' | 'version'
-  >;
-}>;
+export type BootstrapMessage = MessageEvent<
+  ToolkitMessageEnvelope<{
+    type: InboundMessageType.Bootstrap;
+    ynabToolKit: Pick<
+      YNABToolkitObject,
+      'assets' | 'environment' | 'extensionId' | 'name' | 'options' | 'version'
+    >;
+  }>
+>;
 
-export type SettingChangedMessage = MessageEvent<{
-  type: InboundMessageType.SettingChanged;
-  setting: {
-    name: FeatureName;
-    value: FeatureSetting;
-  };
-}>;
+export type SettingChangedMessage = MessageEvent<
+  ToolkitMessageEnvelope<{
+    type: InboundMessageType.SettingChanged;
+    setting: {
+      name: FeatureName;
+      value: FeatureSetting;
+    };
+  }>
+>;
 
 export type InboundMessage = BootstrapMessage | SettingChangedMessage;
 
 export enum OutboundMessageType {
   ToolkitLoaded = 'tk-loaded',
+  ToolkitError = 'ynab-toolkit-error',
 }

--- a/src/extension/features/accounts/link-in-memo/index.js
+++ b/src/extension/features/accounts/link-in-memo/index.js
@@ -1,5 +1,6 @@
 import { Feature } from 'toolkit/extension/features/feature';
 import { isCurrentRouteAccountsPage } from 'toolkit/extension/utils/ynab';
+import { linkifyMemoCell } from './utils';
 
 export class LinkInMemo extends Feature {
   shouldInvoke() {
@@ -11,28 +12,7 @@ export class LinkInMemo extends Feature {
     let memos = document.querySelectorAll('.ynab-grid-cell-memo:not(.ynab-grid-header-cell)');
 
     // Loop through each cell to turn it into a link if the memo starts with "https://"
-    memos.forEach((memo) => {
-      if (!memo.dataset.isLink) {
-        let title = memo.getAttribute('title');
-        if (typeof title === 'string' && title.toLowerCase().startsWith('https://')) {
-          // Get the span containing the full link (title may be truncacted)
-          let span = memo.querySelector('span');
-
-          // Create a link element
-          let link = document.createElement('a');
-          link.setAttribute('href', span.innerText);
-          link.setAttribute('target', '_blank');
-          link.innerText = span.innerText;
-
-          // Swap the original text for the link
-          span.innerText = '';
-          span.appendChild(link);
-
-          // Mark this memo as having a link to prevent duplicate modification
-          memo.dataset.isLink = true;
-        }
-      }
-    });
+    memos.forEach(linkifyMemoCell);
   }
 
   observe(changedNodes) {

--- a/src/extension/features/accounts/link-in-memo/index.test.js
+++ b/src/extension/features/accounts/link-in-memo/index.test.js
@@ -1,0 +1,50 @@
+import { linkifyMemoCell } from './utils';
+
+describe('linkifyMemoCell', () => {
+  const insecureLink = 'http://example.com/demo';
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function buildMemoCell({ title, text }) {
+    const memo = document.createElement('div');
+    memo.className = 'ynab-grid-cell-memo';
+    memo.setAttribute('title', title);
+
+    const span = document.createElement('span');
+    span.textContent = text;
+    memo.appendChild(span);
+
+    document.body.appendChild(memo);
+    return memo;
+  }
+
+  it('converts https memo text into a safe hyperlink', () => {
+    const memo = buildMemoCell({
+      title: 'https://example.com/demo',
+      text: 'https://example.com/demo',
+    });
+
+    linkifyMemoCell(memo);
+
+    const link = memo.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('href')).toBe('https://example.com/demo');
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.textContent).toBe('https://example.com/demo');
+  });
+
+  it('ignores memos whose content is not a safe https URL', () => {
+    const memo = buildMemoCell({
+      title: 'https://example.com/demo',
+      text: insecureLink,
+    });
+
+    linkifyMemoCell(memo);
+
+    expect(memo.querySelector('a')).toBeNull();
+    expect(memo.textContent).toBe(insecureLink);
+  });
+});

--- a/src/extension/features/accounts/link-in-memo/utils.js
+++ b/src/extension/features/accounts/link-in-memo/utils.js
@@ -1,0 +1,52 @@
+export function linkifyMemoCell(memo) {
+  if (memo.dataset.isLink === 'true' || memo.dataset.isLink === true) {
+    return;
+  }
+
+  const title = memo.getAttribute('title');
+  if (typeof title !== 'string' || !title.toLowerCase().startsWith('https://')) {
+    return;
+  }
+
+  const span = memo.querySelector('span');
+  if (!span) {
+    return;
+  }
+
+  const sanitizedHref = sanitizeLink(span.textContent);
+  if (!sanitizedHref) {
+    return;
+  }
+
+  const link = document.createElement('a');
+  link.setAttribute('href', sanitizedHref);
+  link.setAttribute('target', '_blank');
+  link.setAttribute('rel', 'noopener noreferrer');
+  link.textContent = sanitizedHref;
+
+  span.textContent = '';
+  span.appendChild(link);
+  memo.dataset.isLink = true;
+}
+
+export function sanitizeLink(rawValue) {
+  if (typeof rawValue !== 'string') {
+    return null;
+  }
+
+  const trimmedValue = rawValue.trim();
+  if (!trimmedValue) {
+    return null;
+  }
+
+  try {
+    const parsedUrl = new URL(trimmedValue);
+    if (parsedUrl.protocol !== 'https:') {
+      return null;
+    }
+
+    return parsedUrl.href;
+  } catch (_error) {
+    return null;
+  }
+}

--- a/src/extension/features/accounts/link-in-memo/utils.js
+++ b/src/extension/features/accounts/link-in-memo/utils.js
@@ -1,5 +1,5 @@
 export function linkifyMemoCell(memo) {
-  if (memo.dataset.isLink === 'true' || memo.dataset.isLink === true) {
+  if (memo.dataset.isLink === 'true') {
     return;
   }
 

--- a/src/extension/ynab-toolkit.test.ts
+++ b/src/extension/ynab-toolkit.test.ts
@@ -6,7 +6,12 @@ import { YNABToolkit } from './ynab-toolkit';
 import { allToolkitSettings } from 'toolkit/core/settings';
 import { isYNABReady } from 'toolkit/extension/utils/ynab';
 import { readyYNAB, unreadyYNAB } from 'toolkit/test/setup';
-import { OutboundMessageType, InboundMessageType, BootstrapMessage } from 'toolkit/core/messages';
+import {
+  OutboundMessageType,
+  InboundMessageType,
+  BootstrapMessage,
+  TOOLKIT_MESSAGE_CHANNEL,
+} from 'toolkit/core/messages';
 import type { YNABToolkitObject } from 'toolkit/types/toolkit';
 
 const mockIsYNABReady = isYNABReady as jest.Mock;
@@ -26,8 +31,14 @@ const setup = (setupOptions = {}) => {
     });
 
   const postMessageSpy = jest.spyOn(window, 'postMessage');
-  const callMessageListener = (...args: any[]) => {
-    messageCallback.apply(null, args as any);
+  const callMessageListener = (eventOverrides: Partial<MessageEvent> = {}) => {
+    const defaultEvent = {
+      source: window,
+      origin: window.location.origin,
+      data: bootstrapData,
+    } as unknown as MessageEvent;
+
+    messageCallback({ ...defaultEvent, ...eventOverrides } as unknown as MessageEvent);
   };
 
   const ynabToolkit = new YNABToolkit();
@@ -36,6 +47,7 @@ const setup = (setupOptions = {}) => {
   }
 
   const bootstrapData: BootstrapMessage['data'] = {
+    channel: TOOLKIT_MESSAGE_CHANNEL,
     type: InboundMessageType.Bootstrap,
     ynabToolKit: {
       assets: {
@@ -54,10 +66,7 @@ const setup = (setupOptions = {}) => {
   });
 
   if (options.sendBootstrap) {
-    callMessageListener({
-      source: window,
-      data: bootstrapData,
-    });
+    callMessageListener();
   }
 
   return {
@@ -88,7 +97,13 @@ describe('YNABToolkit', () => {
     it('should postMessage the toolkit loaded message', () => {
       const { postMessageSpy, ynabToolkit } = setup({ initialize: false });
       ynabToolkit.initializeToolkit();
-      expect(postMessageSpy).toHaveBeenCalledWith({ type: OutboundMessageType.ToolkitLoaded }, '*');
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        {
+          channel: TOOLKIT_MESSAGE_CHANNEL,
+          type: OutboundMessageType.ToolkitLoaded,
+        },
+        window.location.origin,
+      );
     });
   });
 
@@ -133,6 +148,21 @@ describe('YNABToolkit', () => {
         setup({ sendBootstrap: true });
         expect($('head #tk-global-styles').length).toEqual(1);
       });
+    });
+  });
+
+  describe('message validation', () => {
+    it('ignores messages sent without the toolkit channel token', () => {
+      const { callMessageListener, bootstrapData } = setup();
+      callMessageListener({ data: { ...bootstrapData, channel: 'invalid-channel' } as any });
+
+      expect(window.ynabToolKit).toBeUndefined();
+    });
+
+    it('ignores messages from other origins', () => {
+      const { callMessageListener } = setup();
+      callMessageListener({ origin: 'https://example.com' } as any);
+      expect(window.ynabToolKit).toBeUndefined();
     });
   });
 });

--- a/src/extension/ynab-toolkit.tsx
+++ b/src/extension/ynab-toolkit.tsx
@@ -10,7 +10,12 @@ import { compareSemanticVersion } from './utils/helpers';
 import { componentAppend } from './utils/react';
 import { ToolkitReleaseModal } from 'toolkit/core/components/toolkit-release-modal';
 import { Feature } from './features/feature';
-import { InboundMessage, InboundMessageType, OutboundMessageType } from 'toolkit/core/messages';
+import {
+  InboundMessage,
+  InboundMessageType,
+  OutboundMessageType,
+  TOOLKIT_MESSAGE_CHANNEL,
+} from 'toolkit/core/messages';
 import { ObserveListener, RouteChangeListener } from './listeners';
 
 export let observeListener: ObserveListener;
@@ -18,6 +23,8 @@ export let routeChangeListener: RouteChangeListener;
 
 export const TOOLKIT_LOADED_MESSAGE = 'ynab-toolkit-loaded';
 export const TOOLKIT_BOOTSTRAP_MESSAGE = 'ynab-toolkit-bootstrap';
+
+const TRUSTED_ORIGIN = window.location.origin;
 
 window.__toolkitUtils = {
   ...(window.__toolkitUtils as any),
@@ -31,7 +38,13 @@ export class YNABToolkit {
 
   public initializeToolkit() {
     window.addEventListener('message', this.onBackgroundMessage);
-    window.postMessage({ type: OutboundMessageType.ToolkitLoaded }, '*');
+    window.postMessage(
+      {
+        channel: TOOLKIT_MESSAGE_CHANNEL,
+        type: OutboundMessageType.ToolkitLoaded,
+      },
+      TRUSTED_ORIGIN,
+    );
   }
 
   private applyFeatureCSS() {
@@ -131,7 +144,11 @@ export class YNABToolkit {
   };
 
   private onBackgroundMessage = (event: InboundMessage) => {
-    if (event.source !== window) {
+    if (
+      event.source !== window ||
+      event.origin !== TRUSTED_ORIGIN ||
+      event.data?.channel !== TOOLKIT_MESSAGE_CHANNEL
+    ) {
       return;
     }
 
@@ -143,7 +160,9 @@ export class YNABToolkit {
         };
 
         this.setupErrorTracking();
-        features.forEach((Feature) => this.featureInstances.push(new Feature()));
+        features.forEach((FeatureConstructor: typeof Feature) => {
+          this.featureInstances.push(new FeatureConstructor());
+        });
         this._waitForUserSettings();
         break;
       }
@@ -155,7 +174,7 @@ export class YNABToolkit {
         }
 
         const featureInstance = this.featureInstances.find(
-          ({ constructor }) => constructor.name === name,
+          (instance) => instance.constructor.name === name,
         );
 
         if (featureInstance) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,13 +23,13 @@ module.exports = function (env) {
       'options/options': path.resolve(`${CODE_SOURCE_DIR}/core/options/index.tsx`),
       'popup/popup': path.resolve(`${CODE_SOURCE_DIR}/core/popup/index.tsx`),
       'content-scripts/extension-bridge': path.resolve(
-        `${CODE_SOURCE_DIR}/core/content-scripts/extension-bridge.js`
+        `${CODE_SOURCE_DIR}/core/content-scripts/extension-bridge.js`,
       ),
       'content-scripts/enable-ember-debug': path.resolve(
-        `${CODE_SOURCE_DIR}/core/content-scripts/enable-ember-debug.js`
+        `${CODE_SOURCE_DIR}/core/content-scripts/enable-ember-debug.js`,
       ),
       'web-accessibles/enable-ember-debug': path.resolve(
-        `${CODE_SOURCE_DIR}/core/web-accessibles/enable-ember-debug.js`
+        `${CODE_SOURCE_DIR}/core/web-accessibles/enable-ember-debug.js`,
       ),
       'web-accessibles/ynab-toolkit': path.resolve(`${CODE_SOURCE_DIR}/extension/index.js`),
     },
@@ -46,7 +46,7 @@ module.exports = function (env) {
         toolkit: path.resolve(__dirname, CODE_SOURCE_DIR),
         'toolkit-reports': path.resolve(
           __dirname,
-          path.join(CODE_SOURCE_DIR, 'extension', 'features', 'toolkit-reports')
+          path.join(CODE_SOURCE_DIR, 'extension', 'features', 'toolkit-reports'),
         ),
       },
       extensions: ['.js', '.jsx', '.ts', '.tsx'],


### PR DESCRIPTION
# Harden postMessage + memo links

Closes #3681

Hey team! Brand-new contributor here. I took a quick lap through the codebase (with a little AI assist) and spotted a few easy hardening wins that align with public guidance on secure `postMessage` usage and data handling. None of this should change user-facing behavior; it just narrows attack surface.

## Why

- MDN and other security writeups reiterate that `window.postMessage` must always specify an explicit `targetOrigin` and verify `event.origin` before acting, otherwise untrusted frames can spoof or snarf sensitive payloads.[^mdn][^bindbee][^secureflag][^msft]
- Same docs recommend validating payload shape as well as transport metadata so even trusted senders cannot accidentally route unexpected data into privileged code paths.[^mdn]
- Memo hyperlinking already promotes URLs into clickable anchors, so it’s worth ensuring only `https://` survives and that we emit `rel="noopener noreferrer"` to avoid tab-nabbing.[^mozilla]

[^mdn]: [MDN `window.postMessage` security notes](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)
[^bindbee]: [Bindbee: “Securing Cross-Window Communication”](https://www.bindbee.dev/blog/secure-cross-window-communication)
[^secureflag]: [SecureFlag: “Unchecked Origin in postMessage Vulnerability”](https://knowledge-base.secureflag.com/vulnerabilities/broken_authorization/unchecked_origin_in_postmessage_vulnerability.html)
[^msft]: [Microsoft: “postmessaged-and-compromised”](https://www.microsoft.com/en-us/msrc/blog/2025/08/postmessaged-and-compromised)
[^mozilla]: [MDN link security / rel guidance](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noopener)

## What changed

1. Added a shared `TOOLKIT_MESSAGE_CHANNEL` guard plus explicit origin checks for every message flowing between the page bundle and the injected script. Anything without our token and origin is dropped.
2. `postMessage` senders now use `window.location.origin` rather than `"*"` to match the MDN recommendations.
3. Feature-setting writes pass through a tiny validator so rogue payloads (wrong type, option not in allowlist, malformed color) are ignored instead of persisted.
4. Memo linkification now sanitizes text content via `new URL`, bails on non-HTTPS protocols, and sets `rel="noopener noreferrer"` when opening new tabs.

## Testing I ran

- `yarn test` – all suites pass locally.
- `yarn build:development` – succeeds; dist loads into Chrome.
- `yarn manifest:firefox` + `web-ext run --no-reload --source-dir dist/extension/` – manual smoke in Firefox, messaging still works, memo links behave.

Not sure what CI you run these days, but this should be low-risk. Happy to tweak anything! 🙌
