### PR TITLE
perf: supress tooltip updates

### DIFF
--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -10,6 +10,8 @@ const IGNORE_UPDATES = new Set([
   'js-budget-toolbar-open-category-moves',
   'budget-table-cell-category-moves js-budget-toolbar-open-category-moves category-moves-hidden',
   'category-moves-hidden',
+  // no feature reads these classes today, but if one ever needs to mutate a tooltip
+  // after it opens, these suppressions will need to be revisited.
   'tooltip-content tooltip-visible',
   'tooltip-content',
   'tooltip-visible',

--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -10,6 +10,9 @@ const IGNORE_UPDATES = new Set([
   'js-budget-toolbar-open-category-moves',
   'budget-table-cell-category-moves js-budget-toolbar-open-category-moves category-moves-hidden',
   'category-moves-hidden',
+  'tooltip-content tooltip-visible',
+  'tooltip-content',
+  'tooltip-visible',
   // when you scroll on an accounts page :D
   'ynab-grid-container scrolling',
   'ynab-grid-container',


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
This modification suppresses updates based on ember’s tooltip changes. Specifically `tooltip-content` & `tooltip-visible`. These are fired constantly when the cursor moves over any rows on the Accounts pages.

Performing a quick search in the repo shows no existing features rely on these classes (by reference anyways).

**Screenshots**
N/A
