### PR TITLE
feat(toolkit-reports): replace report nav with anchored popovers

### DIFF
--- a/src/extension/features/toolkit-reports/common/components/popover/component.tsx
+++ b/src/extension/features/toolkit-reports/common/components/popover/component.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import './styles.scss';
+
+const VIEWPORT_MARGIN = 12;
+const TRIGGER_GAP = 4;
+const MIN_CONTENT_HEIGHT = 150;
+
+export type PopoverTriggerProps = {
+  isOpen: boolean;
+  toggle: () => void;
+};
+
+export type PopoverProps = {
+  align?: 'left' | 'right';
+  disabled?: boolean;
+  renderTrigger: (props: PopoverTriggerProps) => React.ReactNode;
+  children: (props: { close: () => void }) => React.ReactNode;
+};
+
+type Position = {
+  top: number;
+  left: number;
+  maxHeight: number;
+  maxWidth: number;
+};
+
+export function Popover({ align = 'left', disabled, renderTrigger, children }: PopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState<Position | null>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setPosition(null);
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+    setIsOpen((wasOpen) => !wasOpen);
+  }, [disabled]);
+
+  useLayoutEffect(() => {
+    if (!isOpen || !triggerRef.current || !contentRef.current) {
+      return;
+    }
+
+    function reposition() {
+      const triggerRect = triggerRef.current!.getBoundingClientRect();
+      const contentRect = contentRef.current!.getBoundingClientRect();
+
+      const maxWidth = window.innerWidth - VIEWPORT_MARGIN * 2;
+      const contentWidth = Math.min(contentRect.width, maxWidth);
+
+      const preferredLeft = align === 'right' ? triggerRect.right - contentWidth : triggerRect.left;
+      const left = Math.min(
+        Math.max(preferredLeft, VIEWPORT_MARGIN),
+        window.innerWidth - contentWidth - VIEWPORT_MARGIN,
+      );
+
+      const top = Math.min(
+        triggerRect.bottom + TRIGGER_GAP,
+        window.innerHeight - VIEWPORT_MARGIN - MIN_CONTENT_HEIGHT,
+      );
+      const maxHeight = window.innerHeight - top - VIEWPORT_MARGIN;
+
+      setPosition({ top, left, maxHeight, maxWidth });
+    }
+
+    reposition();
+
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [isOpen, align]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node;
+      if (!triggerRef.current?.contains(target) && !contentRef.current?.contains(target)) {
+        close();
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        close();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, close]);
+
+  return (
+    <div className="tk-popover" ref={triggerRef}>
+      {renderTrigger({ isOpen, toggle })}
+      {isOpen && (
+        <div
+          className="tk-popover__content"
+          ref={contentRef}
+          style={
+            position
+              ? {
+                  top: position.top,
+                  left: position.left,
+                  maxHeight: position.maxHeight,
+                  maxWidth: position.maxWidth,
+                }
+              : { top: 0, left: 0, visibility: 'hidden' }
+          }
+        >
+          {children({ close })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/extension/features/toolkit-reports/common/components/popover/index.ts
+++ b/src/extension/features/toolkit-reports/common/components/popover/index.ts
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/extension/features/toolkit-reports/common/components/popover/styles.scss
+++ b/src/extension/features/toolkit-reports/common/components/popover/styles.scss
@@ -1,0 +1,12 @@
+.tk-popover {
+  display: inline-flex;
+}
+
+.tk-popover__content {
+  position: fixed;
+  z-index: 1000;
+  overflow-y: auto;
+  border-radius: 0.5rem;
+  background-color: var(--backgroundPrimaryElevated);
+  box-shadow: 0 0.25rem 1.5rem 0 rgba(0, 0, 0, 0.35);
+}

--- a/src/extension/features/toolkit-reports/pages/root/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/component.tsx
@@ -30,8 +30,10 @@ export const RootComponent = ({
 
   return (
     <div className="tk-reports-root tk-flex tk-flex-column tk-full-height">
-      <ReportSelector />
-      <ReportFilters />
+      <div className="tk-reports-toolbar">
+        <ReportSelector />
+        <ReportFilters />
+      </div>
       <Report />
     </div>
   );

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/component.tsx
@@ -5,116 +5,116 @@ import {
   SelectedReportContextPropType,
 } from 'toolkit-reports/common/components/report-context/component';
 import classnames from 'classnames';
+import { Popover } from 'toolkit/extension/features/toolkit-reports/common/components/popover';
 import './styles.scss';
 import { AccountFilter } from './components/account-filter';
 import { CategoryFilter } from './components/category-filter';
 import { DateFilter } from './components/date-filter';
 
 export type ReportFiltersProps = {
-  closeModal: VoidFunction;
   filters: FiltersType;
   selectedReport: SelectedReportContextPropType;
   setFilters: (filter: FiltersType) => void;
-  showAccountFilterModal: (props: React.ComponentProps<typeof AccountFilter>) => void;
-  showCategoryFilterModal: (props: React.ComponentProps<typeof CategoryFilter>) => void;
-  showDateSelectorModal: (props: React.ComponentProps<typeof DateFilter>) => void;
 };
 
-export class ReportFiltersComponent extends React.Component<ReportFiltersProps> {
-  render() {
-    const { disableCategoryFilter } = this.props.selectedReport.filterSettings;
-    const ExtraComponent = this.props.selectedReport.filtersExtraComponent;
-    const { accountFilterIds, categoryFilterIds, dateFilter } = this.props.filters;
-    const categoryButtonClasses = classnames(
-      'tk-button',
-      'tk-button--hollow',
-      'tk-button--medium',
-      'tk-button--text',
-      {
-        'tk-button--disabled': disableCategoryFilter,
-      },
-    );
+export function ReportFiltersComponent({
+  filters,
+  selectedReport,
+  setFilters,
+}: ReportFiltersProps) {
+  const { disableCategoryFilter, includeTrackingAccounts } = selectedReport.filterSettings;
+  const ExtraComponent = selectedReport.filtersExtraComponent;
+  const { accountFilterIds, categoryFilterIds, dateFilter } = filters;
 
-    return (
-      <div className="tk-flex tk-pd-05 tk-flex-shrink-none tk-border-y">
-        <div className="tk-flex">
-          <div className="tk-mg-r-05">
-            <button onClick={this._showCategoryFilterModal} className={categoryButtonClasses}>
-              {categoryFilterIds.size ? 'Some Categories' : 'All Categories'}
-            </button>
-          </div>
-          <div className="tk-mg-r-05">
-            <button
-              onClick={this._showAccountFilterModal}
-              className="tk-button tk-button--hollow tk-button--medium tk-button--text"
-            >
-              {accountFilterIds.size ? 'Some Accounts' : 'All Accounts'}
-            </button>
-          </div>
-          <div className="tk-mg-r-05">
-            <button
-              onClick={this._showDateSelectorModal}
-              className="tk-button tk-button--hollow tk-button--medium tk-button--text"
-            >
-              {`${localizedMonthAndYear(dateFilter.fromDate)} - ${localizedMonthAndYear(
-                dateFilter.toDate,
-              )}`}
-            </button>
-          </div>
+  const categoryButtonClasses = classnames(
+    'tk-button',
+    'tk-button--hollow',
+    'tk-button--medium',
+    'tk-button--text',
+    {
+      'tk-button--disabled': disableCategoryFilter,
+    },
+  );
+
+  const applyFilters = (newFilters: Partial<FiltersType>) => {
+    setFilters({ ...filters, ...newFilters });
+  };
+
+  return (
+    <div className="tk-flex tk-flex-shrink-none">
+      <div className="tk-flex">
+        <div className="tk-mg-r-05">
+          <Popover
+            disabled={disableCategoryFilter}
+            renderTrigger={({ toggle }) => (
+              <button onClick={toggle} className={categoryButtonClasses}>
+                {categoryFilterIds.size ? 'Some Categories' : 'All Categories'}
+              </button>
+            )}
+          >
+            {({ close }) => (
+              <CategoryFilter
+                categoryFilterIds={categoryFilterIds}
+                onCancel={close}
+                onSave={(categories) => {
+                  close();
+                  applyFilters({ categoryFilterIds: categories });
+                }}
+              />
+            )}
+          </Popover>
         </div>
-        {!!ExtraComponent && <ExtraComponent />}
+        <div className="tk-mg-r-05">
+          <Popover
+            renderTrigger={({ toggle }) => (
+              <button
+                onClick={toggle}
+                className="tk-button tk-button--hollow tk-button--medium tk-button--text"
+              >
+                {accountFilterIds.size ? 'Some Accounts' : 'All Accounts'}
+              </button>
+            )}
+          >
+            {({ close }) => (
+              <AccountFilter
+                accountFilterIds={accountFilterIds}
+                includeTrackingAccounts={includeTrackingAccounts}
+                onCancel={close}
+                onSave={(accounts) => {
+                  close();
+                  applyFilters({ accountFilterIds: accounts });
+                }}
+              />
+            )}
+          </Popover>
+        </div>
+        <div className="tk-mg-r-05">
+          <Popover
+            renderTrigger={({ toggle }) => (
+              <button
+                onClick={toggle}
+                className="tk-button tk-button--hollow tk-button--medium tk-button--text"
+              >
+                {`${localizedMonthAndYear(dateFilter.fromDate)} - ${localizedMonthAndYear(
+                  dateFilter.toDate,
+                )}`}
+              </button>
+            )}
+          >
+            {({ close }) => (
+              <DateFilter
+                dateFilter={dateFilter}
+                onCancel={close}
+                onSave={(newDateFilter) => {
+                  close();
+                  applyFilters({ dateFilter: newDateFilter });
+                }}
+              />
+            )}
+          </Popover>
+        </div>
       </div>
-    );
-  }
-
-  _handleAccountsChanged = (accountFilterIds: FiltersType['accountFilterIds']) => {
-    this.props.closeModal();
-    this._applyFilters({ accountFilterIds });
-  };
-
-  _showAccountFilterModal = () => {
-    this.props.showAccountFilterModal({
-      accountFilterIds: this.props.filters.accountFilterIds,
-      includeTrackingAccounts: this.props.selectedReport.filterSettings.includeTrackingAccounts,
-      onCancel: this.props.closeModal,
-      onSave: this._handleAccountsChanged,
-    });
-  };
-
-  _handleCategoriesChanged = (categoryFilterIds: FiltersType['categoryFilterIds']) => {
-    this.props.closeModal();
-    this._applyFilters({ categoryFilterIds });
-  };
-
-  _showCategoryFilterModal = () => {
-    if (this.props.selectedReport.filterSettings.disableCategoryFilter) {
-      return;
-    }
-
-    this.props.showCategoryFilterModal({
-      categoryFilterIds: this.props.filters.categoryFilterIds,
-      onCancel: this.props.closeModal,
-      onSave: this._handleCategoriesChanged,
-    });
-  };
-
-  _handleDatesChanged = (dateFilter: FiltersType['dateFilter']) => {
-    this.props.closeModal();
-    this._applyFilters({ dateFilter });
-  };
-
-  _showDateSelectorModal = () => {
-    this.props.showDateSelectorModal({
-      dateFilter: this.props.filters.dateFilter,
-      onCancel: this.props.closeModal,
-      onSave: this._handleDatesChanged,
-    });
-  };
-
-  _applyFilters(newFilters: Partial<FiltersType>) {
-    this.props.setFilters({
-      ...this.props.filters,
-      ...newFilters,
-    });
-  }
+      {!!ExtraComponent && <ExtraComponent />}
+    </div>
+  );
 }

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/component.tsx
@@ -51,7 +51,7 @@ export class DateFilterComponent extends React.Component<DateFilterProps, DateFi
     return (
       <div className="tk-pd-1">
         <h3 className="tk-mg-0">Date Range</h3>
-        <div className="tk-flex tk-mg-t-1 tk-mg-b-05 tk-pd-y-05 tk-border-y tk-modal-content__header-actions">
+        <div className="tk-flex tk-date-filter__options tk-mg-t-1 tk-mg-b-05 tk-pd-y-05 tk-border-y tk-modal-content__header-actions">
           <button
             name={Options.ThisMonth}
             className="tk-button tk-button--small tk-button--text"

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/components/date-filter/styles.scss
@@ -2,4 +2,8 @@
   &__select {
     width: auto;
   }
+
+  &__options {
+    flex-wrap: wrap;
+  }
 }

--- a/src/extension/features/toolkit-reports/pages/root/components/report-filters/container.ts
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-filters/container.ts
@@ -1,16 +1,8 @@
 import {
-  ModalContextType,
-  withModalContext,
-} from 'toolkit/extension/features/toolkit-reports/common/components/modal';
-import { CategoryFilter } from './components/category-filter';
-import { DateFilter } from './components/date-filter';
-import { AccountFilter } from './components/account-filter';
-import {
   ReportContextType,
   withReportContext,
 } from 'toolkit/extension/features/toolkit-reports/common/components/report-context';
 import { ReportFiltersComponent } from './component';
-import { ComponentProps } from 'react';
 
 function mapReportContextToProps(context: ReportContextType) {
   return {
@@ -20,18 +12,4 @@ function mapReportContextToProps(context: ReportContextType) {
   };
 }
 
-function mapModalContextToProps({ closeModal, showModal }: ModalContextType) {
-  return {
-    closeModal,
-    showAccountFilterModal: (props: ComponentProps<typeof AccountFilter>) =>
-      showModal(AccountFilter, props),
-    showDateSelectorModal: (props: ComponentProps<typeof DateFilter>) =>
-      showModal(DateFilter, props),
-    showCategoryFilterModal: (props: ComponentProps<typeof CategoryFilter>) =>
-      showModal(CategoryFilter, props),
-  };
-}
-
-export const ReportFilters = withModalContext(mapModalContextToProps)(
-  withReportContext(mapReportContextToProps)(ReportFiltersComponent),
-);
+export const ReportFilters = withReportContext(mapReportContextToProps)(ReportFiltersComponent);

--- a/src/extension/features/toolkit-reports/pages/root/components/report-selector/component.tsx
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-selector/component.tsx
@@ -1,36 +1,54 @@
 import * as React from 'react';
 import { REPORT_TYPES } from 'toolkit/extension/features/toolkit-reports/common/constants/report-types';
+import { Popover } from 'toolkit/extension/features/toolkit-reports/common/components/popover';
 import classnames from 'classnames';
 import './styles.scss';
 
-export class ReportSelectorComponent extends React.Component<{
+export function ReportSelectorComponent({
+  activeReportKey,
+  setActiveReportKey,
+}: {
   activeReportKey: string;
   setActiveReportKey: (key: string) => void;
-}> {
-  render() {
-    return (
-      <div className="tk-report-selector">
-        {REPORT_TYPES.map(({ key, name }) => {
-          const reportNameClasses = classnames('tk-report-selector__item', {
-            'tk-report-selector__item--active': this.props.activeReportKey === key,
-          });
+}) {
+  const activeReport = REPORT_TYPES.find(({ key }) => key === activeReportKey);
 
-          return (
-            <div
-              className={reportNameClasses}
-              data-report-key={key}
-              key={key}
-              onClick={this._onSelect}
-            >
-              {name}
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
+  return (
+    <Popover
+      renderTrigger={({ toggle, isOpen }) => (
+        <button
+          type="button"
+          className="tk-report-selector__trigger"
+          onClick={toggle}
+          aria-expanded={isOpen}
+        >
+          {activeReport?.name}
+          <span className="tk-report-selector__trigger-caret" />
+        </button>
+      )}
+    >
+      {({ close }) => (
+        <div className="tk-report-selector__menu">
+          {REPORT_TYPES.map(({ key, name }) => {
+            const itemClasses = classnames('tk-report-selector__item', {
+              'tk-report-selector__item--active': activeReportKey === key,
+            });
 
-  _onSelect = ({ currentTarget }: React.MouseEvent<HTMLDivElement>) => {
-    this.props.setActiveReportKey(currentTarget.dataset.reportKey!);
-  };
+            return (
+              <div
+                className={itemClasses}
+                key={key}
+                onClick={() => {
+                  setActiveReportKey(key);
+                  close();
+                }}
+              >
+                {name}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Popover>
+  );
 }

--- a/src/extension/features/toolkit-reports/pages/root/components/report-selector/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/root/components/report-selector/styles.scss
@@ -1,32 +1,55 @@
-.tk-report-selector {
-  background-color: var(--headerBackground);
-  color: var(--sidebarLabelPrimary);
-  padding: 0.5rem;
+.tk-report-selector__trigger {
   display: flex;
-  gap: 0.5rem;
   align-items: center;
-  flex-wrap: wrap;
+  gap: 0.5em;
+  cursor: pointer;
+  border: 0;
+  border-radius: 1000px;
+  font-size: 0.9em;
+  padding: 0.4em 1em;
+  font-weight: 500;
+  white-space: nowrap;
+  color: var(--sidebarLabelPrimary);
+  background-color: var(--buttonPrimaryBackground);
 
-  &__item {
-    cursor: pointer;
-    border-radius: 1000px;
-    font-size: 0.9em;
-    padding: 0.4em 1em;
-    font-weight: 500;
-    white-space: nowrap;
-    color: var(--buttonSecondaryLabel);
-    background-color: var(--buttonSecondaryBackground);
+  &:hover {
+    background-color: var(--buttonPrimaryBackgroundActive);
+  }
+}
 
+.tk-report-selector__trigger-caret {
+  width: 0;
+  height: 0;
+  border-left: 0.3em solid transparent;
+  border-right: 0.3em solid transparent;
+  border-top: 0.35em solid currentColor;
+}
+
+.tk-report-selector__menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 12rem;
+  padding: 0.4rem;
+}
+
+.tk-report-selector__item {
+  cursor: pointer;
+  border-radius: 0.4rem;
+  font-size: 0.9em;
+  padding: 0.5em 0.75em;
+  font-weight: 500;
+  white-space: nowrap;
+  color: var(--buttonSecondaryLabel);
+
+  &:hover {
+    background-color: var(--buttonSecondaryBackgroundActive);
+  }
+
+  &--active {
+    color: var(--sidebarLabelPrimary);
+    background-color: var(--buttonPrimaryBackground);
     &:hover {
-      background-color: var(--buttonSecondaryBackgroundActive);
-    }
-
-    &--active {
-      color: var(--sidebarLabelPrimary);
       background-color: var(--buttonPrimaryBackground);
-      &:hover {
-        background-color: var(--buttonPrimaryBackground);
-      }
     }
   }
 }

--- a/src/extension/features/toolkit-reports/pages/root/styles.scss
+++ b/src/extension/features/toolkit-reports/pages/root/styles.scss
@@ -2,6 +2,16 @@
   left: 260px;
 }
 
+.tk-reports-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  flex-shrink: 0;
+  background-color: var(--headerBackground);
+}
+
 .tk-highcharts-report-container {
   display: flex;
   flex-grow: 1;


### PR DESCRIPTION
## Summary
- Replace the report selector's wrapping row of pill buttons with a single trigger button that opens a menu anchored directly beneath it.
- Apply the same pattern to the Categories/Accounts/Date filter buttons, replacing their centered modal dialogs.
- Merge the report selector and filter buttons into a single toolbar row.
- Add a shared `Popover` component that measures the trigger/content against the viewport and clamps position (and enables internal scrolling) so menus stay fully on-screen and usable on small windows.

## Test plan
- [x] `yarn build:webpack --env buildType=development` builds cleanly
- [x] `tsc --skipLibCheck` passes (ran via prepush hook)
- [ ] Manually verify in a loaded dev build: report selector, Categories, Accounts, and Date popovers open anchored to their triggers, close on outside click/Escape, and stay on-screen (with scrolling) on a small/narrow window

🤖 Generated with [Claude Code](https://claude.com/claude-code)