### PR TITLE
feat(reports): project future balance from scheduled transactions in Balance Over Time

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/report-context/component.tsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.tsx
@@ -30,7 +30,16 @@ export type ReportContextType = {
   setActiveReportKey: (newKey: string) => void;
   setFilters: (newFilters: any) => void;
   allReportableTransactions: YNABTransaction[];
-  allReportableScheduledTransactions: YNABTransaction[];
+  /**
+   * All scheduled transaction rows, unfiltered with respect to splits: this includes both
+   * split parent rows (which carry the total amount and the real recurrence `frequency`) and
+   * their scheduled sub-transaction children (which carry per-category amounts but always
+   * report `frequency: 'Never'`). Consumers must pick one or the other before using this —
+   * summing amounts requires filtering to `!isSplit` (leaf rows) to avoid double-counting a
+   * split's total against its own children, while anything that needs the recurrence schedule
+   * must filter to `!isScheduledSubTransaction` (parent rows), since children don't carry it.
+   */
+  allScheduledTransactions: YNABTransaction[];
 };
 
 const { Provider, Consumer } = createContext<ReportContextType>({
@@ -40,7 +49,7 @@ const { Provider, Consumer } = createContext<ReportContextType>({
   setActiveReportKey: () => {},
   setFilters: () => {},
   allReportableTransactions: [],
-  allReportableScheduledTransactions: [],
+  allScheduledTransactions: [],
 });
 
 export const ReportContextProvider = Provider;

--- a/src/extension/features/toolkit-reports/common/components/report-context/component.tsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/component.tsx
@@ -30,6 +30,7 @@ export type ReportContextType = {
   setActiveReportKey: (newKey: string) => void;
   setFilters: (newFilters: any) => void;
   allReportableTransactions: YNABTransaction[];
+  allReportableScheduledTransactions: YNABTransaction[];
 };
 
 const { Provider, Consumer } = createContext<ReportContextType>({
@@ -39,6 +40,7 @@ const { Provider, Consumer } = createContext<ReportContextType>({
   setActiveReportKey: () => {},
   setFilters: () => {},
   allReportableTransactions: [],
+  allReportableScheduledTransactions: [],
 });
 
 export const ReportContextProvider = Provider;

--- a/src/extension/features/toolkit-reports/common/components/report-context/reports-provider.tsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/reports-provider.tsx
@@ -110,6 +110,7 @@ export type WithReportContextHocState = {
   filteredTransactions: YNABTransaction[];
   filters: FiltersType;
   allReportableTransactions: YNABTransaction[];
+  allReportableScheduledTransactions: YNABTransaction[];
 };
 
 export function withReportContextProvider<T extends object>(InnerComponent: ComponentType<T>) {
@@ -135,6 +136,7 @@ export function withReportContextProvider<T extends object>(InnerComponent: Comp
         filteredTransactions: [],
         filters: getStoredFilters(initialReportKey),
         allReportableTransactions: [],
+        allReportableScheduledTransactions: [],
       };
     }
 
@@ -158,11 +160,19 @@ export function withReportContextProvider<T extends object>(InnerComponent: Comp
               !transaction.isScheduledTransaction &&
               !transaction.isScheduledSubTransaction,
           );
+          // Upcoming scheduled transactions (the next occurrence of each schedule). These are
+          // kept separate from `allReportableTransactions` so existing reports are unaffected,
+          // but are available to reports that want to project future balances.
+          const allReportableScheduledTransactions = visibleTransactionDisplayItems.filter(
+            (transaction) =>
+              transaction.isScheduledTransaction && !transaction.isScheduledSubTransaction,
+          );
 
           this.setState(
             {
               filteredTransactions: [],
               allReportableTransactions,
+              allReportableScheduledTransactions,
             },
             () => {
               this._applyFilters(this.state.activeReportKey);
@@ -194,6 +204,7 @@ export function withReportContextProvider<T extends object>(InnerComponent: Comp
               setActiveReportKey: this._setActiveReportKey,
               setFilters: this._setFilters,
               allReportableTransactions: this.state.allReportableTransactions,
+              allReportableScheduledTransactions: this.state.allReportableScheduledTransactions,
             }}
           >
             <InnerComponent {...this.props} />

--- a/src/extension/features/toolkit-reports/common/components/report-context/reports-provider.tsx
+++ b/src/extension/features/toolkit-reports/common/components/report-context/reports-provider.tsx
@@ -110,7 +110,7 @@ export type WithReportContextHocState = {
   filteredTransactions: YNABTransaction[];
   filters: FiltersType;
   allReportableTransactions: YNABTransaction[];
-  allReportableScheduledTransactions: YNABTransaction[];
+  allScheduledTransactions: YNABTransaction[];
 };
 
 export function withReportContextProvider<T extends object>(InnerComponent: ComponentType<T>) {
@@ -136,7 +136,7 @@ export function withReportContextProvider<T extends object>(InnerComponent: Comp
         filteredTransactions: [],
         filters: getStoredFilters(initialReportKey),
         allReportableTransactions: [],
-        allReportableScheduledTransactions: [],
+        allScheduledTransactions: [],
       };
     }
 
@@ -160,19 +160,19 @@ export function withReportContextProvider<T extends object>(InnerComponent: Comp
               !transaction.isScheduledTransaction &&
               !transaction.isScheduledSubTransaction,
           );
-          // Upcoming scheduled transactions (the next occurrence of each schedule). These are
-          // kept separate from `allReportableTransactions` so existing reports are unaffected,
-          // but are available to reports that want to project future balances.
-          const allReportableScheduledTransactions = visibleTransactionDisplayItems.filter(
+          // Scheduled transactions (kept separate from `allReportableTransactions` so existing
+          // reports are unaffected). Includes both split parents and their sub-transactions;
+          // see the JSDoc on `ReportContextType.allScheduledTransactions` for how to use this.
+          const allScheduledTransactions = visibleTransactionDisplayItems.filter(
             (transaction) =>
-              transaction.isScheduledTransaction && !transaction.isScheduledSubTransaction,
+              transaction.isScheduledTransaction || transaction.isScheduledSubTransaction,
           );
 
           this.setState(
             {
               filteredTransactions: [],
               allReportableTransactions,
-              allReportableScheduledTransactions,
+              allScheduledTransactions,
             },
             () => {
               this._applyFilters(this.state.activeReportKey);
@@ -204,7 +204,7 @@ export function withReportContextProvider<T extends object>(InnerComponent: Comp
               setActiveReportKey: this._setActiveReportKey,
               setFilters: this._setFilters,
               allReportableTransactions: this.state.allReportableTransactions,
-              allReportableScheduledTransactions: this.state.allReportableScheduledTransactions,
+              allScheduledTransactions: this.state.allScheduledTransactions,
             }}
           >
             <InnerComponent {...this.props} />

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.tsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import moment from 'moment';
 import { RunningBalanceGraph } from './RunningBalanceGraph';
 import { LabeledCheckbox } from 'toolkit/extension/features/toolkit-reports/common/components/labeled-checkbox';
 import { WarningMessage } from './WarningMessage';
@@ -9,11 +10,13 @@ import { AdditionalReportSettings } from 'toolkit/extension/features/toolkit-rep
 import {
   dataPointsToHighChartSeries,
   generateRunningBalanceMap,
+  appendScheduledTransactionsToBalanceMap,
   applyDateFiltersToDataPoints,
   combineDataPoints,
   generateTrendLine,
   checkSeriesLimitReached,
   NUM_DATAPOINTS_LIMIT,
+  SCHEDULED_PROJECTION_MONTHS,
   Datapoint,
   PointPayload,
 } from './utils';
@@ -28,8 +31,12 @@ export type Serie = {
 
 export const BalanceOverTimeComponent = ({
   allReportableTransactions,
+  allReportableScheduledTransactions,
   filters,
-}: Pick<ReportContextType, 'allReportableTransactions' | 'filters'>) => {
+}: Pick<
+  ReportContextType,
+  'allReportableTransactions' | 'allReportableScheduledTransactions' | 'filters'
+>) => {
   const GROUPED_LABEL = 'Selected Accounts';
   const TRENDLINE_PREFIX = 'Trendline for ';
 
@@ -44,6 +51,10 @@ export const BalanceOverTimeComponent = ({
   );
   const [useStepGraph, setUseStepGraph] = useLocalStorage('balance-over-time-useStepGraph', true);
   const [useTrendLine, setUseTrendLine] = useLocalStorage('balance-over-time-useTrendline', false);
+  const [showScheduledTransactions, setShowScheduledTransactions] = useLocalStorage(
+    'balance-over-time-showScheduledTransactions',
+    false,
+  );
 
   // Map of accounts to their corresponding datapoints for each date
   const [runningBalanceMap, setRunningBalanceMap] = useState(new Map());
@@ -63,11 +74,29 @@ export const BalanceOverTimeComponent = ({
     const { fromDate, toDate } = filters.dateFilter;
     let newSeries = [];
 
+    // When projecting scheduled transactions, extend the running balance into the future and let
+    // the graph run past the selected end date out to the projection horizon.
+    const projectionEndDate = moment()
+      .utc()
+      .startOf('day')
+      .add(SCHEDULED_PROJECTION_MONTHS, 'months');
+    const sourceBalanceMap = showScheduledTransactions
+      ? appendScheduledTransactionsToBalanceMap(
+          runningBalanceMap,
+          allReportableScheduledTransactions,
+          projectionEndDate,
+        )
+      : runningBalanceMap;
+    const toDateUTC = showScheduledTransactions ? projectionEndDate.valueOf() : toDate.getUTCTime();
+
     // Filter the overall running balance to only the datapoints what we want
     let filteredData = new Map<string, Map<number, Datapoint>>();
-    runningBalanceMap.forEach((datapoints, accountId) => {
+    sourceBalanceMap.forEach((datapoints, accountId) => {
       if (!accountFilters.has(accountId)) {
-        filteredData.set(accountId, applyDateFiltersToDataPoints(fromDate, toDate, datapoints));
+        filteredData.set(
+          accountId,
+          applyDateFiltersToDataPoints(fromDate.getUTCTime(), toDateUTC, datapoints),
+        );
       }
     });
 
@@ -133,11 +162,13 @@ export const BalanceOverTimeComponent = ({
     setSeries(newSeries);
   }, [
     runningBalanceMap,
+    allReportableScheduledTransactions,
     filters,
     shouldGroupAccounts,
     shouldGroupAccountsByType,
     useStepGraph,
     useTrendLine,
+    showScheduledTransactions,
   ]);
 
   if (datapointLimitReached) {
@@ -175,6 +206,12 @@ export const BalanceOverTimeComponent = ({
           checked={useStepGraph}
           label="Use Step Graph"
           onChange={() => setUseStepGraph(!useStepGraph)}
+        />
+        <LabeledCheckbox
+          id="tk-balance-over-time-scheduled-option"
+          checked={showScheduledTransactions}
+          label="Scheduled Transactions"
+          onChange={() => setShowScheduledTransactions(!showScheduledTransactions)}
         />
       </AdditionalReportSettings>
       <RunningBalanceGraph series={series} />

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.tsx
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/BalanceOverTime.tsx
@@ -31,11 +31,11 @@ export type Serie = {
 
 export const BalanceOverTimeComponent = ({
   allReportableTransactions,
-  allReportableScheduledTransactions,
+  allScheduledTransactions,
   filters,
 }: Pick<
   ReportContextType,
-  'allReportableTransactions' | 'allReportableScheduledTransactions' | 'filters'
+  'allReportableTransactions' | 'allScheduledTransactions' | 'filters'
 >) => {
   const GROUPED_LABEL = 'Selected Accounts';
   const TRENDLINE_PREFIX = 'Trendline for ';
@@ -83,7 +83,7 @@ export const BalanceOverTimeComponent = ({
     const sourceBalanceMap = showScheduledTransactions
       ? appendScheduledTransactionsToBalanceMap(
           runningBalanceMap,
-          allReportableScheduledTransactions,
+          allScheduledTransactions,
           projectionEndDate,
         )
       : runningBalanceMap;
@@ -162,7 +162,7 @@ export const BalanceOverTimeComponent = ({
     setSeries(newSeries);
   }, [
     runningBalanceMap,
-    allReportableScheduledTransactions,
+    allScheduledTransactions,
     filters,
     shouldGroupAccounts,
     shouldGroupAccountsByType,

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/container.ts
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/container.ts
@@ -8,6 +8,7 @@ const mapReportContextToProps = (context: ReportContextType) => {
   return {
     filters: context.filters,
     allReportableTransactions: context.allReportableTransactions,
+    allReportableScheduledTransactions: context.allReportableScheduledTransactions,
   };
 };
 export const BalanceOverTime = withReportContext(mapReportContextToProps)(BalanceOverTimeComponent);

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/container.ts
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/container.ts
@@ -8,7 +8,7 @@ const mapReportContextToProps = (context: ReportContextType) => {
   return {
     filters: context.filters,
     allReportableTransactions: context.allReportableTransactions,
-    allReportableScheduledTransactions: context.allReportableScheduledTransactions,
+    allScheduledTransactions: context.allScheduledTransactions,
   };
 };
 export const BalanceOverTime = withReportContext(mapReportContextToProps)(BalanceOverTimeComponent);

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/utils.spec.ts
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/utils.spec.ts
@@ -1,0 +1,111 @@
+import moment from 'moment';
+import {
+  appendScheduledTransactionsToBalanceMap,
+  expandScheduledTransactionDates,
+  Datapoint,
+} from './utils';
+import { YNABTransaction } from 'toolkit/types/ynab/data/transaction';
+
+const day = (iso: string) => moment.utc(iso).startOf('day');
+const dayUTC = (iso: string) => day(iso).valueOf();
+
+// Minimal scheduled-transaction stub with only the fields the projection utils read.
+function makeScheduled(input: {
+  accountId: string;
+  date: string;
+  frequency?: string | null;
+  inflow?: number;
+  outflow?: number;
+}): YNABTransaction {
+  return {
+    accountId: input.accountId,
+    frequency: input.frequency ?? null,
+    inflow: input.inflow ?? 0,
+    outflow: input.outflow ?? 0,
+    date: { getUTCTime: () => dayUTC(input.date) },
+  } as unknown as YNABTransaction;
+}
+
+describe('balance-over-time projection utils', () => {
+  describe('expandScheduledTransactionDates', () => {
+    it('returns a single occurrence for a non-repeating schedule', () => {
+      const tx = makeScheduled({ accountId: 'a', date: '2026-07-01', frequency: 'never' });
+      const dates = expandScheduledTransactionDates(tx, dayUTC('2026-06-26'), day('2027-06-26'));
+      expect(dates).toEqual([dayUTC('2026-07-01')]);
+    });
+
+    it('expands a monthly schedule across the horizon', () => {
+      const tx = makeScheduled({ accountId: 'a', date: '2026-07-01', frequency: 'monthly' });
+      const dates = expandScheduledTransactionDates(tx, dayUTC('2026-06-26'), day('2026-10-15'));
+      expect(dates).toEqual([
+        dayUTC('2026-07-01'),
+        dayUTC('2026-08-01'),
+        dayUTC('2026-09-01'),
+        dayUTC('2026-10-01'),
+      ]);
+    });
+
+    it('excludes occurrences on or before the cutoff date', () => {
+      const tx = makeScheduled({ accountId: 'a', date: '2026-06-26', frequency: 'weekly' });
+      const dates = expandScheduledTransactionDates(tx, dayUTC('2026-06-26'), day('2026-07-20'));
+      expect(dates).toEqual([dayUTC('2026-07-03'), dayUTC('2026-07-10'), dayUTC('2026-07-17')]);
+    });
+  });
+
+  describe('appendScheduledTransactionsToBalanceMap', () => {
+    it('continues each account balance forward using scheduled transactions', () => {
+      const lastActual = dayUTC('2026-06-26');
+      const actualMap = new Map<string, Map<number, Datapoint>>([
+        [
+          'a',
+          new Map<number, Datapoint>([
+            [lastActual, { runningTotal: 1000, netChange: 0, transactions: [] }],
+          ]),
+        ],
+      ]);
+
+      const scheduled = [
+        makeScheduled({ accountId: 'a', date: '2026-07-01', frequency: 'never', outflow: 200 }),
+        makeScheduled({ accountId: 'a', date: '2026-07-05', frequency: 'never', inflow: 500 }),
+      ];
+
+      const projected = appendScheduledTransactionsToBalanceMap(
+        actualMap,
+        scheduled,
+        day('2026-07-10'),
+      );
+
+      const datapoints = projected.get('a')!;
+      // Actual datapoint is preserved.
+      expect(datapoints.get(lastActual)!.runningTotal).toBe(1000);
+      // Outflow on the 1st drops the balance.
+      expect(datapoints.get(dayUTC('2026-07-01'))!.runningTotal).toBe(800);
+      // Inflow on the 5th raises it.
+      expect(datapoints.get(dayUTC('2026-07-05'))!.runningTotal).toBe(1300);
+      // Balance carries forward on days without occurrences.
+      expect(datapoints.get(dayUTC('2026-07-10'))!.runningTotal).toBe(1300);
+    });
+
+    it('only projects scheduled transactions onto their own account', () => {
+      const lastActual = dayUTC('2026-06-26');
+      const actualMap = new Map<string, Map<number, Datapoint>>([
+        ['a', new Map([[lastActual, { runningTotal: 100, netChange: 0, transactions: [] }]])],
+        ['b', new Map([[lastActual, { runningTotal: 50, netChange: 0, transactions: [] }]])],
+      ]);
+
+      const scheduled = [
+        makeScheduled({ accountId: 'a', date: '2026-07-01', frequency: 'never', inflow: 10 }),
+      ];
+
+      const projected = appendScheduledTransactionsToBalanceMap(
+        actualMap,
+        scheduled,
+        day('2026-07-02'),
+      );
+
+      expect(projected.get('a')!.get(dayUTC('2026-07-01'))!.runningTotal).toBe(110);
+      // Account b has no scheduled transactions, so its balance stays flat.
+      expect(projected.get('b')!.get(dayUTC('2026-07-01'))!.runningTotal).toBe(50);
+    });
+  });
+});

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/utils.ts
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/utils.ts
@@ -317,7 +317,10 @@ export const expandScheduledTransactionDates = (
  * of every scheduled occurrence along the way.
  *
  * @param {Map} runningBalanceMap Map of account ids to their actual datapoints (date -> datapoint)
- * @param {YNABTransaction[]} scheduledTransactions Upcoming scheduled transactions to project
+ * @param {YNABTransaction[]} scheduledTransactions Scheduled transactions to project. May include
+ *   both split parents and their sub-transactions; sub-transactions are excluded here since they
+ *   don't carry their own recurrence `frequency` and their amount is already covered by their
+ *   parent's total.
  * @param {Moment} projectionEndDate How far into the future to project
  * @return {Map} A new map (clone of the input) with projected future datapoints appended
  */
@@ -326,6 +329,10 @@ export const appendScheduledTransactionsToBalanceMap = (
   scheduledTransactions: YNABTransaction[],
   projectionEndDate: Moment,
 ) => {
+  const projectableScheduledTransactions = scheduledTransactions.filter(
+    (transaction) => !transaction.isScheduledSubTransaction,
+  );
+
   // Group the scheduled occurrences by account and date so we can look them up per day.
   const accountToScheduledByDate = new Map<string, Map<number, YNABTransaction[]>>();
 
@@ -333,7 +340,7 @@ export const appendScheduledTransactionsToBalanceMap = (
     const lastActualDateUTC = Math.max(...datapoints.keys());
     const occurrencesByDate = new Map<number, YNABTransaction[]>();
 
-    scheduledTransactions
+    projectableScheduledTransactions
       .filter((transaction) => transaction.accountId === accountId)
       .forEach((transaction) => {
         expandScheduledTransactionDates(transaction, lastActualDateUTC, projectionEndDate).forEach(

--- a/src/extension/features/toolkit-reports/pages/balance-over-time/utils.ts
+++ b/src/extension/features/toolkit-reports/pages/balance-over-time/utils.ts
@@ -229,18 +229,18 @@ export const combineDataPoints = (datapointsArray: Map<number, Datapoint>[]) => 
 
 /**
  * Apply a date filter to the datapoints and return all datapoints within the date range
- * @param {} fromDate The starting date to filter from
- * @param {*} toDate The end date to filter to
+ * @param {number} fromDateUTC The starting date (UTC time) to filter from
+ * @param {number} toDateUTC The end date (UTC time) to filter to
  * @param {Map} datapoints Map of dates in UTC to their corresponding datapoint
  */
 export const applyDateFiltersToDataPoints = (
-  fromDate: DateWithoutTime,
-  toDate: DateWithoutTime,
+  fromDateUTC: number,
+  toDateUTC: number,
   datapoints: Map<number, Datapoint>,
 ) => {
   let filteredDatapoints = new Map<number, Datapoint>();
   datapoints.forEach((data, dateUTC) => {
-    if (dateUTC >= fromDate.getUTCTime() && dateUTC <= toDate.getUTCTime()) {
+    if (dateUTC >= fromDateUTC && dateUTC <= toDateUTC) {
       filteredDatapoints.set(dateUTC, data);
     }
   });
@@ -253,4 +253,131 @@ export const applyDateFiltersToDataPoints = (
  */
 export const checkSeriesLimitReached = (series?: { data: unknown[] }) => {
   return series && series.data && series.data.length >= NUM_DATAPOINTS_LIMIT;
+};
+
+// How many months into the future to project scheduled (future) transactions.
+export const SCHEDULED_PROJECTION_MONTHS = 12;
+
+// Maps YNAB scheduled transaction frequencies to the interval between occurrences.
+// A `null` value means the transaction does not repeat (a single future occurrence).
+const FREQUENCY_INTERVALS: Record<
+  string,
+  { unit: moment.unitOfTime.DurationConstructor; amount: number } | null
+> = {
+  never: null,
+  daily: { unit: 'days', amount: 1 },
+  weekly: { unit: 'weeks', amount: 1 },
+  everyOtherWeek: { unit: 'weeks', amount: 2 },
+  twiceAMonth: { unit: 'days', amount: 15 },
+  every4Weeks: { unit: 'weeks', amount: 4 },
+  monthly: { unit: 'months', amount: 1 },
+  everyOtherMonth: { unit: 'months', amount: 2 },
+  every3Months: { unit: 'months', amount: 3 },
+  every4Months: { unit: 'months', amount: 4 },
+  twiceAYear: { unit: 'months', amount: 6 },
+  yearly: { unit: 'years', amount: 1 },
+  everyOtherYear: { unit: 'years', amount: 2 },
+};
+
+/**
+ * Expand a single scheduled transaction into every occurrence (UTC time) that falls within
+ * `(afterDateUTC, endDate]`, based on its frequency. Non-repeating schedules yield a single
+ * occurrence at their date.
+ */
+export const expandScheduledTransactionDates = (
+  scheduledTransaction: YNABTransaction,
+  afterDateUTC: number,
+  endDate: Moment,
+): number[] => {
+  const dates: number[] = [];
+  if (!scheduledTransaction.date) return dates;
+
+  const interval =
+    scheduledTransaction.frequency != null
+      ? FREQUENCY_INTERVALS[scheduledTransaction.frequency]
+      : null;
+  let occurrence = moment(scheduledTransaction.date.getUTCTime()).utc().startOf('day');
+
+  while (occurrence.isSameOrBefore(endDate)) {
+    const occurrenceUTC = occurrence.valueOf();
+    if (occurrenceUTC > afterDateUTC) {
+      dates.push(occurrenceUTC);
+    }
+    // Non-repeating schedules only contribute a single occurrence.
+    if (!interval) break;
+    occurrence = occurrence.clone().add(interval.amount, interval.unit);
+  }
+  return dates;
+};
+
+/**
+ * Extend an existing (actual) running balance map with projected datapoints generated from
+ * upcoming scheduled transactions. For each account, the projection continues from its current
+ * balance (the last actual datapoint) forward to `projectionEndDate`, accumulating the net change
+ * of every scheduled occurrence along the way.
+ *
+ * @param {Map} runningBalanceMap Map of account ids to their actual datapoints (date -> datapoint)
+ * @param {YNABTransaction[]} scheduledTransactions Upcoming scheduled transactions to project
+ * @param {Moment} projectionEndDate How far into the future to project
+ * @return {Map} A new map (clone of the input) with projected future datapoints appended
+ */
+export const appendScheduledTransactionsToBalanceMap = (
+  runningBalanceMap: Map<string, Map<number, Datapoint>>,
+  scheduledTransactions: YNABTransaction[],
+  projectionEndDate: Moment,
+) => {
+  // Group the scheduled occurrences by account and date so we can look them up per day.
+  const accountToScheduledByDate = new Map<string, Map<number, YNABTransaction[]>>();
+
+  runningBalanceMap.forEach((datapoints, accountId) => {
+    const lastActualDateUTC = Math.max(...datapoints.keys());
+    const occurrencesByDate = new Map<number, YNABTransaction[]>();
+
+    scheduledTransactions
+      .filter((transaction) => transaction.accountId === accountId)
+      .forEach((transaction) => {
+        expandScheduledTransactionDates(transaction, lastActualDateUTC, projectionEndDate).forEach(
+          (dateUTC) => {
+            if (!occurrencesByDate.has(dateUTC)) {
+              occurrencesByDate.set(dateUTC, []);
+            }
+            occurrencesByDate.get(dateUTC)!.push(transaction);
+          },
+        );
+      });
+
+    accountToScheduledByDate.set(accountId, occurrencesByDate);
+  });
+
+  // Build the projected map: clone each account's actual datapoints, then walk forward day-by-day
+  // from the last actual date carrying the running total and applying scheduled occurrences.
+  const projectedMap = new Map<string, Map<number, Datapoint>>();
+  runningBalanceMap.forEach((datapoints, accountId) => {
+    const projectedDatapoints = new Map<number, Datapoint>(datapoints);
+    const lastActualDateUTC = Math.max(...datapoints.keys());
+    const occurrencesByDate = accountToScheduledByDate.get(accountId)!;
+
+    let runningTotal = datapoints.get(lastActualDateUTC)!.runningTotal;
+    let currDate = moment(lastActualDateUTC).utc().add(1, 'days');
+
+    while (currDate.isSameOrBefore(projectionEndDate)) {
+      const dateUTC = currDate.valueOf();
+      const occurrences = occurrencesByDate.get(dateUTC) || [];
+      const netChange = occurrences.reduce(
+        (accum, transaction) => accum - transaction.outflow + transaction.inflow,
+        0,
+      );
+      runningTotal += netChange;
+      projectedDatapoints.set(dateUTC, {
+        transactions: occurrences,
+        runningTotal,
+        netChange,
+      });
+      currDate = currDate.add(1, 'days');
+    }
+
+    projectedMap.set(accountId, projectedDatapoints);
+  });
+
+  return projectedMap;
 };

--- a/src/types/ynab/data/transaction.ts
+++ b/src/types/ynab/data/transaction.ts
@@ -21,6 +21,7 @@ export interface YNABTransaction {
   dateEnteredFromSchedule: DateWithoutTime | null;
   entityId: string;
   flag: string | null;
+  frequency?: string | null;
   importedDate: DateWithoutTime | null;
   importedPayee: YNABPayee | null;
   isScheduledSubTransaction?: boolean;


### PR DESCRIPTION
## Summary

Adds a **Scheduled Transactions** option to the **Balance Over Time** report. When enabled, each account's line continues past today using upcoming scheduled transactions, projecting the future balance up to a 12-month horizon.

## Motivation

Balance Over Time currently stops at today. Users frequently want to see where their balances are *heading* based on the scheduled transactions they've already set up in YNAB (rent, paychecks, subscriptions, etc.). This surfaces that projection directly in the existing report.

## How it works

- Scheduled transactions were previously dropped entirely by the reports provider. They are now collected separately (`allReportableScheduledTransactions`) and exposed via report context, so **existing reports are unaffected**.
- For each account, the projection continues from its current balance (the last actual datapoint) forward to the horizon, applying each scheduled transaction's net change on the days it falls due.
- Recurring schedules are expanded across the horizon by frequency (daily → every-other-year); non-repeating schedules contribute a single occurrence. Unknown/missing frequencies degrade gracefully to a single occurrence.
- When the option is on, the date filter's end date is extended to the projection horizon so the future portion isn't clipped (the date picker otherwise caps "To" at today).
- The setting persists via `useLocalStorage`, consistent with the report's other options. Works alongside Group Accounts / by type / Step Graph / Trendline.

## Testing

- `yarn type-check`, `yarn lint`, and `yarn test` all pass.
- Added unit tests for the projection utilities (`utils.spec.ts`): frequency expansion, cutoff handling, balance carry-forward, and per-account isolation.
- Manually verified in a development build (Balance Over Time report, checkbox toggles the future projection).

## Notes for reviewers

The YNAB `frequency` string values aren't referenced elsewhere in the codebase, so they're mapped from YNAB's known set in `utils.ts` (`FREQUENCY_INTERVALS`). Worth a sanity check against a budget with varied recurrence types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)