### PR TITLE
fix(show-category-balance): guard against missing route/register-grid data

### DIFF
--- a/.claude/skills/learn-ynab/SKILL.md
+++ b/.claude/skills/learn-ynab/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: learn-ynab
+description: Explore the live YNAB web app in Chrome (budget/accounts/reports pages) to learn its Ember services, DOM structure, and data shapes — since we don't have YNAB's source code and must verify everything against the running app. Use when asked to "learn ynab", investigate a YNAB internal/service/property, find what methods are callable on a given page, debug a "Cannot read properties of undefined" style Toolkit crash, or verify/update the reverse-engineered types in src/types/ynab.
+---
+
+# Learn YNAB
+
+Toolkit for YNAB is a browser extension with no access to YNAB's source. Every
+fact this repo has about YNAB's internals (`src/extension/utils/ember.ts`,
+`src/extension/utils/ynab.ts`, `src/types/ynab/**`) was learned by poking at
+the live app in a browser. This skill drives that same process: open the real
+app, navigate to the page in question, and interrogate the running Ember
+application to find out what's actually there right now.
+
+Read `CLAUDE.md` at the repo root first if you haven't already — it covers
+the extension architecture (`Feature` lifecycle, `observe()`/`shouldInvoke()`,
+the container-lookup bridge) this skill assumes.
+
+## Before you start
+
+- Load the `claude-in-chrome` skill and its tools before touching any
+  `mcp__claude-in-chrome__*` tool (`ToolSearch` with
+  `select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__computer,mcp__claude-in-chrome__read_page,mcp__claude-in-chrome__tabs_create_mcp,mcp__claude-in-chrome__javascript_tool,mcp__claude-in-chrome__read_network_requests,mcp__claude-in-chrome__read_console_messages`).
+- This drives the user's **real, logged-in YNAB account with their real
+  financial data**. Stay read-only: run inspection snippets, don't submit
+  forms, don't click destructive buttons (delete/reconcile/approve), and
+  don't trigger `alert`/`confirm`/`prompt` dialogs (they block the extension
+  — see the `claude-in-chrome` skill's dialog guidance). Treat anything you
+  read (balances, payee names, memos) as sensitive; don't paste it into
+  artifacts or anywhere outside this conversation.
+- Check `mcp__claude-in-chrome__tabs_context_mcp` first — reuse an existing
+  `app.ynab.com` tab if the user already has one open and logged in, rather
+  than opening a new one and forcing a fresh login.
+
+## 1. Get to the right page
+
+YNAB's routes (confirmed from this repo's own tests/utils, not guessed):
+
+- Budget: `https://app.ynab.com/<budget-id>/budget[/<YYYY-MM>]`
+- Accounts: `https://app.ynab.com/<budget-id>/accounts[/<account-id>]`
+- Reports: `https://app.ynab.com/<budget-id>/reports/<report>` (native) or
+  `https://app.ynab.com/<budget-id>/budget#toolkit-reports[/<tab>]` (Toolkit's
+  own reports — see `src/extension/features/toolkit-reports/README.md`)
+
+If you don't know the user's `<budget-id>`, navigate to
+`https://app.ynab.com/` and let YNAB redirect, or read it off the current
+tab's URL via `tabs_context_mcp`.
+
+## 2. Interrogate the live Ember app
+
+Use `mcp__claude-in-chrome__javascript_tool` to run snippets in the page's
+own context (same access our injected `ynab-toolkit.js` bundle has). Useful
+starting points, mirroring `src/extension/utils/ember.ts`:
+
+```js
+// Root Ember application instance (== __ynabapp__ in ember.ts)
+const app = window.YNAB.NAMESPACES[0];
+
+// List every already-instantiated container entry (services, controllers,
+// components currently in use on this page) — great for discovering what
+// exists without guessing a name first.
+Object.keys(app.__container__.cache);
+
+// Look up one service and inspect its actual current shape.
+const registerGrid = app.__container__.lookup('service:registerGrid');
+Object.keys(registerGrid);
+
+// Router / current route, mirrors getRouter()/getCurrentRouteName()
+app.__container__.lookup('router:main').currentRouteName;
+
+// YNAB's own constants/utilities global (used throughout src/extension/utils/ynab.ts)
+window.ynab.constants;
+window.ynab.utilities;
+```
+
+If a lookup throws (service not yet instantiated for this route), that's
+itself useful information — it means code shouldn't assume that service is
+present without navigating to the page that creates it first, same lesson as
+the `ShowCategoryBalance` bug (see `CLAUDE.md`).
+
+To find the DOM classes a feature's `observe()` should key off of, use
+`read_page` or the `javascript_tool` to inspect `element.className` on the
+relevant rows/cells directly, rather than trusting an existing feature's
+hardcoded selector — YNAB's markup shifts across redesigns.
+
+To understand a data shape (e.g. what a category calculation object looks
+like), `read_network_requests` on the relevant XHR/fetch call is often more
+reliable than digging through Ember internals — it's YNAB's actual wire
+format for that page.
+
+## 3. Cross-check against what this repo already claims
+
+Compare what you found against:
+
+- `src/extension/utils/ember.ts` / `src/extension/utils/ynab.ts` — the
+  wrapper functions this repo already uses.
+- `src/types/ynab/**` — the hand-maintained type hypotheses. Search for the
+  service/model name you just inspected (e.g.
+  `src/types/ynab/services/YNABRegisterGridService.d.ts`).
+
+If what you found live disagrees with a type or wrapper function, that's the
+actual bug/gap — fix the type or add the missing guard, don't just patch the
+symptom in the one feature that happened to crash.
+
+## 4. Leave a trail
+
+If you added or corrected a type in `src/types/ynab/**` based on what you
+found, that's the durable record — prefer updating the type over writing a
+one-off note. Only write a scratch note (in the scratchpad directory) if the
+finding doesn't map cleanly onto an existing type file and isn't yet worth
+committing as one.

--- a/.claude/skills/learn-ynab/SKILL.md
+++ b/.claude/skills/learn-ynab/SKILL.md
@@ -12,9 +12,10 @@ the live app in a browser. This skill drives that same process: open the real
 app, navigate to the page in question, and interrogate the running Ember
 application to find out what's actually there right now.
 
-Read `CLAUDE.md` at the repo root first if you haven't already — it covers
-the extension architecture (`Feature` lifecycle, `observe()`/`shouldInvoke()`,
-the container-lookup bridge) this skill assumes.
+Read `docs/architecture.md` and `docs/ynab-internals.md` first if you
+haven't already — they cover the extension architecture (`Feature`
+lifecycle, `observe()`/`shouldInvoke()`, the container-lookup bridge) this
+skill assumes.
 
 ## Before you start
 
@@ -76,7 +77,7 @@ window.ynab.utilities;
 If a lookup throws (service not yet instantiated for this route), that's
 itself useful information — it means code shouldn't assume that service is
 present without navigating to the page that creates it first, same lesson as
-the `ShowCategoryBalance` bug (see `CLAUDE.md`).
+the `ShowCategoryBalance` bug (see `docs/ynab-internals.md`).
 
 To find the DOM classes a feature's `observe()` should key off of, use
 `read_page` or the `javascript_tool` to inspect `element.className` on the

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,3 +15,13 @@ want to build in issues, feel free to put a note up on the github issues
 board to let the team know you're working on something new.
 
 You can find documentation on how to build features [here](https://github.com/toolkit-for-ynab/toolkit-for-ynab/blob/main/docs/building-features.md).
+
+### Opening a Pull Request
+
+Follow [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) when opening
+a PR: reference the GitHub issue if there is one, explain the bugfix/feature/
+modification and why it's needed, and include screenshots or a video for any
+visual or feature change. Note that `gh pr create` does not apply the
+template automatically when a `--body` is passed explicitly, so fill in its
+actual sections yourself rather than substituting a different summary
+format.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,141 +1,29 @@
 # Toolkit for YNAB — Development Notes
 
-## What this project is
-
 A browser extension (Chrome/Firefox/Edge) that enhances the YNAB web app at
-`https://app.ynab.com`. It is a content script injected into YNAB's page —
+`https://app.ynab.com`. It's a content script injected into YNAB's page —
 **we do not have YNAB's source code**. YNAB is a closed-source Ember.js SPA
-that we do not control and cannot see the source of. Everything we know about
-its internal services, DOM structure, and data shapes comes from manually
-poking at the live running app, not from reading their code.
+we don't control, so everything this repo knows about its internal services,
+DOM structure, and data shapes comes from manually poking at the live
+running app, not from reading their code, and it can go stale without
+warning. When touching anything that reaches into YNAB, verify it against
+the live app rather than trusting what's written here — see
+[`docs/ynab-internals.md`](./docs/ynab-internals.md).
 
-## The golden rule: verify against the live app, don't trust memory
+## Where to look
 
-YNAB can and does change internal service/property names, DOM class names,
-and Ember service shapes without warning. Nothing here is a stable contract —
-it's what someone observed at some point. When a feature crashes with
-something like `Cannot read properties of undefined (reading 'find')` deep in
-a Toolkit feature, the near-universal cause is: an assumption about YNAB's
-internal shape (a property that always existed on a service, a route that a
-feature assumed it was always running on) is no longer true. See the
-`ShowCategoryBalance` fix as a reference case: it called
-`getRegisterGridService().visibleTransactionDisplayItems.find(...)` without
-checking it was on the accounts route or guarding for the service/collection
-being undefined — every sibling feature that touches the register grid
-service (`RowSplitMonths`, `ResetColumnWidths`, ...) gates on
-`isCurrentRouteAccountsPage()` first; this one didn't.
-
-Before trusting a property/method documented anywhere in this repo
-(including `src/types/ynab/**`), verify it still exists live. Use the
-`learn-ynab` skill (`.claude/skills/learn-ynab/`) to do that.
-
-## How the extension works
-
-- The build produces `ynab-toolkit.js`, injected as a web-accessible resource
-  so it runs in the page's own JS context — it has direct access to the
-  page's global `window.YNAB` (Ember application namespace) and `$` (jQuery).
-- Every feature (`src/extension/features/**`) extends `Feature`
-  (`src/extension/features/feature.ts`) and implements lifecycle hooks:
-  `constructor`, `willInvoke`, `shouldInvoke`, `invoke`, `observe`,
-  `onRouteChanged`, `onBudgetChanged`, `destroy`, `injectCSS`. Full contract
-  in `docs/building-features.md` — read it before writing or modifying a
-  feature.
-- DOM changes are watched by a single global `MutationObserver`
-  (`src/extension/listeners/observeListener.js`) that calls every enabled
-  feature's `observe(changedNodes)` on every relevant mutation.
-  **`observe()` is not automatically gated by `shouldInvoke()`** — each
-  feature must call `this.shouldInvoke()` (or otherwise check its own
-  preconditions) inside `observe()` itself if it wants that guard. Forgetting
-  this is a recurring bug source.
-- Route changes are detected via Ember observers on `currentRouteName`,
-  `budgetVersionId`, `selectedAccountId`, `monthString`, surfaced through
-  `onRouteChanged(currentRoute)`.
-
-## Reaching into YNAB's live Ember app
-
-- `src/extension/utils/ember.ts` is the bridge into YNAB's app instance:
-  `__ynabapp__ = YNAB.NAMESPACES[0]`. `containerLookup`, `serviceLookup`,
-  `controllerLookup`, `componentLookup`, `factoryLookup` all resolve through
-  `__ynabapp__.__container__` (Ember's DI container).
-- `src/extension/utils/ynab.ts` wraps the common lookups:
-  `getBudgetService()`, `getRegisterGridService()`, `getAccountsService()`,
-  `getModalService()`, `getApplicationService()`, `getRouter()`,
-  `isCurrentRouteAccountsPage()` / `isCurrentRouteBudgetPage()` /
-  `isCurrentRouteReportPage()`, etc.
-- `src/types/ynab/**` holds hand-maintained, reverse-engineered TypeScript
-  types for YNAB's internal services/models (budget service, register grid
-  service, transaction/sub-category/payee collections, Ember view registry,
-  window globals...). These are best-effort documentation of what someone
-  found live at some point — not official types. Treat them as a starting
-  hypothesis, not ground truth.
-
-## We don't have YNAB's source — how to investigate
-
-1. Reproduce the scenario live at `app.ynab.com` (the `claude-in-chrome`
-   tools/skill drive this).
-2. Read the console error carefully. Toolkit errors are wrapped with the
-   feature name/setting/function
-   (`src/core/common/errors/with-toolkit-error.ts`). A stack frame pointing
-   into `chrome-extension://.../ynab-toolkit.js` is _our_ compiled bundle; a
-   frame pointing into YNAB's own hashed `vendor.*.js` / `ynab_web` bundle is
-   _their_ code (unminified source isn't available to us — don't try to read
-   it, talk to the live app instead).
-3. Inspect YNAB's live state directly instead of guessing from a minified
-   stack trace:
-   - Run JS against `window.YNAB.NAMESPACES[0].__container__` in the page
-     console, e.g. `Object.keys(YNAB.NAMESPACES[0].__container__.cache)` to
-     list already-instantiated services/controllers, or
-     `YNAB.NAMESPACES[0].__container__.lookup('service:registerGrid')` to
-     inspect one service's live shape and confirm a property still exists.
-   - Check the Network tab for what YNAB's API actually returns on a given
-     page — useful for confirming data shapes independent of Ember internals.
-   - Inspect the DOM for the current class names a feature's `observe()`
-     keys off of; these shift on YNAB redesigns.
-4. Update `src/types/ynab/**` to match what you actually found live, and add
-   `?.`/existence guards in feature code accordingly — every reach into
-   YNAB's internals should assume the property might be missing or renamed,
-   because it eventually will be.
-
-## Build / test / lint
-
-- `yarn build:dev` / `yarn watch` — build into `dist/extension`; load
-  unpacked via `chrome://extensions` (Developer Mode → Load unpacked). See
-  `docs/testing.md` for Chrome/Firefox specifics.
-- `yarn test` — Jest, jsdom environment pre-seeded to look like
-  `app.ynab.com` (`src/test/setup.js`). Feature tests typically
-  `jest.mock('toolkit/extension/features/feature')` and
-  `jest.spyOn(ynabUtils, 'someLookup')` to fake the Ember layer rather than
-  standing up real Ember state.
-- `yarn lint` / `yarn lint:fix` — ESLint.
-- `yarn gen` — regenerates `src/core/settings/settings.ts`,
-  `docs/feature-list.md`, and the feature index from each feature's
-  `settings.js`. Run after adding/renaming a feature or changing its
-  settings. (These generated files aren't committed from a fresh worktree —
-  if Jest fails with "Could not locate module ... settings", run `yarn gen`
-  first.)
-- `yarn type-check` — `tsc --skipLibCheck`.
-
-## Where things live
-
-- `src/extension/features/<section>/<feature-name>/` — one directory per
-  feature (`index.{js,ts}` + `settings.js` + optional `index.css`/tests).
-  Sections: `accounts/`, `budget/`, `general/`, `reports/` (tweaks to
-  YNAB's native reports), `toolkit-reports/` (fully Toolkit-authored
-  reports).
-- `src/extension/utils/` — shared helpers (`ember.ts`, `ynab.ts`, `date.ts`,
-  `currency.ts`, ...).
-- `src/extension/listeners/` — the `MutationObserver` (`observeListener.js`)
-  and route-change listener that drive every feature's lifecycle.
-- `src/types/ynab/` — reverse-engineered types for YNAB's internals.
-- `docs/building-features.md` — the Feature lifecycle contract.
-- `docs/testing.md` — loading the built extension into a browser to test
-  manually.
-
-## Opening pull requests
-
-Read `.github/PULL_REQUEST_TEMPLATE.md` and follow it — `gh pr create` does
-not apply the template automatically when a body is passed explicitly, so
-fill in its actual sections yourself (GitHub issue reference if applicable,
-explanation of the bugfix/feature/modification and why, screenshots/video
-for anything visual or feature-affecting) rather than substituting your own
-free-form summary format.
+- [`docs/architecture.md`](./docs/architecture.md) — how the extension is
+  structured: the Feature lifecycle, the MutationObserver/route-change
+  plumbing, where code lives.
+- [`docs/building-features.md`](./docs/building-features.md) — the `Feature`
+  class contract; read before writing or modifying a feature.
+- [`docs/ynab-internals.md`](./docs/ynab-internals.md) — reaching into
+  YNAB's live Ember app, the reverse-engineered types in `src/types/ynab/`,
+  and how to investigate when something breaks. Operationalized by the
+  `learn-ynab` skill (`.claude/skills/learn-ynab/`).
+- [`docs/development.md`](./docs/development.md) — build/test/lint commands,
+  code generation.
+- [`docs/testing.md`](./docs/testing.md) — loading the built extension into
+  a browser for manual testing.
+- [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md) — contribution
+  process, including the PR template.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,141 @@
+# Toolkit for YNAB — Development Notes
+
+## What this project is
+
+A browser extension (Chrome/Firefox/Edge) that enhances the YNAB web app at
+`https://app.ynab.com`. It is a content script injected into YNAB's page —
+**we do not have YNAB's source code**. YNAB is a closed-source Ember.js SPA
+that we do not control and cannot see the source of. Everything we know about
+its internal services, DOM structure, and data shapes comes from manually
+poking at the live running app, not from reading their code.
+
+## The golden rule: verify against the live app, don't trust memory
+
+YNAB can and does change internal service/property names, DOM class names,
+and Ember service shapes without warning. Nothing here is a stable contract —
+it's what someone observed at some point. When a feature crashes with
+something like `Cannot read properties of undefined (reading 'find')` deep in
+a Toolkit feature, the near-universal cause is: an assumption about YNAB's
+internal shape (a property that always existed on a service, a route that a
+feature assumed it was always running on) is no longer true. See the
+`ShowCategoryBalance` fix as a reference case: it called
+`getRegisterGridService().visibleTransactionDisplayItems.find(...)` without
+checking it was on the accounts route or guarding for the service/collection
+being undefined — every sibling feature that touches the register grid
+service (`RowSplitMonths`, `ResetColumnWidths`, ...) gates on
+`isCurrentRouteAccountsPage()` first; this one didn't.
+
+Before trusting a property/method documented anywhere in this repo
+(including `src/types/ynab/**`), verify it still exists live. Use the
+`learn-ynab` skill (`.claude/skills/learn-ynab/`) to do that.
+
+## How the extension works
+
+- The build produces `ynab-toolkit.js`, injected as a web-accessible resource
+  so it runs in the page's own JS context — it has direct access to the
+  page's global `window.YNAB` (Ember application namespace) and `$` (jQuery).
+- Every feature (`src/extension/features/**`) extends `Feature`
+  (`src/extension/features/feature.ts`) and implements lifecycle hooks:
+  `constructor`, `willInvoke`, `shouldInvoke`, `invoke`, `observe`,
+  `onRouteChanged`, `onBudgetChanged`, `destroy`, `injectCSS`. Full contract
+  in `docs/building-features.md` — read it before writing or modifying a
+  feature.
+- DOM changes are watched by a single global `MutationObserver`
+  (`src/extension/listeners/observeListener.js`) that calls every enabled
+  feature's `observe(changedNodes)` on every relevant mutation.
+  **`observe()` is not automatically gated by `shouldInvoke()`** — each
+  feature must call `this.shouldInvoke()` (or otherwise check its own
+  preconditions) inside `observe()` itself if it wants that guard. Forgetting
+  this is a recurring bug source.
+- Route changes are detected via Ember observers on `currentRouteName`,
+  `budgetVersionId`, `selectedAccountId`, `monthString`, surfaced through
+  `onRouteChanged(currentRoute)`.
+
+## Reaching into YNAB's live Ember app
+
+- `src/extension/utils/ember.ts` is the bridge into YNAB's app instance:
+  `__ynabapp__ = YNAB.NAMESPACES[0]`. `containerLookup`, `serviceLookup`,
+  `controllerLookup`, `componentLookup`, `factoryLookup` all resolve through
+  `__ynabapp__.__container__` (Ember's DI container).
+- `src/extension/utils/ynab.ts` wraps the common lookups:
+  `getBudgetService()`, `getRegisterGridService()`, `getAccountsService()`,
+  `getModalService()`, `getApplicationService()`, `getRouter()`,
+  `isCurrentRouteAccountsPage()` / `isCurrentRouteBudgetPage()` /
+  `isCurrentRouteReportPage()`, etc.
+- `src/types/ynab/**` holds hand-maintained, reverse-engineered TypeScript
+  types for YNAB's internal services/models (budget service, register grid
+  service, transaction/sub-category/payee collections, Ember view registry,
+  window globals...). These are best-effort documentation of what someone
+  found live at some point — not official types. Treat them as a starting
+  hypothesis, not ground truth.
+
+## We don't have YNAB's source — how to investigate
+
+1. Reproduce the scenario live at `app.ynab.com` (the `claude-in-chrome`
+   tools/skill drive this).
+2. Read the console error carefully. Toolkit errors are wrapped with the
+   feature name/setting/function
+   (`src/core/common/errors/with-toolkit-error.ts`). A stack frame pointing
+   into `chrome-extension://.../ynab-toolkit.js` is _our_ compiled bundle; a
+   frame pointing into YNAB's own hashed `vendor.*.js` / `ynab_web` bundle is
+   _their_ code (unminified source isn't available to us — don't try to read
+   it, talk to the live app instead).
+3. Inspect YNAB's live state directly instead of guessing from a minified
+   stack trace:
+   - Run JS against `window.YNAB.NAMESPACES[0].__container__` in the page
+     console, e.g. `Object.keys(YNAB.NAMESPACES[0].__container__.cache)` to
+     list already-instantiated services/controllers, or
+     `YNAB.NAMESPACES[0].__container__.lookup('service:registerGrid')` to
+     inspect one service's live shape and confirm a property still exists.
+   - Check the Network tab for what YNAB's API actually returns on a given
+     page — useful for confirming data shapes independent of Ember internals.
+   - Inspect the DOM for the current class names a feature's `observe()`
+     keys off of; these shift on YNAB redesigns.
+4. Update `src/types/ynab/**` to match what you actually found live, and add
+   `?.`/existence guards in feature code accordingly — every reach into
+   YNAB's internals should assume the property might be missing or renamed,
+   because it eventually will be.
+
+## Build / test / lint
+
+- `yarn build:dev` / `yarn watch` — build into `dist/extension`; load
+  unpacked via `chrome://extensions` (Developer Mode → Load unpacked). See
+  `docs/testing.md` for Chrome/Firefox specifics.
+- `yarn test` — Jest, jsdom environment pre-seeded to look like
+  `app.ynab.com` (`src/test/setup.js`). Feature tests typically
+  `jest.mock('toolkit/extension/features/feature')` and
+  `jest.spyOn(ynabUtils, 'someLookup')` to fake the Ember layer rather than
+  standing up real Ember state.
+- `yarn lint` / `yarn lint:fix` — ESLint.
+- `yarn gen` — regenerates `src/core/settings/settings.ts`,
+  `docs/feature-list.md`, and the feature index from each feature's
+  `settings.js`. Run after adding/renaming a feature or changing its
+  settings. (These generated files aren't committed from a fresh worktree —
+  if Jest fails with "Could not locate module ... settings", run `yarn gen`
+  first.)
+- `yarn type-check` — `tsc --skipLibCheck`.
+
+## Where things live
+
+- `src/extension/features/<section>/<feature-name>/` — one directory per
+  feature (`index.{js,ts}` + `settings.js` + optional `index.css`/tests).
+  Sections: `accounts/`, `budget/`, `general/`, `reports/` (tweaks to
+  YNAB's native reports), `toolkit-reports/` (fully Toolkit-authored
+  reports).
+- `src/extension/utils/` — shared helpers (`ember.ts`, `ynab.ts`, `date.ts`,
+  `currency.ts`, ...).
+- `src/extension/listeners/` — the `MutationObserver` (`observeListener.js`)
+  and route-change listener that drive every feature's lifecycle.
+- `src/types/ynab/` — reverse-engineered types for YNAB's internals.
+- `docs/building-features.md` — the Feature lifecycle contract.
+- `docs/testing.md` — loading the built extension into a browser to test
+  manually.
+
+## Opening pull requests
+
+Read `.github/PULL_REQUEST_TEMPLATE.md` and follow it — `gh pr create` does
+not apply the template automatically when a body is passed explicitly, so
+fill in its actual sections yourself (GitHub issue reference if applicable,
+explanation of the bugfix/feature/modification and why, screenshots/video
+for anything visual or feature-affecting) rather than substituting your own
+free-form summary format.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,37 @@
+# Extension Architecture
+
+## How the extension works
+
+- The build produces `ynab-toolkit.js`, injected as a web-accessible resource
+  so it runs in the page's own JS context — it has direct access to the
+  page's global `window.YNAB` (Ember application namespace) and `$` (jQuery).
+- Every feature (`src/extension/features/**`) extends `Feature`
+  (`src/extension/features/feature.ts`) and implements lifecycle hooks:
+  `constructor`, `willInvoke`, `shouldInvoke`, `invoke`, `observe`,
+  `onRouteChanged`, `onBudgetChanged`, `destroy`, `injectCSS`. Full contract
+  in [`building-features.md`](./building-features.md) — read it before
+  writing or modifying a feature.
+- DOM changes are watched by a single global `MutationObserver`
+  (`src/extension/listeners/observeListener.js`) that calls every enabled
+  feature's `observe(changedNodes)` on every relevant mutation.
+  **`observe()` is not automatically gated by `shouldInvoke()`** — each
+  feature must call `this.shouldInvoke()` (or otherwise check its own
+  preconditions) inside `observe()` itself if it wants that guard. Forgetting
+  this is a recurring bug source.
+- Route changes are detected via Ember observers on `currentRouteName`,
+  `budgetVersionId`, `selectedAccountId`, `monthString`, surfaced through
+  `onRouteChanged(currentRoute)`.
+
+## Where things live
+
+- `src/extension/features/<section>/<feature-name>/` — one directory per
+  feature (`index.{js,ts}` + `settings.js` + optional `index.css`/tests).
+  Sections: `accounts/`, `budget/`, `general/`, `reports/` (tweaks to
+  YNAB's native reports), `toolkit-reports/` (fully Toolkit-authored
+  reports).
+- `src/extension/utils/` — shared helpers (`ember.ts`, `ynab.ts`, `date.ts`,
+  `currency.ts`, ...). See [`ynab-internals.md`](./ynab-internals.md) for
+  `ember.ts`/`ynab.ts` specifically.
+- `src/extension/listeners/` — the `MutationObserver` (`observeListener.js`)
+  and route-change listener that drive every feature's lifecycle.
+- `src/types/ynab/` — reverse-engineered types for YNAB's internals.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,18 @@
+# Build / Test / Lint
+
+- `yarn build:dev` / `yarn watch` — build into `dist/extension`; load
+  unpacked via `chrome://extensions` (Developer Mode → Load unpacked). See
+  [`testing.md`](./testing.md) for Chrome/Firefox specifics.
+- `yarn test` — Jest, jsdom environment pre-seeded to look like
+  `app.ynab.com` (`src/test/setup.js`). Feature tests typically
+  `jest.mock('toolkit/extension/features/feature')` and
+  `jest.spyOn(ynabUtils, 'someLookup')` to fake the Ember layer rather than
+  standing up real Ember state.
+- `yarn lint` / `yarn lint:fix` — ESLint.
+- `yarn gen` — regenerates `src/core/settings/settings.ts`,
+  `docs/feature-list.md`, and the feature index from each feature's
+  `settings.js`. Run after adding/renaming a feature or changing its
+  settings. (These generated files aren't committed from a fresh worktree —
+  if Jest fails with "Could not locate module ... settings", run `yarn gen`
+  first.)
+- `yarn type-check` — `tsc --skipLibCheck`.

--- a/docs/ynab-internals.md
+++ b/docs/ynab-internals.md
@@ -1,0 +1,75 @@
+# Working With YNAB's Internals
+
+We ship a browser extension against `https://app.ynab.com` and **do not have
+YNAB's source code**. YNAB is a closed-source Ember.js SPA that we do not
+control and cannot see the source of. Everything this repo knows about its
+internal services, DOM structure, and data shapes comes from manually poking
+at the live running app, not from reading their code.
+
+## The golden rule: verify against the live app, don't trust memory
+
+YNAB can and does change internal service/property names, DOM class names,
+and Ember service shapes without warning. Nothing here is a stable contract —
+it's what someone observed at some point. When a feature crashes with
+something like `Cannot read properties of undefined (reading 'find')` deep in
+a Toolkit feature, the near-universal cause is: an assumption about YNAB's
+internal shape (a property that always existed on a service, a route that a
+feature assumed it was always running on) is no longer true. See the
+`ShowCategoryBalance` fix as a reference case: it called
+`getRegisterGridService().visibleTransactionDisplayItems.find(...)` without
+checking it was on the accounts route or guarding for the service/collection
+being undefined — every sibling feature that touches the register grid
+service (`RowSplitMonths`, `ResetColumnWidths`, ...) gates on
+`isCurrentRouteAccountsPage()` first; this one didn't.
+
+Before trusting a property/method documented anywhere in this repo
+(including `src/types/ynab/**`), verify it still exists live. Use the
+`learn-ynab` skill (`.claude/skills/learn-ynab/`) to do that.
+
+## Reaching into YNAB's live Ember app
+
+- `src/extension/utils/ember.ts` is the bridge into YNAB's app instance:
+  `__ynabapp__ = YNAB.NAMESPACES[0]`. `containerLookup`, `serviceLookup`,
+  `controllerLookup`, `componentLookup`, `factoryLookup` all resolve through
+  `__ynabapp__.__container__` (Ember's DI container).
+- `src/extension/utils/ynab.ts` wraps the common lookups:
+  `getBudgetService()`, `getRegisterGridService()`, `getAccountsService()`,
+  `getModalService()`, `getApplicationService()`, `getRouter()`,
+  `isCurrentRouteAccountsPage()` / `isCurrentRouteBudgetPage()` /
+  `isCurrentRouteReportPage()`, etc.
+- `src/types/ynab/**` holds hand-maintained, reverse-engineered TypeScript
+  types for YNAB's internal services/models (budget service, register grid
+  service, transaction/sub-category/payee collections, Ember view registry,
+  window globals...). These are best-effort documentation of what someone
+  found live at some point — not official types. Treat them as a starting
+  hypothesis, not ground truth.
+
+## We don't have YNAB's source — how to investigate
+
+1. Reproduce the scenario live at `app.ynab.com` (the `claude-in-chrome`
+   tools/skill drive this).
+2. Read the console error carefully. Toolkit errors are wrapped with the
+   feature name/setting/function
+   (`src/core/common/errors/with-toolkit-error.ts`). A stack frame pointing
+   into `chrome-extension://.../ynab-toolkit.js` is _our_ compiled bundle; a
+   frame pointing into YNAB's own hashed `vendor.*.js` / `ynab_web` bundle is
+   _their_ code (unminified source isn't available to us — don't try to read
+   it, talk to the live app instead).
+3. Inspect YNAB's live state directly instead of guessing from a minified
+   stack trace:
+   - Run JS against `window.YNAB.NAMESPACES[0].__container__` in the page
+     console, e.g. `Object.keys(YNAB.NAMESPACES[0].__container__.cache)` to
+     list already-instantiated services/controllers, or
+     `YNAB.NAMESPACES[0].__container__.lookup('service:registerGrid')` to
+     inspect one service's live shape and confirm a property still exists.
+   - Check the Network tab for what YNAB's API actually returns on a given
+     page — useful for confirming data shapes independent of Ember internals.
+   - Inspect the DOM for the current class names a feature's `observe()`
+     keys off of; these shift on YNAB redesigns.
+4. Update `src/types/ynab/**` to match what you actually found live, and add
+   `?.`/existence guards in feature code accordingly — every reach into
+   YNAB's internals should assume the property might be missing or renamed,
+   because it eventually will be.
+
+See also the `learn-ynab` skill (`.claude/skills/learn-ynab/`), which
+operationalizes this workflow end-to-end in a browser.

--- a/src/extension/features/accounts/show-category-balance/index.js
+++ b/src/extension/features/accounts/show-category-balance/index.js
@@ -1,14 +1,20 @@
 import { Feature } from 'toolkit/extension/features/feature';
-import { getAllBudgetMonthsViewModel, getRegisterGridService } from 'toolkit/extension/utils/ynab';
+import {
+  getAllBudgetMonthsViewModel,
+  getRegisterGridService,
+  isCurrentRouteAccountsPage,
+} from 'toolkit/extension/utils/ynab';
 import { getCurrentDate } from 'toolkit/extension/utils/date';
 import { formatCurrency } from 'toolkit/extension/utils/currency';
 
 export class ShowCategoryBalance extends Feature {
   shouldInvoke() {
-    return $('.ynab-grid-body-row').length > 0;
+    return isCurrentRouteAccountsPage() && $('.ynab-grid-body-row').length > 0;
   }
 
   observe(changedNodes) {
+    if (!this.shouldInvoke()) return;
+
     if (changedNodes.has('ynab-grid-body-row')) {
       this.invoke();
     }
@@ -19,12 +25,15 @@ export class ShowCategoryBalance extends Feature {
   }
 
   invoke() {
+    const visibleTransactionDisplayItems = getRegisterGridService()?.visibleTransactionDisplayItems;
+    if (!visibleTransactionDisplayItems) {
+      return;
+    }
+
     $('.ynab-grid-body-row').each((_, element) => {
-      const transaction = getRegisterGridService().visibleTransactionDisplayItems.find(
-        ({ entityId }) => {
-          return entityId === element.dataset.rowId;
-        },
-      );
+      const transaction = visibleTransactionDisplayItems.find(({ entityId }) => {
+        return entityId === element.dataset.rowId;
+      });
       if (!transaction) {
         return;
       }

--- a/src/extension/features/accounts/show-category-balance/index.test.js
+++ b/src/extension/features/accounts/show-category-balance/index.test.js
@@ -1,0 +1,73 @@
+jest.mock('toolkit/extension/features/feature');
+
+import * as ynabUtils from 'toolkit/extension/utils/ynab';
+import { ShowCategoryBalance } from './index';
+
+describe('ShowCategoryBalance', () => {
+  let feature;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    feature = new ShowCategoryBalance();
+  });
+
+  function addGridRow(rowId) {
+    const row = document.createElement('div');
+    row.className = 'ynab-grid-body-row';
+    row.dataset.rowId = rowId;
+    document.body.appendChild(row);
+    return row;
+  }
+
+  describe('shouldInvoke()', () => {
+    it('is false when not on the accounts route, even if grid rows are present', () => {
+      jest.spyOn(ynabUtils, 'isCurrentRouteAccountsPage').mockReturnValue(false);
+      addGridRow('txn-1');
+
+      expect(feature.shouldInvoke()).toBe(false);
+    });
+
+    it('is true on the accounts route when grid rows are present', () => {
+      jest.spyOn(ynabUtils, 'isCurrentRouteAccountsPage').mockReturnValue(true);
+      addGridRow('txn-1');
+
+      expect(feature.shouldInvoke()).toBe(true);
+    });
+  });
+
+  describe('invoke()', () => {
+    it('does not throw when visibleTransactionDisplayItems is undefined', () => {
+      addGridRow('txn-1');
+      jest.spyOn(ynabUtils, 'getRegisterGridService').mockReturnValue({});
+
+      expect(() => feature.invoke()).not.toThrow();
+    });
+
+    it('does not throw when the register grid service itself is undefined', () => {
+      addGridRow('txn-1');
+      jest.spyOn(ynabUtils, 'getRegisterGridService').mockReturnValue(undefined);
+
+      expect(() => feature.invoke()).not.toThrow();
+    });
+  });
+
+  describe('observe()', () => {
+    it('does not invoke when shouldInvoke() is false', () => {
+      jest.spyOn(feature, 'shouldInvoke').mockReturnValue(false);
+      const invokeSpy = jest.spyOn(feature, 'invoke');
+
+      feature.observe(new Set(['ynab-grid-body-row']));
+
+      expect(invokeSpy).not.toHaveBeenCalled();
+    });
+
+    it('invokes when shouldInvoke() is true and a relevant node changed', () => {
+      jest.spyOn(feature, 'shouldInvoke').mockReturnValue(true);
+      const invokeSpy = jest.spyOn(feature, 'invoke').mockImplementation(() => {});
+
+      feature.observe(new Set(['ynab-grid-body-row']));
+
+      expect(invokeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
GitHub Issue (if applicable): N/A (reported via console error, not a filed issue)

**Explanation of Bugfix/Feature/Modification:**

`ShowCategoryBalance` was crashing with:

```
Cannot read properties of undefined (reading 'find') TypeError: Cannot read properties of undefined (reading 'find')
```

Root cause: unlike every other accounts feature that touches
`getRegisterGridService()` (`RowSplitMonths`, `ResetColumnWidths`, etc.),
`ShowCategoryBalance.shouldInvoke()` never checked `isCurrentRouteAccountsPage()`,
and its `observe()` didn't call `shouldInvoke()` at all before invoking. That let
`invoke()` run in states where the register grid service's
`visibleTransactionDisplayItems` collection wasn't populated for the current
context, so `.find(...)` threw on `undefined`.

Fix:
- `shouldInvoke()` now also requires `isCurrentRouteAccountsPage()`.
- `observe()` now bails early via `shouldInvoke()`, matching the sibling feature pattern.
- `invoke()` hoists and guards `visibleTransactionDisplayItems` so a missing/undefined collection is a no-op instead of a crash.

Also added `.claude/skills/learn-ynab/` and a repo-root `CLAUDE.md` documenting
that this project has no access to YNAB's source and how to safely
investigate/verify YNAB's internals live in the browser when debugging issues
like this one, plus a note on following `.github/PULL_REQUEST_TEMPLATE.md` when
opening PRs.

**Screenshots**

Not applicable — this is a defensive/logic fix with no visual change; covered by new unit tests in `index.test.js` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)