### PR TITLE
fix(ci): use fine-grained PAT for semantic-release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -6,12 +6,11 @@ on:
     paths-ignore:
       - '**.md'
       - './scripts/**'
-      - './release.config.cjs'
+      - '.config/releaserc.js'
   workflow_dispatch: {}
 
 env:
   HUSKY: 0
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
   packages: write
@@ -46,14 +45,14 @@ jobs:
 
       - name: Semantic Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npx semantic-release --debug
 
       - name: Merge main branch -> develop
         uses: devmasx/merge-branch@master
         with:
           type: now
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
           from_branch: ${{ github.ref_name }}
           target_branch: develop
           message: 'chore(ci): sync develop with ${{ github.ref_name }} [skip ci]'


### PR DESCRIPTION
## Summary

- Switches the semantic-release step and develop sync step from `secrets.GITHUB_TOKEN` (the Actions bot) to `secrets.GH_TOKEN` (a fine-grained PAT scoped to this repo)
- The Actions bot was not in `main`'s push allowlist, causing `@semantic-release/git` and `@semantic-release/github` to 403 when trying to push the release commit and create the GitHub Release
- Also fixes a stale `paths-ignore` entry that pointed to `./release.config.cjs` (doesn't exist) instead of `.config/releaserc.js`

## Test plan

- [ ] Merge this PR to `develop`, then merge `develop` → `main`
- [ ] Confirm the CI/CD Semantic Release workflow runs to completion
- [ ] Confirm a `chore(release): X.Y.Z [skip ci]` commit appears on `main`
- [ ] Confirm a GitHub Release is created with the zip files attached
- [ ] Confirm `develop` is synced back from `main` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)