### PR TITLE
fix(row-split-months): Fix flickering when interacting with any of the rows

### DIFF
--- a/src/extension/features/accounts/row-split-months/index.css
+++ b/src/extension/features/accounts/row-split-months/index.css
@@ -1,3 +1,4 @@
 .tk-rsm-last {
-  border-bottom-width: 0.5rem;
+  /* !important is required to override is-checked styling */
+  border-bottom-width: 0.5rem !important;
 }

--- a/src/extension/features/accounts/row-split-months/index.js
+++ b/src/extension/features/accounts/row-split-months/index.js
@@ -14,7 +14,7 @@ export class RowSplitMonths extends Feature {
   observe(changedNodes) {
     if (!this.shouldInvoke()) return;
 
-    if (changedNodes.has('ynab-grid-body')) {
+    if (changedNodes.has('ynab-grid-body') || changedNodes.has('ynab-grid-body-row')) {
       this.invoke();
     }
   }
@@ -26,6 +26,12 @@ export class RowSplitMonths extends Feature {
       const nextRow = allRows.eq(ix + 1)?.[0];
 
       if (!nextRow) {
+        return;
+      }
+
+      // This element already has the necessary styling, so we can skip the extra look
+      // up (and prevent infinite updates)
+      if (element.classList.contains('tk-rsm-last')) {
         return;
       }
 

--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -120,24 +120,22 @@ export class ObserveListener {
     this.features.forEach((feature) => {
       const observe = feature.observe.bind(feature, this.changedNodes);
       const wrapped = withToolkitError(observe, feature);
-      setTimeout(() => {
-        const startFeatureObserve = Date.now();
+      const startFeatureObserve = Date.now();
 
-        wrapped();
+      wrapped();
 
-        const featureElapsed = Date.now() - startFeatureObserve;
-        if (window.ynabToolKit.enableProfiling && featureElapsed > 0) {
-          console.log(
-            `${feature.constructor.name}.observe() took %c${featureElapsed}ms%c to run`,
-            featureElapsed < 10
-              ? 'color: green'
-              : featureElapsed < 50
-              ? 'color: yellow'
-              : 'color: red',
-            '',
-          );
-        }
-      }, 0);
+      const featureElapsed = Date.now() - startFeatureObserve;
+      if (window.ynabToolKit.enableProfiling && featureElapsed > 0) {
+        console.log(
+          `${feature.constructor.name}.observe() took %c${featureElapsed}ms%c to run`,
+          featureElapsed < 10
+            ? 'color: green'
+            : featureElapsed < 50
+            ? 'color: yellow'
+            : 'color: red',
+          '',
+        );
+      }
     });
   }
 }


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
This change contains three core changes:
1. Fixes the `RowSplitMonths` feature not re-applying styling when a single row changes.
2. Fixes the `RowSplitMonths` styling to override selected row styling causing the divider to disappear.
3. Changes `observeListener.js` to no longer trigger `Feature#observe` inside a `setTimeout`. This fixes the DOM painting many times for a single mutation event. Once with the YNAB originated DOM changes, and a subsequent time for each individual feature.  

**Screenshots**
Before:

https://github.com/user-attachments/assets/049c06f7-66c0-4430-a9e5-b547a985acf3

After:

https://github.com/user-attachments/assets/7076869a-cb36-4e60-9a15-94616361fe4d


