### PR TITLE
fix(show-category-balance): update to use ember tooltip

### DIFF
--- a/src/extension/features/accounts/show-category-balance/index.js
+++ b/src/extension/features/accounts/show-category-balance/index.js
@@ -45,11 +45,18 @@ export class ShowCategoryBalance extends Feature {
       // if there's no budget data (could be an income/credit category) skip it.
       if (!budgetData) return;
 
-      const title = $('.ynab-grid-cell-subCategoryName', element).attr('title');
+      const emberTooltipId = $('.ynab-grid-cell-subCategoryName', element).attr('aria-describedby');
+
+      // There should always be an associated ember tooltip, but just in case.
+      if (!emberTooltipId) return;
+
+      const emberSelector = `#${emberTooltipId}`;
+      const title = $(emberSelector).text();
+
       const newTitle = `${title.replace(/\(Balance.*/, '').trim()} (Balance: ${formatCurrency(
         budgetData.balance,
       )})`;
-      $('.ynab-grid-cell-subCategoryName', element).attr('title', newTitle);
+      $(emberSelector).text(newTitle);
     });
   }
 }


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
Fixes the `ShowCategoryBalance` feature. Originally, YNAB used the `title` attribute for tooltips, but they have since replaced them with a JS based tooltip (ember). 

**Screenshots**

<img width="235" height="110" alt="image" src="https://github.com/user-attachments/assets/e348ed0a-babe-482f-b056-e86b4767a2a5" />
