### PR TITLE
chore(ci): enable Sentry sourcemap uploads on release

### DIFF
--- a/.config/releaserc.js
+++ b/.config/releaserc.js
@@ -89,7 +89,7 @@ const config = {
     [
       '@semantic-release/exec',
       {
-        publishCmd: 'yarn build:ci-test', // UPDATE TO 'yarn build:ci' when in 'production'
+        publishCmd: 'yarn build:ci',
       },
     ],
     [

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: npx semantic-release --debug
 
       - name: Merge main branch -> develop


### PR DESCRIPTION
## Summary

- Switches `releaserc.js` `publishCmd` from `build:ci-test` to `build:ci`, enabling Sentry release creation and sourcemap uploads on every release
- Wires `SENTRY_AUTH_TOKEN` secret into the semantic-release workflow (secret already exists in repo)

## Test plan

- [ ] Merge to develop, then trigger a release by merging develop → main and confirm Sentry release appears in the Sentry dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)