### PR TITLE
feat(observe-listener): warn in dev when a feature's observe() loops

### DIFF
--- a/src/extension/listeners/observeListener.js
+++ b/src/extension/listeners/observeListener.js
@@ -21,10 +21,18 @@ const IGNORE_UPDATES = new Set([
   'scrolling',
 ]);
 
+// How many times a single feature's observe() can run within OBSERVE_LOOP_WINDOW_MS before
+// we warn that it's likely stuck re-triggering itself (e.g. mutating the DOM in a way that
+// satisfies its own trigger condition again, with nothing left to force a yield between calls).
+const OBSERVE_LOOP_THRESHOLD = 30;
+const OBSERVE_LOOP_WINDOW_MS = 250;
+
 export class ObserveListener {
   lastChangedNodes = new Set();
 
   duplicateCount = 0;
+
+  featureInvocationTimestamps = new Map();
 
   constructor() {
     this.features = [];
@@ -126,6 +134,10 @@ export class ObserveListener {
       const observe = feature.observe.bind(feature, this.changedNodes);
       const wrapped = withToolkitError(observe, feature);
       setTimeout(() => {
+        if (ynabToolKit.environment === 'development') {
+          this.detectObserveLoop(feature);
+        }
+
         const startFeatureObserve = Date.now();
 
         wrapped();
@@ -144,5 +156,33 @@ export class ObserveListener {
         }
       }, 0);
     });
+  }
+
+  /**
+   * Dev-only: warns if a single feature's observe() is firing many times in a very short
+   * window, which usually means its DOM mutation satisfies its own trigger condition again
+   * (e.g. adding a class without checking it's not already there) and it's stuck re-running
+   * itself with nothing forcing a yield in between.
+   */
+  detectObserveLoop(feature) {
+    const name = feature.constructor.name;
+    const now = Date.now();
+    const recentCalls = (this.featureInvocationTimestamps.get(name) || []).filter(
+      (timestamp) => now - timestamp < OBSERVE_LOOP_WINDOW_MS,
+    );
+    recentCalls.push(now);
+    this.featureInvocationTimestamps.set(name, recentCalls);
+
+    if (recentCalls.length > OBSERVE_LOOP_THRESHOLD) {
+      console.error(
+        `Possible infinite observe() loop in %c${name}%c: it ran ${recentCalls.length} times in the last ${OBSERVE_LOOP_WINDOW_MS}ms.\n` +
+          'This usually means observe()/invoke() mutates the DOM in a way that re-satisfies its own trigger condition on every pass ' +
+          '(e.g. adding a class without checking classList.contains() first). Add a guard so the mutation is a no-op once already applied.',
+        'font-weight: bold; color: red',
+        '',
+      );
+      // Reset so we don't spam the console on every subsequent call while the loop continues.
+      this.featureInvocationTimestamps.set(name, []);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds a dev-only diagnostic to `ObserveListener`: if a single feature's `observe()` runs more than 30 times in a 250ms window, it logs a `console.error` naming that feature and explaining the likely cause.

## Motivation

While reviewing #3733 (which removes the `setTimeout(fn, 0)` wrapper around each feature's `observe()` call to fix `RowSplitMonths` flicker), we traced through what that `setTimeout` was actually doing. It wasn't load-bearing for correctness — but it *was*, more than anything, an accidental hack that gave any feature whose DOM mutation happens to re-satisfy its own trigger condition a forced yield between reruns, via the macrotask boundary. Removing it (correctly, for the flicker fix) also removes that incidental protection. #3733 itself hit exactly this case in `RowSplitMonths` and had to add a `classList.contains()` guard to avoid a tight synchronous reentrancy loop.

We audited the rest of the ~56 features implementing `observe()` and didn't find another feature currently exposed to this today (the ones that looked risky at a glance turned out to be protected by other means — non-class attribute mutations being filtered out, or gate conditions that don't overlap with what they mutate). But that safety is coincidental, not structural, so a future feature could easily reintroduce this class of bug without anyone noticing until a user's tab visibly stutters or freezes.

This adds the missing feedback loop: a clear, actionable console error identifying the specific feature during development, before it ships.

## How it works

- `ObserveListener` now tracks a rolling window of invocation timestamps per feature (`featureInvocationTimestamps`).
- Each time a feature's `observe()` is about to run, `detectObserveLoop()` checks how many times that same feature has run in the last 250ms.
- If it's more than 30, logs `console.error` naming the feature and suggesting the fix (add a guard so the mutation is a no-op once already applied), then resets the counter so it doesn't spam the console every subsequent tick.
- Gated behind `ynabToolKit.environment === 'development'`, consistent with the existing `debug()` method's convention — zero overhead in production.
- Complements (doesn't replace) the existing global `duplicateCount` warning in `debug()`: that one is slower to trip (100 identical emits, no attribution) — this one is per-feature and identifies the culprit directly.

## Testing

- `yarn lint`, `yarn type-check` pass.
- Threshold (30 calls / 250ms) is a judgment call — loose enough to avoid false positives on legitimately busy features, tight enough to catch a real spin quickly. Happy to tune based on feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)